### PR TITLE
fix(kubernetes): early-exit on error

### DIFF
--- a/app/providers/kubernetes/kubernetes.go
+++ b/app/providers/kubernetes/kubernetes.go
@@ -37,14 +37,15 @@ type KubernetesProvider struct {
 func NewKubernetesProvider(providerConfig providerConfig.Kubernetes) (*KubernetesProvider, error) {
 	kubeclientConfig, err := rest.InClusterConfig()
 
+	if err != nil {
+		return nil, err
+	}
+
 	kubeclientConfig.QPS = providerConfig.QPS
 	kubeclientConfig.Burst = providerConfig.Burst
 
 	log.Debug(fmt.Sprintf("Provider configuration:  QPS=%v, Burst=%v", kubeclientConfig.QPS, kubeclientConfig.Burst))
 
-	if err != nil {
-		return nil, err
-	}
 	client, err := kubernetes.NewForConfig(kubeclientConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Helped me troubleshoot a SIGSEGV error:

- before: `panic: runtime error: invalid memory address or nil pointer dereference`
- after: `panic: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory`
