### PR TITLE
chore(docker): add a warning log when the container has no healthcheck defined

### DIFF
--- a/app/providers/docker/docker.go
+++ b/app/providers/docker/docker.go
@@ -112,6 +112,7 @@ func (p *DockerClassicProvider) GetState(ctx context.Context, name string) (inst
 				return instance.NotReadyInstanceState(name, 0, p.desiredReplicas), nil
 			}
 		}
+		p.l.WarnContext(ctx, "container running without healthcheck, you should define a healthcheck on your container so that Sablier properly detects when the container is ready to handle requests.", slog.String("container", name))
 		return instance.ReadyInstanceState(name, p.desiredReplicas), nil
 	case "exited":
 		if spec.State.ExitCode != 0 {


### PR DESCRIPTION
When no healthcheck is defined, Sablier will cannot properly detect when the targeted container is able to handle requests yet. If your container startup period is more than 1 second, you're likely to experience issues and a healthcheck is recommended.

