### PR TITLE
fix: apply default session duration for blocking strategy

### DIFF
--- a/internal/api/start_blocking.go
+++ b/internal/api/start_blocking.go
@@ -12,7 +12,8 @@ import (
 func StartBlocking(router *gin.RouterGroup, s *routes.ServeStrategy) {
 	router.GET("/strategies/blocking", func(c *gin.Context) {
 		request := models.BlockingRequest{
-			Timeout: s.StrategyConfig.Blocking.DefaultTimeout,
+			SessionDuration: s.SessionsConfig.DefaultDuration,
+			Timeout:         s.StrategyConfig.Blocking.DefaultTimeout,
 		}
 
 		if err := c.ShouldBind(&request); err != nil {


### PR DESCRIPTION
I have been using v1.8.4 with docker and Caddy.

There appears to be be an issue where the default session duration is not being applied for blocking strategies (with no explicitly specified duration).

I discovered this when setting up my first use of the blocking strategy and saw in the logs that the group was expiring immediately and this was resulting in an error for the requester. The debug logs also showed that the expiration was being set for 0 seconds for the blocking strategies, while dynamic ones were working as expected. I was relying on the documented default session duration of 5m.

Testing confirmed that `sessions.default-duration`, whether specified in yaml or via command-line or not specified at all, was never applied for blocking strategies. Here, the session duration would always be 0 unless the `duration` was explicitly set in the sablier configuration in the Caddyfile (or similar) and therefore overriding the default.

This bug might explain some of the issues people have had.

Inspecting the code I (a non-Go speaker) could not find anywhere where this default was being applied for blocking strategies, so I added it in as per the dynamic strategy and I believe it all works correctly now.

This change will obviously increase the actual effective default session duration for blocking strategies from 0s to 5m when existing installs are upgraded.

...

P.S. Thanks for this great tool. I have been successfully reducing the needless power draw incurred by various seldom used services. The crucial thing was, as you recommend, putting in place appropriate health checks on the containers.

EDIT: I don't know how to fix the issue with merge check. I would be interested to know how to properly make or fix this pull request but otherwise just make the change to the code yourself if you like.
