### PR TITLE
fix: apply default session duration for blocking strategy

### DIFF
--- a/internal/api/start_blocking.go
+++ b/internal/api/start_blocking.go
@@ -12,7 +12,8 @@ import (
 func StartBlocking(router *gin.RouterGroup, s *routes.ServeStrategy) {
 	router.GET("/strategies/blocking", func(c *gin.Context) {
 		request := models.BlockingRequest{
-			Timeout: s.StrategyConfig.Blocking.DefaultTimeout,
+			SessionDuration: s.SessionsConfig.DefaultDuration,
+			Timeout:         s.StrategyConfig.Blocking.DefaultTimeout,
 		}
 
 		if err := c.ShouldBind(&request); err != nil {


### PR DESCRIPTION
Merging is still blocked - closing duplicate.
