### PR TITLE
test: use httpexpect v2.17 upstream

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -26,7 +26,6 @@ func Test_Dynamic(t *testing.T) {
 	e.GET("/whoami").
 		WithMaxRetries(20).
 		WithRetryDelay(50*time.Millisecond, time.Second*2).
-		WithRetryPolicy(httpexpect.RetryCustomHandler).
 		WithRetryPolicyFunc(RetryUntilBodyContains("Host: localhost:8080")).
 		Expect().
 		Status(http.StatusOK).
@@ -55,7 +54,6 @@ func Test_Multiple(t *testing.T) {
 	e.GET("/whoami").
 		WithMaxRetries(20).
 		WithRetryDelay(50*time.Millisecond, time.Second*2).
-		WithRetryPolicy(httpexpect.RetryCustomHandler).
 		WithRetryPolicyFunc(RetryUntilBodyContains("Host: localhost:8080")).
 		Expect().
 		Status(http.StatusOK).
@@ -64,7 +62,6 @@ func Test_Multiple(t *testing.T) {
 	e.GET("/nginx").
 		WithMaxRetries(20).
 		WithRetryDelay(50*time.Millisecond, time.Second*2).
-		WithRetryPolicy(httpexpect.RetryCustomHandler).
 		WithRetryPolicyFunc(RetryUntilBodyContains("nginx/")).
 		Expect().
 		Status(http.StatusNotFound).
@@ -84,7 +81,6 @@ func Test_Healthy(t *testing.T) {
 	e.GET("/nginx").
 		WithMaxRetries(20).
 		WithRetryDelay(50*time.Millisecond, time.Second*2).
-		WithRetryPolicy(httpexpect.RetryCustomHandler).
 		WithRetryPolicyFunc(RetryUntilBodyContains("nginx/")).
 		Expect().
 		Status(http.StatusNotFound).
@@ -104,7 +100,6 @@ func Test_Group(t *testing.T) {
 	e.GET("/group").
 		WithMaxRetries(20).
 		WithRetryDelay(50*time.Millisecond, time.Second*2).
-		WithRetryPolicy(httpexpect.RetryCustomHandler).
 		WithRetryPolicyFunc(RetryUntilBodyContains("Host: localhost:8080")).
 		Expect().
 		Status(http.StatusOK).

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -27,7 +27,7 @@ func Test_Dynamic(t *testing.T) {
 		WithMaxRetries(20).
 		WithRetryDelay(50*time.Millisecond, time.Second*2).
 		WithRetryPolicy(httpexpect.RetryCustomHandler).
-		WithCustomHandler(RetryUntilBodyContains("Host: localhost:8080")).
+		WithRetryPolicyFunc(RetryUntilBodyContains("Host: localhost:8080")).
 		Expect().
 		Status(http.StatusOK).
 		Body().Contains(`Host: localhost:8080`)
@@ -56,7 +56,7 @@ func Test_Multiple(t *testing.T) {
 		WithMaxRetries(20).
 		WithRetryDelay(50*time.Millisecond, time.Second*2).
 		WithRetryPolicy(httpexpect.RetryCustomHandler).
-		WithCustomHandler(RetryUntilBodyContains("Host: localhost:8080")).
+		WithRetryPolicyFunc(RetryUntilBodyContains("Host: localhost:8080")).
 		Expect().
 		Status(http.StatusOK).
 		Body().Contains(`Host: localhost:8080`)
@@ -65,7 +65,7 @@ func Test_Multiple(t *testing.T) {
 		WithMaxRetries(20).
 		WithRetryDelay(50*time.Millisecond, time.Second*2).
 		WithRetryPolicy(httpexpect.RetryCustomHandler).
-		WithCustomHandler(RetryUntilBodyContains("nginx/")).
+		WithRetryPolicyFunc(RetryUntilBodyContains("nginx/")).
 		Expect().
 		Status(http.StatusNotFound).
 		Body().Contains(`nginx/`)
@@ -85,7 +85,7 @@ func Test_Healthy(t *testing.T) {
 		WithMaxRetries(20).
 		WithRetryDelay(50*time.Millisecond, time.Second*2).
 		WithRetryPolicy(httpexpect.RetryCustomHandler).
-		WithCustomHandler(RetryUntilBodyContains("nginx/")).
+		WithRetryPolicyFunc(RetryUntilBodyContains("nginx/")).
 		Expect().
 		Status(http.StatusNotFound).
 		Body().Contains(`nginx/`)
@@ -105,7 +105,7 @@ func Test_Group(t *testing.T) {
 		WithMaxRetries(20).
 		WithRetryDelay(50*time.Millisecond, time.Second*2).
 		WithRetryPolicy(httpexpect.RetryCustomHandler).
-		WithCustomHandler(RetryUntilBodyContains("Host: localhost:8080")).
+		WithRetryPolicyFunc(RetryUntilBodyContains("Host: localhost:8080")).
 		Expect().
 		Status(http.StatusOK).
 		Body().Contains(`Host: localhost:8080`)

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,9 @@ module github.com/sablierapp/sablier
 
 go 1.24.0
 
-replace github.com/gavv/httpexpect/v2 => github.com/acouvreur/httpexpect/v2 v2.16.0
-
 require (
 	github.com/docker/docker v27.5.1+incompatible
-	github.com/gavv/httpexpect/v2 v2.16.0
+	github.com/gavv/httpexpect/v2 v2.17.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/go-cmp v0.7.0
 	github.com/lmittmann/tint v1.0.7

--- a/go.work.sum
+++ b/go.work.sum
@@ -338,6 +338,8 @@ github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cq
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY+9ef8E=
 github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
+github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2 h1:ZBbLwSJqkHBuFDA6DUhhse0IGJ7T5bemHyNILUjvOq4=
+github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2/go.mod h1:VSw57q4QFiWDbRnjdX8Cb3Ow0SFncRw+bA/ofY6Q83w=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5 h1:rFw4nCn9iMW+Vajsk51NtYIcwSTkXr+JGrMd36kTDJw=
@@ -446,6 +448,10 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8 h1:a9ENSRDFBUPkJ5lCg
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fxamacker/cbor/v2 v2.6.0 h1:sU6J2usfADwWlYDAFhZBQ6TnLFBHxgesMrQfQgk1tWA=
 github.com/fxamacker/cbor/v2 v2.6.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/gavv/httpexpect/v2 v2.16.0 h1:Ty2favARiTYTOkCRZGX7ojXXjGyNAIohM1lZ3vqaEwI=
+github.com/gavv/httpexpect/v2 v2.16.0/go.mod h1:uJLaO+hQ25ukBJtQi750PsztObHybNllN+t+MbbW8PY=
+github.com/gavv/httpexpect/v2 v2.17.0 h1:nIJqt5v5e4P7/0jODpX2gtSw+pHXUqdP28YcjqwDZmE=
+github.com/gavv/httpexpect/v2 v2.17.0/go.mod h1:E8ENFlT9MZ3Si2sfM6c6ONdwXV2noBCGkhA+lkJgkP0=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/gliderlabs/ssh v0.1.1 h1:j3L6gSLQalDETeEg/Jg0mGY0/y/N6zI2xX1978P0Uqw=
 github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
@@ -596,6 +602,8 @@ github.com/hashicorp/vault/api/auth/approle v0.6.0 h1:ELfFFQlTM/e97WJKu1HvNFa7lQ
 github.com/hashicorp/vault/api/auth/approle v0.6.0/go.mod h1:CCoIl1xBC3lAWpd1HV+0ovk76Z8b8Mdepyk21h3pGk0=
 github.com/hashicorp/vault/api/auth/kubernetes v0.6.0 h1:K8sKGhtTAqGKfzaaYvUSIOAqTOIn3Gk1EsCEAMzZHtM=
 github.com/hashicorp/vault/api/auth/kubernetes v0.6.0/go.mod h1:Htwcjez5J9PwAHaZ1EYMBlgGq3/in5ajUV4+WCPihPE=
+github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
+github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/hudl/fargo v1.4.0 h1:ZDDILMbB37UlAVLlWcJ2Iz1XuahZZTDZfdCKeclfq2s=
 github.com/hudl/fargo v1.4.0/go.mod h1:9Ai6uvFy5fQNq6VPKtg+Ceq1+eTY4nKUlR2JElEOcDo=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=

--- a/pkg/store/valkey/valkey_test.go
+++ b/pkg/store/valkey/valkey_test.go
@@ -53,14 +53,11 @@ func TestValKey(t *testing.T) {
 
 	t.Parallel()
 	t.Run("ValKeyErrNotFound", func(t *testing.T) {
-		t.Parallel()
 		_, err := vk.Get(ctx, "ValKeyErrNotFound")
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
 	t.Run("ValKeyPut", func(t *testing.T) {
-		t.Parallel()
-
-		err := vk.Put(ctx, sablier.InstanceInfo{Name: "ValKeyPut"}, 30*time.Second)
+		err := vk.Put(ctx, sablier.InstanceInfo{Name: "ValKeyPut"}, 1*time.Second)
 		assert.NilError(t, err)
 
 		i, err := vk.Get(ctx, "ValKeyPut")
@@ -72,8 +69,6 @@ func TestValKey(t *testing.T) {
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
 	t.Run("ValKeyDelete", func(t *testing.T) {
-		t.Parallel()
-
 		err := vk.Put(ctx, sablier.InstanceInfo{Name: "ValKeyDelete"}, 30*time.Second)
 		assert.NilError(t, err)
 
@@ -88,7 +83,6 @@ func TestValKey(t *testing.T) {
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
 	t.Run("ValKeyOnExpire", func(t *testing.T) {
-		t.Parallel()
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 

--- a/pkg/store/valkey/valkey_test.go
+++ b/pkg/store/valkey/valkey_test.go
@@ -60,7 +60,7 @@ func TestValKey(t *testing.T) {
 	t.Run("ValKeyPut", func(t *testing.T) {
 		t.Parallel()
 
-		err := vk.Put(ctx, sablier.InstanceInfo{Name: "ValKeyPut"}, 1*time.Second)
+		err := vk.Put(ctx, sablier.InstanceInfo{Name: "ValKeyPut"}, 30*time.Second)
 		assert.NilError(t, err)
 
 		i, err := vk.Get(ctx, "ValKeyPut")


### PR DESCRIPTION
This change brings the WithRetryPolicyFunc previously implemented in the fork.