### PR TITLE
better: add latest to docker release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,6 +57,7 @@ dockers_v2:
       - 'ghcr.io/sablierapp/sablier'
     tags:
       - '{{ .Version }}'
+      - 'latest'
     dockerfile: build/Dockerfile
     platforms:
       - linux/amd64


### PR DESCRIPTION
Currently the release process doesn't update latest docker tag:

For example current release is 

<img width="1903" height="283" alt="image" src="https://github.com/user-attachments/assets/728509a2-6295-4291-84ab-fd7f791dbfb7" />


But latest is

<img width="1892" height="285" alt="image" src="https://github.com/user-attachments/assets/dc14b78d-d597-4875-b197-e96dece49e2c" />

Which correspond to

<img width="1896" height="281" alt="image" src="https://github.com/user-attachments/assets/63890349-4bec-4ce3-a391-0160c12419f7" />

I added latest tag to go releaser so now latest docker tag will be updated as expected:

<img width="1079" height="1065" alt="image" src="https://github.com/user-attachments/assets/267df426-cc01-4b03-b679-3376169ca597" />
