### PR TITLE
fix(logging): access log level is set to debug

### DIFF
--- a/internal/server/logging.go
+++ b/internal/server/logging.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"log/slog"
 
 	"github.com/gin-gonic/gin"
@@ -11,27 +10,8 @@ import (
 // StructuredLogger logs a gin HTTP request in JSON format. Allows to set the
 // logger for testing purposes.
 func StructuredLogger(logger *slog.Logger) gin.HandlerFunc {
-	if logger.Enabled(context.TODO(), slog.LevelDebug) {
-		return sloggin.NewWithConfig(logger, sloggin.Config{
-			DefaultLevel:     slog.LevelInfo,
-			ClientErrorLevel: slog.LevelWarn,
-			ServerErrorLevel: slog.LevelError,
-
-			WithUserAgent:      false,
-			WithRequestID:      true,
-			WithRequestBody:    false,
-			WithRequestHeader:  false,
-			WithResponseBody:   false,
-			WithResponseHeader: false,
-			WithSpanID:         false,
-			WithTraceID:        false,
-
-			Filters: []sloggin.Filter{},
-		})
-	}
-
 	return sloggin.NewWithConfig(logger, sloggin.Config{
-		DefaultLevel:     slog.LevelInfo,
+		DefaultLevel:     slog.LevelDebug,
 		ClientErrorLevel: slog.LevelWarn,
 		ServerErrorLevel: slog.LevelError,
 


### PR DESCRIPTION
Client errors are still warning, and server error is still error.

Closes #787 