### PR TITLE
fix: async InstanceStart calls

### DIFF
--- a/pkg/sablier/instance_request.go
+++ b/pkg/sablier/instance_request.go
@@ -15,6 +15,34 @@ type pendingStart struct {
 	err  error
 }
 
+// consumePendingError checks whether a pending start exists for the given
+// instance. It returns (pending, error):
+//   - pending=true, err=nil  → start still in progress, caller should skip inspect
+//   - pending=false, err!=nil → start completed with error, entry cleared for retry
+//   - pending=false, err=nil  → no pending entry or already cleaned up
+func (s *Sablier) consumePendingError(name string) (bool, error) {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+
+	ps, exists := s.pendingStarts[name]
+	if !exists {
+		return false, nil
+	}
+
+	select {
+	case <-ps.done:
+		// Goroutine finished — clean up regardless of outcome
+		delete(s.pendingStarts, name)
+		if ps.err != nil {
+			return false, fmt.Errorf("instance start failed: %w", ps.err)
+		}
+		return false, nil
+	default:
+		// Still running
+		return true, nil
+	}
+}
+
 func (s *Sablier) requestStart(ctx context.Context, name string) (InstanceInfo, error) {
 	s.pendingMu.Lock()
 	defer s.pendingMu.Unlock()
@@ -24,7 +52,6 @@ func (s *Sablier) requestStart(ctx context.Context, name string) (InstanceInfo, 
 		case <-ps.done:
 			// Goroutine completed
 			if ps.err != nil {
-				// Return the unconsumed error and clear the entry so the next call retries
 				err := ps.err
 				delete(s.pendingStarts, name)
 				return InstanceInfo{}, fmt.Errorf("instance start failed: %w", err)
@@ -41,11 +68,24 @@ func (s *Sablier) requestStart(ctx context.Context, name string) (InstanceInfo, 
 	ps := &pendingStart{done: make(chan struct{})}
 	s.pendingStarts[name] = ps
 
+	// Detach from the request context to avoid retaining HTTP request values,
+	// but use a bounded timeout to prevent goroutine leaks.
+	startCtx, cancel := context.WithTimeout(context.Background(), s.InstanceStartTimeout)
+
 	go func() {
+		defer cancel()
 		defer close(ps.done)
-		if err := s.provider.InstanceStart(context.Background(), name); err != nil {
+		if err := s.provider.InstanceStart(startCtx, name); err != nil {
 			ps.err = err
-			s.l.ErrorContext(ctx, "async instance start failed", slog.String("instance", name), slog.Any("error", err))
+			s.l.Error("async instance start failed", slog.String("instance", name), slog.Any("error", err))
+		} else {
+			// Success — clean up immediately so the entry doesn't linger
+			s.pendingMu.Lock()
+			// Only delete if ps is still the current entry (not replaced by a retry)
+			if current, ok := s.pendingStarts[name]; ok && current == ps {
+				delete(s.pendingStarts, name)
+			}
+			s.pendingMu.Unlock()
 		}
 	}()
 
@@ -71,12 +111,23 @@ func (s *Sablier) InstanceRequest(ctx context.Context, name string, duration tim
 		s.l.ErrorContext(ctx, "request to start instance failed", slog.String("instance", name), slog.Any("error", err))
 		return InstanceInfo{}, fmt.Errorf("cannot retrieve instance from store: %w", err)
 	} else if state.Status != InstanceStatusReady {
-		s.l.DebugContext(ctx, "request to check instance status received", slog.String("instance", name), slog.String("current_status", string(state.Status)))
-		state, err = s.provider.InstanceInspect(ctx, name)
-		if err != nil {
-			return InstanceInfo{}, err
+		// Check for a completed (possibly failed) async start before inspecting
+		pending, pendingErr := s.consumePendingError(name)
+		if pendingErr != nil {
+			return InstanceInfo{}, pendingErr
 		}
-		s.l.DebugContext(ctx, "request to check instance status completed", slog.String("instance", name), slog.String("new_status", string(state.Status)))
+
+		if pending {
+			// Start is still in progress — no point inspecting, return current state
+			s.l.DebugContext(ctx, "instance start still in progress, skipping inspect", slog.String("instance", name))
+		} else {
+			s.l.DebugContext(ctx, "request to check instance status received", slog.String("instance", name), slog.String("current_status", string(state.Status)))
+			state, err = s.provider.InstanceInspect(ctx, name)
+			if err != nil {
+				return InstanceInfo{}, err
+			}
+			s.l.DebugContext(ctx, "request to check instance status completed", slog.String("instance", name), slog.String("new_status", string(state.Status)))
+		}
 	}
 
 	s.l.DebugContext(ctx, "set expiration for instance", slog.String("instance", name), slog.Duration("expiration", duration))

--- a/pkg/sablier/instance_request.go
+++ b/pkg/sablier/instance_request.go
@@ -4,10 +4,53 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/sablierapp/sablier/pkg/store"
 	"log/slog"
 	"time"
+
+	"github.com/sablierapp/sablier/pkg/store"
 )
+
+type pendingStart struct {
+	done chan struct{}
+	err  error
+}
+
+func (s *Sablier) requestStart(ctx context.Context, name string) (InstanceInfo, error) {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+
+	if ps, exists := s.pendingStarts[name]; exists {
+		select {
+		case <-ps.done:
+			// Goroutine completed
+			if ps.err != nil {
+				// Return the unconsumed error and clear the entry so the next call retries
+				err := ps.err
+				delete(s.pendingStarts, name)
+				return InstanceInfo{}, fmt.Errorf("instance start failed: %w", err)
+			}
+			// Succeeded previously but instance is no longer in store — start a new one
+			delete(s.pendingStarts, name)
+		default:
+			// Still running — don't start another goroutine
+			s.l.DebugContext(ctx, "instance start already in progress", slog.String("instance", name))
+			return NotReadyInstanceState(name, 0, 1), nil
+		}
+	}
+
+	ps := &pendingStart{done: make(chan struct{})}
+	s.pendingStarts[name] = ps
+
+	go func() {
+		defer close(ps.done)
+		if err := s.provider.InstanceStart(context.Background(), name); err != nil {
+			ps.err = err
+			s.l.ErrorContext(ctx, "async instance start failed", slog.String("instance", name), slog.Any("error", err))
+		}
+	}()
+
+	return NotReadyInstanceState(name, 0, 1), nil
+}
 
 func (s *Sablier) InstanceRequest(ctx context.Context, name string, duration time.Duration) (InstanceInfo, error) {
 	if name == "" {
@@ -18,16 +61,12 @@ func (s *Sablier) InstanceRequest(ctx context.Context, name string, duration tim
 	if errors.Is(err, store.ErrKeyNotFound) {
 		s.l.DebugContext(ctx, "request to start instance received", slog.String("instance", name))
 
-		err = s.provider.InstanceStart(ctx, name)
+		state, err = s.requestStart(ctx, name)
 		if err != nil {
 			return InstanceInfo{}, err
 		}
 
-		state, err = s.provider.InstanceInspect(ctx, name)
-		if err != nil {
-			return InstanceInfo{}, err
-		}
-		s.l.DebugContext(ctx, "request to start instance status completed", slog.String("instance", name), slog.String("status", string(state.Status)))
+		s.l.DebugContext(ctx, "request to start instance dispatched", slog.String("instance", name), slog.String("status", string(state.Status)))
 	} else if err != nil {
 		s.l.ErrorContext(ctx, "request to start instance failed", slog.String("instance", name), slog.Any("error", err))
 		return InstanceInfo{}, fmt.Errorf("cannot retrieve instance from store: %w", err)

--- a/pkg/sablier/instance_request_test.go
+++ b/pkg/sablier/instance_request_test.go
@@ -1,0 +1,261 @@
+package sablier_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"github.com/sablierapp/sablier/pkg/store"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+)
+
+// checkWithTimeout polls fn at the given interval until it returns true or the timeout expires.
+func checkWithTimeout(interval, timeout time.Duration, fn func() bool) bool {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		if fn() {
+			return true
+		}
+		select {
+		case <-deadline:
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
+func TestInstanceRequest_EmptyName(t *testing.T) {
+	manager, _, _ := setupSablier(t)
+
+	_, err := manager.InstanceRequest(t.Context(), "", time.Minute)
+	assert.Error(t, err, "instance name cannot be empty")
+}
+
+func TestInstanceRequest_NewInstance_StartsAsync(t *testing.T) {
+	manager, sessions, provider := setupSablier(t)
+	ctx := t.Context()
+
+	startCalled := make(chan struct{})
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+
+	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
+		close(startCalled)
+		return nil
+	})
+
+	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil)
+
+	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+	assert.Equal(t, info.Name, "nginx")
+
+	// Wait for the async goroutine to complete
+	select {
+	case <-startCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("InstanceStart was never called asynchronously")
+	}
+}
+
+func TestInstanceRequest_NewInstance_ReturnsBeforeStartCompletes(t *testing.T) {
+	manager, sessions, provider := setupSablier(t)
+	ctx := t.Context()
+
+	startBlocking := make(chan struct{})
+	startCalled := make(chan struct{})
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+
+	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
+		close(startCalled)
+		<-startBlocking
+		return nil
+	})
+
+	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil)
+
+	// InstanceRequest returns immediately with not-ready
+	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+
+	// Verify the goroutine is still running (InstanceStart was called but blocked)
+	select {
+	case <-startCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("InstanceStart was never called")
+	}
+
+	close(startBlocking)
+}
+
+func TestInstanceRequest_DuplicateCallsDoNotHammerProvider(t *testing.T) {
+	manager, sessions, provider := setupSablier(t)
+	ctx := t.Context()
+
+	startBlocking := make(chan struct{})
+	startCalled := make(chan struct{})
+
+	// Both calls hit ErrKeyNotFound
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).Times(2)
+	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil).Times(2)
+
+	// InstanceStart must be called exactly once
+	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
+		close(startCalled)
+		<-startBlocking
+		return nil
+	}).Times(1)
+
+	// First call — starts the goroutine
+	info1, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info1.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+
+	// Wait for the goroutine to actually enter InstanceStart
+	select {
+	case <-startCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("InstanceStart was never called")
+	}
+
+	// Second call — reuses existing pending start, does NOT call InstanceStart again
+	info2, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info2.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+
+	close(startBlocking)
+}
+
+func TestInstanceRequest_PreviousErrorForwardedToUser(t *testing.T) {
+	manager, sessions, provider := setupSablier(t)
+	ctx := t.Context()
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
+	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil).AnyTimes()
+
+	// First call's goroutine fails immediately
+	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("connection refused")).Times(1)
+
+	// First call succeeds (returns not-ready, goroutine starts)
+	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+
+	// Allow the goroutine to finish setting the error and closing ps.done
+	assert.Assert(t, checkWithTimeout(100*time.Millisecond, 5*time.Second, func() bool {
+		_, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
+		return err != nil
+	}), "expected error to be surfaced")
+	assert.ErrorContains(t, err, "instance start failed: connection refused")
+}
+
+func TestInstanceRequest_RetryAfterErrorConsumed(t *testing.T) {
+	manager, sessions, provider := setupSablier(t)
+	ctx := t.Context()
+
+	secondDone := make(chan struct{})
+
+	// Allow multiple Get calls: the polling helper may call InstanceRequest several times
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
+	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil).AnyTimes()
+
+	gomock.InOrder(
+		// First attempt — fails immediately
+		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("connection refused")),
+		// Third call — retries with a new goroutine
+		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
+			close(secondDone)
+			return nil
+		}),
+	)
+
+	// 1st call: dispatches goroutine
+	_, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+
+	// 2nd call: poll until the error is consumable (goroutine must finish first)
+	assert.Assert(t, checkWithTimeout(100*time.Millisecond, 5*time.Second, func() bool {
+		_, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
+		return err != nil
+	}), "expected error to be surfaced")
+	assert.ErrorContains(t, err, "instance start failed: connection refused")
+
+	// 3rd call: retries, starts a new goroutine
+	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+
+	select {
+	case <-secondDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Retry goroutine was never started")
+	}
+}
+
+func TestInstanceRequest_ExistingNotReady_InspectsProvider(t *testing.T) {
+	manager, sessions, provider := setupSablier(t)
+	ctx := t.Context()
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{
+		Name:   "nginx",
+		Status: sablier.InstanceStatusNotReady,
+	}, nil)
+
+	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(sablier.InstanceInfo{
+		Name:            "nginx",
+		CurrentReplicas: 1,
+		DesiredReplicas: 1,
+		Status:          sablier.InstanceStatusReady,
+	}, nil)
+
+	sessions.EXPECT().Put(ctx, sablier.InstanceInfo{
+		Name:            "nginx",
+		CurrentReplicas: 1,
+		DesiredReplicas: 1,
+		Status:          sablier.InstanceStatusReady,
+	}, time.Minute).Return(nil)
+
+	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusReady))
+}
+
+func TestInstanceRequest_ExistingReady_SkipsInspect(t *testing.T) {
+	manager, sessions, _ := setupSablier(t)
+	ctx := t.Context()
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{
+		Name:            "nginx",
+		CurrentReplicas: 1,
+		DesiredReplicas: 1,
+		Status:          sablier.InstanceStatusReady,
+	}, nil)
+
+	sessions.EXPECT().Put(ctx, sablier.InstanceInfo{
+		Name:            "nginx",
+		CurrentReplicas: 1,
+		DesiredReplicas: 1,
+		Status:          sablier.InstanceStatusReady,
+	}, time.Minute).Return(nil)
+
+	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusReady))
+}
+
+func TestInstanceRequest_StoreGetError(t *testing.T) {
+	manager, sessions, _ := setupSablier(t)
+	ctx := t.Context()
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, errors.New("connection refused"))
+
+	_, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.ErrorContains(t, err, "cannot retrieve instance from store")
+}

--- a/pkg/sablier/instance_request_test.go
+++ b/pkg/sablier/instance_request_test.go
@@ -55,7 +55,6 @@ func TestInstanceRequest_NewInstance_StartsAsync(t *testing.T) {
 	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
 	assert.Equal(t, info.Name, "nginx")
 
-	// Wait for the async goroutine to complete
 	select {
 	case <-startCalled:
 	case <-time.After(5 * time.Second):
@@ -80,12 +79,10 @@ func TestInstanceRequest_NewInstance_ReturnsBeforeStartCompletes(t *testing.T) {
 
 	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil)
 
-	// InstanceRequest returns immediately with not-ready
 	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
 	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
 
-	// Verify the goroutine is still running (InstanceStart was called but blocked)
 	select {
 	case <-startCalled:
 	case <-time.After(5 * time.Second):
@@ -102,30 +99,38 @@ func TestInstanceRequest_DuplicateCallsDoNotHammerProvider(t *testing.T) {
 	startBlocking := make(chan struct{})
 	startCalled := make(chan struct{})
 
-	// Both calls hit ErrKeyNotFound
-	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).Times(2)
-	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil).Times(2)
+	notReady := sablier.NotReadyInstanceState("nginx", 0, 1)
 
-	// InstanceStart must be called exactly once
+	// First call: store miss → triggers requestStart
+	// Second call: store returns the not-ready state written by Put → hits status != ready path
+	gomock.InOrder(
+		sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound),
+		sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil),
+	)
+
+	// InstanceStart: exactly once (second call must not trigger another)
 	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
 		close(startCalled)
 		<-startBlocking
 		return nil
 	}).Times(1)
 
+	// Second call: start is still pending → skips InstanceInspect, returns not-ready
+	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil).Times(2)
+
 	// First call — starts the goroutine
 	info1, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
 	assert.Equal(t, info1.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
 
-	// Wait for the goroutine to actually enter InstanceStart
+	// Wait for the goroutine to enter InstanceStart
 	select {
 	case <-startCalled:
 	case <-time.After(5 * time.Second):
 		t.Fatal("InstanceStart was never called")
 	}
 
-	// Second call — reuses existing pending start, does NOT call InstanceStart again
+	// Second call — start still pending, skips inspect, no duplicate InstanceStart
 	info2, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
 	assert.Equal(t, info2.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
@@ -133,26 +138,33 @@ func TestInstanceRequest_DuplicateCallsDoNotHammerProvider(t *testing.T) {
 	close(startBlocking)
 }
 
-func TestInstanceRequest_PreviousErrorForwardedToUser(t *testing.T) {
+func TestInstanceRequest_AsyncErrorSurfacedOnNotReadyPath(t *testing.T) {
 	manager, sessions, provider := setupSablier(t)
 	ctx := t.Context()
 
-	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
-	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil).AnyTimes()
+	notReady := sablier.NotReadyInstanceState("nginx", 0, 1)
 
-	// First call's goroutine fails immediately
-	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("connection refused")).Times(1)
+	// First call: store miss → requestStart
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
 
-	// First call succeeds (returns not-ready, goroutine starts)
+	// Goroutine fails immediately
+	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("connection refused"))
+
 	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
 	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
 
-	// Allow the goroutine to finish setting the error and closing ps.done
+	// Subsequent calls: store returns the stored not-ready state (realistic behavior).
+	// While goroutine is still running, polling returns not-ready with Put.
+	// Once goroutine finishes, consumePendingError surfaces the error (no Put in that case).
+	sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil).AnyTimes()
+	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil).AnyTimes()
+
 	assert.Assert(t, checkWithTimeout(100*time.Millisecond, 5*time.Second, func() bool {
 		_, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
 		return err != nil
-	}), "expected error to be surfaced")
+	}), "expected async error to be surfaced on the not-ready path")
 	assert.ErrorContains(t, err, "instance start failed: connection refused")
 }
 
@@ -160,34 +172,35 @@ func TestInstanceRequest_RetryAfterErrorConsumed(t *testing.T) {
 	manager, sessions, provider := setupSablier(t)
 	ctx := t.Context()
 
+	notReady := sablier.NotReadyInstanceState("nginx", 0, 1)
 	secondDone := make(chan struct{})
 
-	// Allow multiple Get calls: the polling helper may call InstanceRequest several times
+	// All Get/Put calls use AnyTimes since polling may hit them multiple times
 	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
-	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil).AnyTimes()
+	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil).AnyTimes()
 
 	gomock.InOrder(
 		// First attempt — fails immediately
 		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("connection refused")),
-		// Third call — retries with a new goroutine
+		// Retry — succeeds
 		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
 			close(secondDone)
 			return nil
 		}),
 	)
 
-	// 1st call: dispatches goroutine
+	// 1st call: dispatches goroutine (fails)
 	_, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
 
-	// 2nd call: poll until the error is consumable (goroutine must finish first)
+	// 2nd call: poll until the error is consumable
 	assert.Assert(t, checkWithTimeout(100*time.Millisecond, 5*time.Second, func() bool {
 		_, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
 		return err != nil
 	}), "expected error to be surfaced")
 	assert.ErrorContains(t, err, "instance start failed: connection refused")
 
-	// 3rd call: retries, starts a new goroutine
+	// 3rd call: entry cleared, store miss again → requestStart retries
 	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
 	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
@@ -197,6 +210,78 @@ func TestInstanceRequest_RetryAfterErrorConsumed(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Retry goroutine was never started")
 	}
+}
+
+func TestInstanceRequest_SuccessfulStartCleansUpPendingEntry(t *testing.T) {
+	manager, sessions, provider := setupSablier(t)
+	ctx := t.Context()
+
+	notReady := sablier.NotReadyInstanceState("nginx", 0, 1)
+	ready := sablier.ReadyInstanceState("nginx", 1)
+
+	// 1st call: store miss → requestStart (goroutine succeeds)
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
+
+	startDone := make(chan struct{})
+	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
+		close(startDone)
+		return nil
+	})
+
+	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+
+	// Wait for goroutine to finish and self-clean
+	select {
+	case <-startDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("InstanceStart goroutine never completed")
+	}
+	// Small settle time for the goroutine to acquire the lock and clean up
+	time.Sleep(50 * time.Millisecond)
+
+	// 2nd call: store returns not-ready, no pending entry exists, goes straight to inspect
+	sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil)
+	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(ready, nil)
+	sessions.EXPECT().Put(ctx, ready, time.Minute).Return(nil)
+
+	info, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusReady))
+}
+
+func TestInstanceRequest_StartTimeoutSurfacesError(t *testing.T) {
+	manager, sessions, provider := setupSablier(t)
+	manager.InstanceStartTimeout = 100 * time.Millisecond
+	ctx := t.Context()
+
+	notReady := sablier.NotReadyInstanceState("nginx", 0, 1)
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
+
+	// InstanceStart blocks until context is cancelled
+	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(startCtx interface{}, _ string) error {
+		<-startCtx.(interface{ Done() <-chan struct{} }).Done()
+		return startCtx.(interface{ Err() error }).Err()
+	})
+
+	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+
+	// Subsequent calls: store returns not-ready; polling may get not-ready while
+	// the goroutine is still in progress, or the timeout error once it completes.
+	sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil).AnyTimes()
+	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil).AnyTimes()
+
+	assert.Assert(t, checkWithTimeout(50*time.Millisecond, 5*time.Second, func() bool {
+		_, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
+		return err != nil
+	}), "expected timeout error to be surfaced")
+	assert.ErrorContains(t, err, "instance start failed")
 }
 
 func TestInstanceRequest_ExistingNotReady_InspectsProvider(t *testing.T) {

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -23,6 +23,10 @@ type Sablier struct {
 	// against the provider. Defaults to 5 seconds.
 	BlockingRefreshFrequency time.Duration
 
+	// InstanceStartTimeout is the maximum time allowed for an async InstanceStart
+	// call before it is cancelled. Defaults to 5 minutes.
+	InstanceStartTimeout time.Duration
+
 	l *slog.Logger
 }
 
@@ -35,6 +39,7 @@ func New(logger *slog.Logger, store Store, provider Provider) *Sablier {
 		pendingStarts:            map[string]*pendingStart{},
 		l:                        logger,
 		BlockingRefreshFrequency: 5 * time.Second,
+		InstanceStartTimeout:     5 * time.Minute,
 	}
 }
 

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -2,10 +2,11 @@ package sablier
 
 import (
 	"context"
-	"github.com/google/go-cmp/cmp"
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 type Sablier struct {
@@ -14,6 +15,9 @@ type Sablier struct {
 
 	groupsMu sync.RWMutex
 	groups   map[string][]string
+
+	pendingMu     sync.Mutex
+	pendingStarts map[string]*pendingStart
 
 	// BlockingRefreshFrequency is the frequency at which the instances are checked
 	// against the provider. Defaults to 5 seconds.
@@ -28,6 +32,7 @@ func New(logger *slog.Logger, store Store, provider Provider) *Sablier {
 		sessions:                 store,
 		groupsMu:                 sync.RWMutex{},
 		groups:                   map[string][]string{},
+		pendingStarts:            map[string]*pendingStart{},
 		l:                        logger,
 		BlockingRefreshFrequency: 5 * time.Second,
 	}


### PR DESCRIPTION
`provider.InstanceStart` has no guarantee of execution time. When the call is hanging, then the whole request and loading page is hanging which defeat the purpose of a waiting page.

Closes #782