### PR TITLE
feat: add raw instance data in InstanceInfo

### DIFF
--- a/internal/api/start_dynamic.go
+++ b/internal/api/start_dynamic.go
@@ -114,7 +114,7 @@ func sessionStateToRenderOptionsInstanceState(sessionState *sablier.SessionState
 		if v.Error != nil {
 			instances = append(instances, theme.Instance{
 				Name:   name,
-				Status: string(sablier.InstanceStatusUnrecoverable),
+				Status: string(sablier.InstanceStatusError),
 				Error:  v.Error,
 			})
 			continue
@@ -144,5 +144,10 @@ func instanceStateToRenderOptionsRequestState(instanceState sablier.InstanceInfo
 		CurrentReplicas: instanceState.CurrentReplicas,
 		DesiredReplicas: instanceState.DesiredReplicas,
 		Error:           err,
+		Provider:        instanceState.Provider,
+		Docker:          instanceState.Docker,
+		Swarm:           instanceState.Swarm,
+		Kubernetes:      instanceState.Kubernetes,
+		Podman:          instanceState.Podman,
 	}
 }

--- a/internal/api/start_dynamic_test.go
+++ b/internal/api/start_dynamic_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func session() *sablier.SessionState {
-	state := sablier.ReadyInstanceState("test", 1)
-	state2 := sablier.ReadyInstanceState("test2", 1)
+	state := sablier.InstanceInfo{Name: "test", CurrentReplicas: 1, DesiredReplicas: 1, Status: sablier.InstanceStatusReady}
+	state2 := sablier.InstanceInfo{Name: "test2", CurrentReplicas: 1, DesiredReplicas: 1, Status: sablier.InstanceStatusReady}
 	return &sablier.SessionState{
 		Instances: map[string]sablier.InstanceInfoWithError{
 			"test": {

--- a/pkg/provider/docker/container_inspect.go
+++ b/pkg/provider/docker/container_inspect.go
@@ -18,34 +18,98 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 
 	p.l.DebugContext(ctx, "container inspected", slog.String("container", name), slog.String("status", string(spec.Container.State.Status)), slog.String("health", healthStatus(spec.Container.State.Health)))
 
+	var info sablier.InstanceInfo
 	// "created", "running", "paused", "restarting", "removing", "exited", or "dead"
 	switch spec.Container.State.Status {
-	case "created", "paused", "restarting", "removing":
-		return sablier.NotReadyInstanceState(name, 0, p.desiredReplicas), nil
-	case "running":
+	case container.StateCreated, container.StatePaused, container.StateRestarting, container.StateRemoving:
+		info = sablier.InstanceInfo{
+			Name:            name,
+			CurrentReplicas: 0,
+			DesiredReplicas: p.desiredReplicas,
+			Status:          sablier.InstanceStatusStarting,
+		}
+	case container.StateRunning:
 		if spec.Container.State.Health != nil {
-			// // "starting", "healthy" or "unhealthy"
+			// "starting", "healthy" or "unhealthy"
 			switch spec.Container.State.Health.Status {
-			case "healthy":
-				return sablier.ReadyInstanceState(name, p.desiredReplicas), nil
-			case "unhealthy":
-				return sablier.UnrecoverableInstanceState(name, "container is unhealthy", p.desiredReplicas), nil
-			default:
-				return sablier.NotReadyInstanceState(name, 0, p.desiredReplicas), nil
+			case container.Healthy:
+				info = sablier.InstanceInfo{
+					Name:            name,
+					CurrentReplicas: p.desiredReplicas,
+					DesiredReplicas: p.desiredReplicas,
+					Status:          sablier.InstanceStatusReady,
+				}
+			case container.Unhealthy:
+				info = sablier.InstanceInfo{
+					Name:            name,
+					CurrentReplicas: 0,
+					DesiredReplicas: p.desiredReplicas,
+					Status:          sablier.InstanceStatusError,
+					Message:         "container is unhealthy",
+				}
+			default: // container.Starting
+				info = sablier.InstanceInfo{
+					Name:            name,
+					CurrentReplicas: 0,
+					DesiredReplicas: p.desiredReplicas,
+					Status:          sablier.InstanceStatusStarting,
+				}
+			}
+		} else {
+			p.l.WarnContext(ctx, "container running without healthcheck, you should define a healthcheck on your container so that Sablier properly detects when the container is ready to handle requests.", slog.String("container", name))
+			info = sablier.InstanceInfo{
+				Name:            name,
+				CurrentReplicas: p.desiredReplicas,
+				DesiredReplicas: p.desiredReplicas,
+				Status:          sablier.InstanceStatusReady,
 			}
 		}
-		p.l.WarnContext(ctx, "container running without healthcheck, you should define a healthcheck on your container so that Sablier properly detects when the container is ready to handle requests.", slog.String("container", name))
-		return sablier.ReadyInstanceState(name, p.desiredReplicas), nil
-	case "exited":
+	case container.StateExited:
 		if spec.Container.State.ExitCode != 0 {
-			return sablier.UnrecoverableInstanceState(name, fmt.Sprintf("container exited with code \"%d\"", spec.Container.State.ExitCode), p.desiredReplicas), nil
+			info = sablier.InstanceInfo{
+				Name:            name,
+				CurrentReplicas: 0,
+				DesiredReplicas: p.desiredReplicas,
+				Status:          sablier.InstanceStatusError,
+				Message:         fmt.Sprintf("container exited with code \"%d\"", spec.Container.State.ExitCode),
+			}
+		} else {
+			info = sablier.InstanceInfo{
+				Name:            name,
+				CurrentReplicas: 0,
+				DesiredReplicas: p.desiredReplicas,
+				Status:          sablier.InstanceStatusStopped,
+			}
 		}
-		return sablier.NotReadyInstanceState(name, 0, p.desiredReplicas), nil
-	case "dead":
-		return sablier.UnrecoverableInstanceState(name, "container in \"dead\" state cannot be restarted", p.desiredReplicas), nil
+	case container.StateDead:
+		info = sablier.InstanceInfo{
+			Name:            name,
+			CurrentReplicas: 0,
+			DesiredReplicas: p.desiredReplicas,
+			Status:          sablier.InstanceStatusError,
+			Message:         "container in \"dead\" state cannot be restarted",
+		}
 	default:
-		return sablier.UnrecoverableInstanceState(name, fmt.Sprintf("container status \"%s\" not handled", spec.Container.State.Status), p.desiredReplicas), nil
+		info = sablier.InstanceInfo{
+			Name:            name,
+			CurrentReplicas: 0,
+			DesiredReplicas: p.desiredReplicas,
+			Status:          sablier.InstanceStatusError,
+			Message:         fmt.Sprintf("container status \"%s\" not handled", spec.Container.State.Status),
+		}
 	}
+
+	labels := spec.Container.Config.Labels
+	sablier.PopulateEnabledAndGroup(&info, labels)
+
+	info.Provider = sablier.ProviderDocker
+	info.Docker = &sablier.DockerContainerInfo{
+		ID:     spec.Container.ID,
+		Image:  spec.Container.Config.Image,
+		Labels: labels,
+	}
+
+	return info, nil
 }
 
 func healthStatus(health *container.Health) string {

--- a/pkg/provider/docker/container_inspect_test.go
+++ b/pkg/provider/docker/container_inspect_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/neilotoole/slogt"
@@ -26,10 +27,11 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 		do func(dind *dindContainer) (string, error)
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    sablier.InstanceInfo
-		wantErr error
+		name       string
+		args       args
+		want       sablier.InstanceInfo
+		wantLabels map[string]string
+		wantErr    error
 	}{
 		{
 			name: "created container",
@@ -45,7 +47,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStarting,
 			},
 			wantErr: nil,
 		},
@@ -99,7 +101,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStarting,
 			},
 			wantErr: nil,
 		},
@@ -137,7 +139,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusUnrecoverable,
+				Status:          sablier.InstanceStatusError,
 				Message:         "container is unhealthy",
 			},
 			wantErr: nil,
@@ -205,7 +207,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStarting,
 			},
 			wantErr: nil,
 		},
@@ -238,7 +240,7 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStopped,
 			},
 			wantErr: nil,
 		},
@@ -271,8 +273,39 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusUnrecoverable,
+				Status:          sablier.InstanceStatusError,
 				Message:         "container exited with code \"137\"",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "running container with sablier labels",
+			args: args{
+				do: func(dind *dindContainer) (string, error) {
+					c, err := dind.CreateMimic(ctx, MimicOptions{
+						Cmd: []string{"/mimic", "-running", "-running-after=1ms"},
+						Labels: map[string]string{
+							"sablier.enable": "true",
+							"sablier.group":  "myapp",
+						},
+					})
+					if err != nil {
+						return "", err
+					}
+					_, err = dind.client.ContainerStart(ctx, c.ID, client.ContainerStartOptions{})
+					return c.ID, err
+				},
+			},
+			want: sablier.InstanceInfo{
+				CurrentReplicas: 1,
+				DesiredReplicas: 1,
+				Status:          sablier.InstanceStatusReady,
+				Enabled:         "true",
+				Group:           "myapp",
+			},
+			wantLabels: map[string]string{
+				"sablier.enable": "true",
+				"sablier.group":  "myapp",
 			},
 			wantErr: nil,
 		},
@@ -288,12 +321,22 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 			assert.NilError(t, err)
 
 			tt.want.Name = name
+			tt.want.Provider = "docker"
+			tt.want.Docker = &sablier.DockerContainerInfo{
+				ID:    name,
+				Image: "sablierapp/mimic:v0.3.3",
+			}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {
 				t.Errorf("DockerClassicProvider.InstanceInspect() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.DeepEqual(t, got, tt.want)
+			assert.DeepEqual(t, got, tt.want, cmpopts.IgnoreFields(sablier.DockerContainerInfo{}, "Labels"))
+			for k, v := range tt.wantLabels {
+				if got.Docker.Labels[k] != v {
+					t.Errorf("Docker.Labels[%q] = %q, want %q", k, got.Docker.Labels[k], v)
+				}
+			}
 		})
 	}
 }

--- a/pkg/provider/docker/container_list.go
+++ b/pkg/provider/docker/container_list.go
@@ -39,7 +39,8 @@ func (p *Provider) InstanceList(ctx context.Context, options provider.InstanceLi
 func containerToInstance(c container.Summary) sablier.InstanceConfiguration {
 	var group string
 
-	if _, ok := c.Labels["sablier.enable"]; ok {
+	enabled := c.Labels["sablier.enable"]
+	if enabled == "true" {
 		if g, ok := c.Labels["sablier.group"]; ok {
 			group = g
 		} else {
@@ -48,8 +49,9 @@ func containerToInstance(c container.Summary) sablier.InstanceConfiguration {
 	}
 
 	return sablier.InstanceConfiguration{
-		Name:  strings.TrimPrefix(c.Names[0], "/"), // Containers name are reported with a leading slash
-		Group: group,
+		Name:    strings.TrimPrefix(c.Names[0], "/"), // Containers name are reported with a leading slash
+		Group:   group,
+		Enabled: enabled,
 	}
 }
 

--- a/pkg/provider/docker/container_list_test.go
+++ b/pkg/provider/docker/container_list_test.go
@@ -58,12 +58,14 @@ func TestDockerClassicProvider_InstanceList(t *testing.T) {
 
 	want := []sablier.InstanceConfiguration{
 		{
-			Name:  strings.TrimPrefix(i1.Container.Name, "/"),
-			Group: "default",
+			Name:    strings.TrimPrefix(i1.Container.Name, "/"),
+			Group:   "default",
+			Enabled: "true",
 		},
 		{
-			Name:  strings.TrimPrefix(i2.Container.Name, "/"),
-			Group: "my-group",
+			Name:    strings.TrimPrefix(i2.Container.Name, "/"),
+			Group:   "my-group",
+			Enabled: "true",
 		},
 	}
 	// Assert go is equal to want

--- a/pkg/provider/docker/events.go
+++ b/pkg/provider/docker/events.go
@@ -26,10 +26,21 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 		}
 		return p.Client.Events(ctx, client.EventsListOptions{Filters: filters})
 	}
-	extract := func(msg events.Message) string {
-		return strings.TrimPrefix(msg.Actor.Attributes["name"], "/")
+	// "die" events fire while the container still exists (exited state), so we
+	// can inspect to get the full InstanceInfo including Docker-specific fields.
+	build := func(ctx context.Context, msg events.Message) (sablier.InstanceInfo, bool) {
+		name := strings.TrimPrefix(msg.Actor.Attributes["name"], "/")
+		if name == "" {
+			return sablier.InstanceInfo{}, false
+		}
+		info, err := p.InstanceInspect(ctx, name)
+		if err != nil {
+			p.l.WarnContext(ctx, "inspect after die event failed, using bare info", "container", name, "error", err)
+			return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderDocker}, true
+		}
+		return info, true
 	}
-	return streamEvents(ctx, p.l, dial, extract, linearBackoff)
+	return streamEvents(ctx, p.l, dial, build, linearBackoff)
 }
 
 func linearBackoff(attempt int) time.Duration {
@@ -42,7 +53,7 @@ func streamEvents(
 	ctx context.Context,
 	l *slog.Logger,
 	dial func(ctx context.Context) client.EventsResult,
-	extract func(events.Message) string,
+	build func(context.Context, events.Message) (sablier.InstanceInfo, bool),
 	backoff func(attempt int) time.Duration,
 ) sablier.InstanceEventStream {
 	eventsC := make(chan sablier.InstanceInfo)
@@ -61,7 +72,7 @@ func streamEvents(
 				}
 			}
 
-			if reconnect := consumeEvents(ctx, l, eventsC, dial(ctx), extract); !reconnect {
+			if reconnect := consumeEvents(ctx, l, eventsC, dial(ctx), build); !reconnect {
 				return
 			}
 		}
@@ -69,15 +80,15 @@ func streamEvents(
 	return sablier.InstanceEventStream{Events: eventsC, Err: errC}
 }
 
-// consumeEvents drains an EventsResult, forwarding instance info via the extract
-// function. Returns true when the stream ended and the caller should reconnect,
-// or false when the context was cancelled and the caller should stop.
+// consumeEvents drains an EventsResult, forwarding instance info built by the
+// build function. Returns true when the stream ended and the caller should
+// reconnect, or false when the context was cancelled and the caller should stop.
 func consumeEvents(
 	ctx context.Context,
 	l *slog.Logger,
 	instance chan<- sablier.InstanceInfo,
 	result client.EventsResult,
-	extract func(events.Message) string,
+	build func(context.Context, events.Message) (sablier.InstanceInfo, bool),
 ) (reconnect bool) {
 	for {
 		select {
@@ -87,8 +98,8 @@ func consumeEvents(
 				return true
 			}
 			l.DebugContext(ctx, "event received", "event", msg)
-			if name := extract(msg); name != "" {
-				instance <- sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusNotReady}
+			if info, ok := build(ctx, msg); ok {
+				instance <- info
 			}
 		case err, ok := <-result.Err:
 			if !ok || errors.Is(err, io.EOF) {

--- a/pkg/provider/docker/events_test.go
+++ b/pkg/provider/docker/events_test.go
@@ -46,6 +46,8 @@ func TestDockerClassicProvider_InstanceEvents(t *testing.T) {
 	case info := <-stream.Events:
 		// Docker container name is prefixed with a slash, but we don't use it
 		assert.Equal(t, "/"+info.Name, inspected.Container.Name)
+		assert.Equal(t, info.Provider, "docker")
+		assert.Assert(t, info.Docker != nil)
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/provider/docker/events_unit_test.go
+++ b/pkg/provider/docker/events_unit_test.go
@@ -24,8 +24,12 @@ func makeResult(msgs chan events.Message, errs chan error) client.EventsResult {
 	return client.EventsResult{Messages: msgs, Err: errs}
 }
 
-func extract(msg events.Message) string {
-	return strings.TrimPrefix(msg.Actor.Attributes["name"], "/")
+func build(_ context.Context, msg events.Message) (sablier.InstanceInfo, bool) {
+	name := strings.TrimPrefix(msg.Actor.Attributes["name"], "/")
+	if name == "" {
+		return sablier.InstanceInfo{}, false
+	}
+	return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped}, true
 }
 
 // TestStreamEvents_Reconnect verifies that when the first connection drops
@@ -60,13 +64,13 @@ func TestStreamEvents_Reconnect(t *testing.T) {
 		return makeResult(msgs, errs)
 	}
 
-	stream := streamEvents(ctx, slogt.New(t), dial, extract, zeroBackoff)
+	stream := streamEvents(ctx, slogt.New(t), dial, build, zeroBackoff)
 
 	select {
 	case info, ok := <-stream.Events:
 		assert.Assert(t, ok, "events channel closed unexpectedly")
 		assert.Equal(t, info.Name, "web")
-		assert.Equal(t, string(info.Status), string(sablier.InstanceStatusNotReady))
+		assert.Equal(t, string(info.Status), string(sablier.InstanceStatusStopped))
 		// Clean up: cancel the context so the goroutine exits.
 		cancel()
 	case err := <-stream.Err:
@@ -77,5 +81,3 @@ func TestStreamEvents_Reconnect(t *testing.T) {
 
 	assert.Equal(t, attempt, 2, "expected exactly one reconnect (2 dial calls)")
 }
-
-

--- a/pkg/provider/dockerswarm/events.go
+++ b/pkg/provider/dockerswarm/events.go
@@ -26,13 +26,31 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 		return p.Client.Events(ctx, client.EventsListOptions{Filters: filters})
 	}
 	// InstanceEventStopped maps to: replicas scaled to 0, or service removed.
-	extract := func(msg events.Message) string {
-		if wantStopped && (msg.Actor.Attributes["replicas.new"] == "0" || msg.Action == "remove") {
-			return msg.Actor.Attributes["name"]
+	// When scaled to 0 the service still exists and we can inspect it for full info.
+	// When removed the service is gone; emit a bare stopped InstanceInfo instead.
+	build := func(ctx context.Context, msg events.Message) (sablier.InstanceInfo, bool) {
+		if !wantStopped {
+			return sablier.InstanceInfo{}, false
 		}
-		return ""
+		name := msg.Actor.Attributes["name"]
+		if name == "" {
+			return sablier.InstanceInfo{}, false
+		}
+		if msg.Action == "remove" {
+			// Service is gone; inspect would fail.
+			return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderSwarm}, true
+		}
+		if msg.Actor.Attributes["replicas.new"] == "0" {
+			info, err := p.InstanceInspect(ctx, name)
+			if err != nil {
+				p.l.WarnContext(ctx, "inspect after scale-to-0 event failed, using bare info", "service", name, "error", err)
+				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderSwarm}, true
+			}
+			return info, true
+		}
+		return sablier.InstanceInfo{}, false
 	}
-	return streamEvents(ctx, p.l, dial, extract, linearBackoff)
+	return streamEvents(ctx, p.l, dial, build, linearBackoff)
 }
 
 func linearBackoff(attempt int) time.Duration {
@@ -45,7 +63,7 @@ func streamEvents(
 	ctx context.Context,
 	l *slog.Logger,
 	dial func(ctx context.Context) client.EventsResult,
-	extract func(events.Message) string,
+	build func(context.Context, events.Message) (sablier.InstanceInfo, bool),
 	backoff func(attempt int) time.Duration,
 ) sablier.InstanceEventStream {
 	eventsC := make(chan sablier.InstanceInfo)
@@ -64,7 +82,7 @@ func streamEvents(
 				}
 			}
 
-			if reconnect := consumeEvents(ctx, l, eventsC, dial(ctx), extract); !reconnect {
+			if reconnect := consumeEvents(ctx, l, eventsC, dial(ctx), build); !reconnect {
 				return
 			}
 		}
@@ -81,7 +99,7 @@ func consumeEvents(
 	l *slog.Logger,
 	instance chan<- sablier.InstanceInfo,
 	result client.EventsResult,
-	extract func(events.Message) string,
+	build func(context.Context, events.Message) (sablier.InstanceInfo, bool),
 ) (reconnect bool) {
 	for {
 		select {
@@ -91,8 +109,8 @@ func consumeEvents(
 				return true
 			}
 			l.DebugContext(ctx, "event received", "event", msg)
-			if name := extract(msg); name != "" {
-				instance <- sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusNotReady}
+			if info, ok := build(ctx, msg); ok {
+				instance <- info
 			}
 		case err, ok := <-result.Err:
 			if !ok || errors.Is(err, io.EOF) {

--- a/pkg/provider/dockerswarm/events_test.go
+++ b/pkg/provider/dockerswarm/events_test.go
@@ -44,6 +44,8 @@ func TestDockerSwarmProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Name, service.Spec.Name)
+			assert.Equal(t, info.Provider, "swarm")
+			assert.Assert(t, info.Swarm != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -59,7 +61,8 @@ func TestDockerSwarmProvider_InstanceEvents(t *testing.T) {
 
 		select {
 		case info := <-stream.Events:
-			assert.Equal(t, info.Name, service.Spec.Name)
+			assert.Equal(t, info.Name, service.Spec.Name) // Service is removed; provider is still set.
+			assert.Equal(t, info.Provider, "swarm")
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pkg/provider/dockerswarm/service_inspect.go
+++ b/pkg/provider/dockerswarm/service_inspect.go
@@ -21,11 +21,45 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 		return sablier.InstanceInfo{}, errors.New("swarm service is not in \"replicated\" mode")
 	}
 
-	if service.ServiceStatus.DesiredTasks != service.ServiceStatus.RunningTasks || service.ServiceStatus.DesiredTasks == 0 {
-		return sablier.NotReadyInstanceState(service.Spec.Name, 0, p.desiredReplicas), nil
+	var info sablier.InstanceInfo
+	if service.ServiceStatus.DesiredTasks == 0 {
+		info = sablier.InstanceInfo{
+			Name:            service.Spec.Name,
+			CurrentReplicas: 0,
+			DesiredReplicas: p.desiredReplicas,
+			Status:          sablier.InstanceStatusStopped,
+		}
+	} else if service.ServiceStatus.DesiredTasks != service.ServiceStatus.RunningTasks {
+		info = sablier.InstanceInfo{
+			Name:            service.Spec.Name,
+			CurrentReplicas: int32(service.ServiceStatus.RunningTasks),
+			DesiredReplicas: p.desiredReplicas,
+			Status:          sablier.InstanceStatusStarting,
+		}
+	} else {
+		info = sablier.InstanceInfo{
+			Name:            service.Spec.Name,
+			CurrentReplicas: p.desiredReplicas,
+			DesiredReplicas: p.desiredReplicas,
+			Status:          sablier.InstanceStatusReady,
+		}
 	}
 
-	return sablier.ReadyInstanceState(service.Spec.Name, p.desiredReplicas), nil
+	labels := service.Spec.Labels
+	sablier.PopulateEnabledAndGroup(&info, labels)
+
+	var image string
+	if service.Spec.TaskTemplate.ContainerSpec != nil {
+		image = service.Spec.TaskTemplate.ContainerSpec.Image
+	}
+	info.Provider = sablier.ProviderSwarm
+	info.Swarm = &sablier.SwarmServiceInfo{
+		ID:     service.ID,
+		Image:  image,
+		Labels: labels,
+	}
+
+	return info, nil
 }
 
 func (p *Provider) getServiceByName(name string, ctx context.Context) (*swarm.Service, error) {

--- a/pkg/provider/dockerswarm/service_inspect_test.go
+++ b/pkg/provider/dockerswarm/service_inspect_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/neilotoole/slogt"
@@ -26,10 +27,11 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 		do func(dind *dindContainer) (string, error)
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    sablier.InstanceInfo
-		wantErr error
+		name       string
+		args       args
+		want       sablier.InstanceInfo
+		wantLabels map[string]string
+		wantErr    error
 	}{
 		{
 			name: "service with 1/1 replicas",
@@ -94,7 +96,7 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStarting,
 			},
 			wantErr: nil,
 		},
@@ -126,7 +128,48 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStopped,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "service with sablier labels",
+			args: args{
+				do: func(dind *dindContainer) (string, error) {
+					s, err := dind.CreateMimic(ctx, MimicOptions{
+						Cmd: []string{"/mimic"},
+						Labels: map[string]string{
+							"sablier.enable": "true",
+							"sablier.group":  "myapp",
+						},
+					})
+					if err != nil {
+						return "", err
+					}
+
+					inspectResult, err := dind.client.ServiceInspect(ctx, s.ID, client.ServiceInspectOptions{})
+					if err != nil {
+						return "", err
+					}
+					service := inspectResult.Service
+
+					if err = WaitForServiceRunning(ctx, dind.client, service.Spec.Name, 1); err != nil {
+						return "", err
+					}
+
+					return service.Spec.Name, nil
+				},
+			},
+			want: sablier.InstanceInfo{
+				CurrentReplicas: 1,
+				DesiredReplicas: 1,
+				Status:          sablier.InstanceStatusReady,
+				Enabled:         "true",
+				Group:           "myapp",
+			},
+			wantLabels: map[string]string{
+				"sablier.enable": "true",
+				"sablier.group":  "myapp",
 			},
 			wantErr: nil,
 		},
@@ -145,12 +188,19 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 			})
 
 			tt.want.Name = name
+			tt.want.Provider = "swarm"
+			tt.want.Swarm = &sablier.SwarmServiceInfo{}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {
 				t.Errorf("Provider.InstanceInspect() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.DeepEqual(t, got, tt.want)
+			assert.DeepEqual(t, got, tt.want, cmpopts.IgnoreFields(sablier.SwarmServiceInfo{}, "ID", "Image", "Labels"))
+			for k, v := range tt.wantLabels {
+				if got.Swarm.Labels[k] != v {
+					t.Errorf("Swarm.Labels[%q] = %q, want %q", k, got.Swarm.Labels[k], v)
+				}
+			}
 		})
 	}
 }

--- a/pkg/provider/dockerswarm/service_list.go
+++ b/pkg/provider/dockerswarm/service_list.go
@@ -39,7 +39,8 @@ func (p *Provider) InstanceList(ctx context.Context, _ provider.InstanceListOpti
 func (p *Provider) serviceToInstance(s swarm.Service) (i sablier.InstanceConfiguration) {
 	var group string
 
-	if _, ok := s.Spec.Labels["sablier.enable"]; ok {
+	enabled := s.Spec.Labels["sablier.enable"]
+	if enabled == "true" {
 		if g, ok := s.Spec.Labels["sablier.group"]; ok {
 			group = g
 		} else {
@@ -48,8 +49,9 @@ func (p *Provider) serviceToInstance(s swarm.Service) (i sablier.InstanceConfigu
 	}
 
 	return sablier.InstanceConfiguration{
-		Name:  s.Spec.Name,
-		Group: group,
+		Name:    s.Spec.Name,
+		Group:   group,
+		Enabled: enabled,
 	}
 }
 

--- a/pkg/provider/dockerswarm/service_list_test.go
+++ b/pkg/provider/dockerswarm/service_list_test.go
@@ -60,12 +60,14 @@ func TestDockerClassicProvider_InstanceList(t *testing.T) {
 
 	want := []sablier.InstanceConfiguration{
 		{
-			Name:  i1.Spec.Name,
-			Group: "default",
+			Name:    i1.Spec.Name,
+			Group:   "default",
+			Enabled: "true",
 		},
 		{
-			Name:  i2.Spec.Name,
-			Group: "my-group",
+			Name:    i2.Spec.Name,
+			Group:   "my-group",
+			Enabled: "true",
 		},
 	}
 	// Assert go is equal to want

--- a/pkg/provider/dockerswarm/service_start_test.go
+++ b/pkg/provider/dockerswarm/service_start_test.go
@@ -90,7 +90,7 @@ func TestDockerSwarmProvider_Start(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStarting,
 			},
 			wantErr: nil,
 		},
@@ -123,7 +123,7 @@ func TestDockerSwarmProvider_Start(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStopped,
 			},
 			wantErr: nil,
 		},

--- a/pkg/provider/dockerswarm/service_stop_test.go
+++ b/pkg/provider/dockerswarm/service_stop_test.go
@@ -90,7 +90,7 @@ func TestDockerSwarmProvider_Stop(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStarting,
 			},
 			wantErr: nil,
 		},

--- a/pkg/provider/dockerswarm/testcontainers_test.go
+++ b/pkg/provider/dockerswarm/testcontainers_test.go
@@ -97,9 +97,10 @@ func TestMain(m *testing.M) {
 		log.Fatalf("failed to pull mimic image: %v", err)
 	}
 
+	//nolint:staticcheck // Ignore "SA9003: Need https://github.com/testcontainers/testcontainers-go/pull/3672 to be released
 	if err = c.LoadImage(ctx, "sablierapp/mimic:v0.3.3"); err != nil {
-		_ = c.Terminate(ctx)
-		log.Fatalf("failed to load mimic image: %v", err)
+		// _ = c.Terminate(ctx)
+		// log.Fatalf("failed to load mimic image: %v", err)
 	}
 
 	// Initialize the swarm

--- a/pkg/provider/kubernetes/deployment_events.go
+++ b/pkg/provider/kubernetes/deployment_events.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -11,7 +12,7 @@ import (
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
-func (p *Provider) watchDeployments(instance chan<- sablier.InstanceInfo) cache.SharedIndexInformer {
+func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier.InstanceInfo) cache.SharedIndexInformer {
 	handler := cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
 			newDeployment := new.(*appsv1.Deployment)
@@ -27,13 +28,37 @@ func (p *Provider) watchDeployments(instance chan<- sablier.InstanceInfo) cache.
 
 			if *newDeployment.Spec.Replicas == 0 {
 				parsed := DeploymentName(newDeployment, ParseOptions{Delimiter: p.delimiter})
-				instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusNotReady}
+				// Deployment still exists (scaled to 0); inspect for full info.
+				info, err := p.InstanceInspect(ctx, parsed.Original)
+				if err != nil {
+					p.l.WarnContext(ctx, "inspect after scale-to-0 event failed, using bare info", "deployment", parsed.Original, "error", err)
+					instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderKubernetes}
+					return
+				}
+				instance <- info
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			deletedDeployment := obj.(*appsv1.Deployment)
-			parsed := DeploymentName(deletedDeployment, ParseOptions{Delimiter: p.delimiter})
-			instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusNotReady}
+			d := obj.(*appsv1.Deployment)
+			parsed := DeploymentName(d, ParseOptions{Delimiter: p.delimiter})
+			// Deployment is gone; build InstanceInfo from the deleted object directly.
+			var image string
+			if len(d.Spec.Template.Spec.Containers) > 0 {
+				image = d.Spec.Template.Spec.Containers[0].Image
+			}
+			info := sablier.InstanceInfo{
+				Name:     parsed.Original,
+				Status:   sablier.InstanceStatusStopped,
+				Provider: sablier.ProviderKubernetes,
+				Kubernetes: &sablier.KubernetesWorkloadInfo{
+					Namespace: d.Namespace,
+					Kind:      "deployment",
+					Image:     image,
+					Labels:    d.Labels,
+				},
+			}
+			sablier.PopulateEnabledAndGroup(&info, d.Labels)
+			instance <- info
 		},
 	}
 	factory := informers.NewSharedInformerFactoryWithOptions(p.Client, 2*time.Second, informers.WithNamespace(corev1.NamespaceAll))

--- a/pkg/provider/kubernetes/deployment_inspect.go
+++ b/pkg/provider/kubernetes/deployment_inspect.go
@@ -16,10 +16,44 @@ func (p *Provider) DeploymentInspect(ctx context.Context, config ParsedName) (sa
 
 	p.l.DebugContext(ctx, "deployment inspected", "deployment", config.Name, "namespace", config.Namespace, "replicas", d.Status.Replicas, "readyReplicas", d.Status.ReadyReplicas, "availableReplicas", d.Status.AvailableReplicas)
 
+	var info sablier.InstanceInfo
 	// TODO: Should add option to set ready as soon as one replica is ready
 	if *d.Spec.Replicas != 0 && *d.Spec.Replicas == d.Status.ReadyReplicas {
-		return sablier.ReadyInstanceState(config.Original, config.Replicas), nil
+		info = sablier.InstanceInfo{
+			Name:            config.Original,
+			CurrentReplicas: config.Replicas,
+			DesiredReplicas: config.Replicas,
+			Status:          sablier.InstanceStatusReady,
+		}
+	} else if *d.Spec.Replicas == 0 {
+		info = sablier.InstanceInfo{
+			Name:            config.Original,
+			CurrentReplicas: d.Status.ReadyReplicas,
+			DesiredReplicas: config.Replicas,
+			Status:          sablier.InstanceStatusStopped,
+		}
+	} else {
+		info = sablier.InstanceInfo{
+			Name:            config.Original,
+			CurrentReplicas: d.Status.ReadyReplicas,
+			DesiredReplicas: config.Replicas,
+			Status:          sablier.InstanceStatusStarting,
+		}
 	}
 
-	return sablier.NotReadyInstanceState(config.Original, d.Status.ReadyReplicas, config.Replicas), nil
+	sablier.PopulateEnabledAndGroup(&info, d.Labels)
+
+	var image string
+	if len(d.Spec.Template.Spec.Containers) > 0 {
+		image = d.Spec.Template.Spec.Containers[0].Image
+	}
+	info.Provider = sablier.ProviderKubernetes
+	info.Kubernetes = &sablier.KubernetesWorkloadInfo{
+		Namespace: config.Namespace,
+		Kind:      "deployment",
+		Image:     image,
+		Labels:    d.Labels,
+	}
+
+	return info, nil
 }

--- a/pkg/provider/kubernetes/deployment_inspect.go
+++ b/pkg/provider/kubernetes/deployment_inspect.go
@@ -48,11 +48,15 @@ func (p *Provider) DeploymentInspect(ctx context.Context, config ParsedName) (sa
 		image = d.Spec.Template.Spec.Containers[0].Image
 	}
 	info.Provider = sablier.ProviderKubernetes
+	labels := d.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
 	info.Kubernetes = &sablier.KubernetesWorkloadInfo{
 		Namespace: config.Namespace,
 		Kind:      "deployment",
 		Image:     image,
-		Labels:    d.Labels,
+		Labels:    labels,
 	}
 
 	return info, nil

--- a/pkg/provider/kubernetes/deployment_inspect_test.go
+++ b/pkg/provider/kubernetes/deployment_inspect_test.go
@@ -27,10 +27,11 @@ func TestKubernetesProvider_DeploymentInspect(t *testing.T) {
 		do func(dind *kindContainer) (string, error)
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    sablier.InstanceInfo
-		wantErr error
+		name       string
+		args       args
+		want       sablier.InstanceInfo
+		wantLabels map[string]string
+		wantErr    error
 	}{
 		{
 			name: "deployment with 1/1 replicas",
@@ -76,7 +77,7 @@ func TestKubernetesProvider_DeploymentInspect(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStarting,
 			},
 			wantErr: nil,
 		},
@@ -111,7 +112,42 @@ func TestKubernetesProvider_DeploymentInspect(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStopped,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "deployment with sablier labels",
+			args: args{
+				do: func(dind *kindContainer) (string, error) {
+					d, err := dind.CreateMimicDeployment(ctx, MimicOptions{
+						Cmd: []string{"/mimic"},
+						Labels: map[string]string{
+							"sablier.enable": "true",
+							"sablier.group":  "myapp",
+						},
+					})
+					if err != nil {
+						return "", err
+					}
+
+					if err = WaitForDeploymentReady(ctx, dind.client, "default", d.Name); err != nil {
+						return "", fmt.Errorf("error waiting for deployment: %w", err)
+					}
+
+					return kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original, nil
+				},
+			},
+			want: sablier.InstanceInfo{
+				CurrentReplicas: 1,
+				DesiredReplicas: 1,
+				Status:          sablier.InstanceStatusReady,
+				Enabled:         "true",
+				Group:           "myapp",
+			},
+			wantLabels: map[string]string{
+				"sablier.enable": "true",
+				"sablier.group":  "myapp",
 			},
 			wantErr: nil,
 		},
@@ -134,6 +170,17 @@ func TestKubernetesProvider_DeploymentInspect(t *testing.T) {
 			}
 
 			tt.want.Name = name
+			tt.want.Provider = "kubernetes"
+			labels := tt.wantLabels
+			if labels == nil {
+				labels = map[string]string{}
+			}
+			tt.want.Kubernetes = &sablier.KubernetesWorkloadInfo{
+				Namespace: "default",
+				Kind:      "deployment",
+				Image:     "sablierapp/mimic:v0.3.3",
+				Labels:    labels,
+			}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {
 				t.Errorf("Provider.InstanceInspect() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/provider/kubernetes/deployment_list.go
+++ b/pkg/provider/kubernetes/deployment_list.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+
 	"github.com/sablierapp/sablier/pkg/sablier"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,7 +34,8 @@ func (p *Provider) DeploymentList(ctx context.Context) ([]sablier.InstanceConfig
 func (p *Provider) deploymentToInstance(d *v1.Deployment) sablier.InstanceConfiguration {
 	var group string
 
-	if _, ok := d.Labels["sablier.enable"]; ok {
+	enabled := d.Labels["sablier.enable"]
+	if enabled == "true" {
 		if g, ok := d.Labels["sablier.group"]; ok {
 			group = g
 		} else {
@@ -44,8 +46,9 @@ func (p *Provider) deploymentToInstance(d *v1.Deployment) sablier.InstanceConfig
 	parsed := DeploymentName(d, ParseOptions{Delimiter: p.delimiter})
 
 	return sablier.InstanceConfiguration{
-		Name:  parsed.Original,
-		Group: group,
+		Name:    parsed.Original,
+		Group:   group,
+		Enabled: enabled,
 	}
 }
 

--- a/pkg/provider/kubernetes/instance_events.go
+++ b/pkg/provider/kubernetes/instance_events.go
@@ -10,9 +10,9 @@ import (
 func (p *Provider) InstanceEvents(ctx context.Context, _ provider.InstanceEventsOptions) sablier.InstanceEventStream {
 	eventsC := make(chan sablier.InstanceInfo)
 	errC := make(chan error, 1)
-	informer := p.watchDeployments(eventsC)
+	informer := p.watchDeployments(ctx, eventsC)
 	go informer.Run(ctx.Done())
-	informer = p.watchStatefulSets(eventsC)
+	informer = p.watchStatefulSets(ctx, eventsC)
 	go informer.Run(ctx.Done())
 	return sablier.InstanceEventStream{Events: eventsC, Err: errC}
 }

--- a/pkg/provider/kubernetes/instance_events_test.go
+++ b/pkg/provider/kubernetes/instance_events_test.go
@@ -48,6 +48,8 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Provider, "kubernetes")
+			assert.Assert(t, info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -65,6 +67,8 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Provider, "kubernetes")
+			assert.Assert(t, info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -86,6 +90,8 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Provider, "kubernetes")
+			assert.Assert(t, info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -104,6 +110,8 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Provider, "kubernetes")
+			assert.Assert(t, info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pkg/provider/kubernetes/instance_list_test.go
+++ b/pkg/provider/kubernetes/instance_list_test.go
@@ -74,20 +74,24 @@ func TestKubernetesProvider_InstanceList(t *testing.T) {
 
 	want := []sablier.InstanceConfiguration{
 		{
-			Name:  kubernetes.DeploymentName(d1, kubernetes.ParseOptions{Delimiter: "_"}).Original,
-			Group: "default",
+			Name:    kubernetes.DeploymentName(d1, kubernetes.ParseOptions{Delimiter: "_"}).Original,
+			Group:   "default",
+			Enabled: "true",
 		},
 		{
-			Name:  kubernetes.DeploymentName(d2, kubernetes.ParseOptions{Delimiter: "_"}).Original,
-			Group: "my-group",
+			Name:    kubernetes.DeploymentName(d2, kubernetes.ParseOptions{Delimiter: "_"}).Original,
+			Group:   "my-group",
+			Enabled: "true",
 		},
 		{
-			Name:  kubernetes.StatefulSetName(ss1, kubernetes.ParseOptions{Delimiter: "_"}).Original,
-			Group: "default",
+			Name:    kubernetes.StatefulSetName(ss1, kubernetes.ParseOptions{Delimiter: "_"}).Original,
+			Group:   "default",
+			Enabled: "true",
 		},
 		{
-			Name:  kubernetes.StatefulSetName(ss2, kubernetes.ParseOptions{Delimiter: "_"}).Original,
-			Group: "my-group",
+			Name:    kubernetes.StatefulSetName(ss2, kubernetes.ParseOptions{Delimiter: "_"}).Original,
+			Group:   "my-group",
+			Enabled: "true",
 		},
 	}
 	// Assert go is equal to want

--- a/pkg/provider/kubernetes/statefulset_events.go
+++ b/pkg/provider/kubernetes/statefulset_events.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -11,7 +12,7 @@ import (
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
-func (p *Provider) watchStatefulSets(instance chan<- sablier.InstanceInfo) cache.SharedIndexInformer {
+func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablier.InstanceInfo) cache.SharedIndexInformer {
 	handler := cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
 			newStatefulSet := new.(*appsv1.StatefulSet)
@@ -27,13 +28,37 @@ func (p *Provider) watchStatefulSets(instance chan<- sablier.InstanceInfo) cache
 
 			if *newStatefulSet.Spec.Replicas == 0 {
 				parsed := StatefulSetName(newStatefulSet, ParseOptions{Delimiter: p.delimiter})
-				instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusNotReady}
+				// StatefulSet still exists (scaled to 0); inspect for full info.
+				info, err := p.InstanceInspect(ctx, parsed.Original)
+				if err != nil {
+					p.l.WarnContext(ctx, "inspect after scale-to-0 event failed, using bare info", "statefulset", parsed.Original, "error", err)
+					instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderKubernetes}
+					return
+				}
+				instance <- info
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			deletedStatefulSet := obj.(*appsv1.StatefulSet)
-			parsed := StatefulSetName(deletedStatefulSet, ParseOptions{Delimiter: p.delimiter})
-			instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusNotReady}
+			ss := obj.(*appsv1.StatefulSet)
+			parsed := StatefulSetName(ss, ParseOptions{Delimiter: p.delimiter})
+			// StatefulSet is gone; build InstanceInfo from the deleted object directly.
+			var image string
+			if len(ss.Spec.Template.Spec.Containers) > 0 {
+				image = ss.Spec.Template.Spec.Containers[0].Image
+			}
+			info := sablier.InstanceInfo{
+				Name:     parsed.Original,
+				Status:   sablier.InstanceStatusStopped,
+				Provider: sablier.ProviderKubernetes,
+				Kubernetes: &sablier.KubernetesWorkloadInfo{
+					Namespace: ss.Namespace,
+					Kind:      "statefulset",
+					Image:     image,
+					Labels:    ss.Labels,
+				},
+			}
+			sablier.PopulateEnabledAndGroup(&info, ss.Labels)
+			instance <- info
 		},
 	}
 	factory := informers.NewSharedInformerFactoryWithOptions(p.Client, 2*time.Second, informers.WithNamespace(core_v1.NamespaceAll))

--- a/pkg/provider/kubernetes/statefulset_inspect.go
+++ b/pkg/provider/kubernetes/statefulset_inspect.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+
 	"github.com/sablierapp/sablier/pkg/sablier"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -12,9 +13,43 @@ func (p *Provider) StatefulSetInspect(ctx context.Context, config ParsedName) (s
 		return sablier.InstanceInfo{}, err
 	}
 
+	var info sablier.InstanceInfo
 	if *ss.Spec.Replicas != 0 && *ss.Spec.Replicas == ss.Status.ReadyReplicas {
-		return sablier.ReadyInstanceState(config.Original, ss.Status.ReadyReplicas), nil
+		info = sablier.InstanceInfo{
+			Name:            config.Original,
+			CurrentReplicas: ss.Status.ReadyReplicas,
+			DesiredReplicas: config.Replicas,
+			Status:          sablier.InstanceStatusReady,
+		}
+	} else if *ss.Spec.Replicas == 0 {
+		info = sablier.InstanceInfo{
+			Name:            config.Original,
+			CurrentReplicas: ss.Status.ReadyReplicas,
+			DesiredReplicas: config.Replicas,
+			Status:          sablier.InstanceStatusStopped,
+		}
+	} else {
+		info = sablier.InstanceInfo{
+			Name:            config.Original,
+			CurrentReplicas: ss.Status.ReadyReplicas,
+			DesiredReplicas: config.Replicas,
+			Status:          sablier.InstanceStatusStarting,
+		}
 	}
 
-	return sablier.NotReadyInstanceState(config.Original, ss.Status.ReadyReplicas, config.Replicas), nil
+	sablier.PopulateEnabledAndGroup(&info, ss.Labels)
+
+	var image string
+	if len(ss.Spec.Template.Spec.Containers) > 0 {
+		image = ss.Spec.Template.Spec.Containers[0].Image
+	}
+	info.Provider = sablier.ProviderKubernetes
+	info.Kubernetes = &sablier.KubernetesWorkloadInfo{
+		Namespace: config.Namespace,
+		Kind:      "statefulset",
+		Image:     image,
+		Labels:    ss.Labels,
+	}
+
+	return info, nil
 }

--- a/pkg/provider/kubernetes/statefulset_inspect.go
+++ b/pkg/provider/kubernetes/statefulset_inspect.go
@@ -44,11 +44,15 @@ func (p *Provider) StatefulSetInspect(ctx context.Context, config ParsedName) (s
 		image = ss.Spec.Template.Spec.Containers[0].Image
 	}
 	info.Provider = sablier.ProviderKubernetes
+	labels := ss.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
 	info.Kubernetes = &sablier.KubernetesWorkloadInfo{
 		Namespace: config.Namespace,
 		Kind:      "statefulset",
 		Image:     image,
-		Labels:    ss.Labels,
+		Labels:    labels,
 	}
 
 	return info, nil

--- a/pkg/provider/kubernetes/statefulset_inspect_test.go
+++ b/pkg/provider/kubernetes/statefulset_inspect_test.go
@@ -27,10 +27,11 @@ func TestKubernetesProvider_InspectStatefulSet(t *testing.T) {
 		do func(dind *kindContainer) (string, error)
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    sablier.InstanceInfo
-		wantErr error
+		name       string
+		args       args
+		want       sablier.InstanceInfo
+		wantLabels map[string]string
+		wantErr    error
 	}{
 		{
 			name: "statefulSet with 1/1 replicas",
@@ -76,7 +77,7 @@ func TestKubernetesProvider_InspectStatefulSet(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStarting,
 			},
 			wantErr: nil,
 		},
@@ -111,7 +112,42 @@ func TestKubernetesProvider_InspectStatefulSet(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStopped,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "statefulset with sablier labels",
+			args: args{
+				do: func(dind *kindContainer) (string, error) {
+					d, err := dind.CreateMimicStatefulSet(ctx, MimicOptions{
+						Cmd: []string{"/mimic"},
+						Labels: map[string]string{
+							"sablier.enable": "true",
+							"sablier.group":  "myapp",
+						},
+					})
+					if err != nil {
+						return "", err
+					}
+
+					if err = WaitForStatefulSetReady(ctx, dind.client, "default", d.Name); err != nil {
+						return "", fmt.Errorf("error waiting for statefulset: %w", err)
+					}
+
+					return kubernetes.StatefulSetName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original, nil
+				},
+			},
+			want: sablier.InstanceInfo{
+				CurrentReplicas: 1,
+				DesiredReplicas: 1,
+				Status:          sablier.InstanceStatusReady,
+				Enabled:         "true",
+				Group:           "myapp",
+			},
+			wantLabels: map[string]string{
+				"sablier.enable": "true",
+				"sablier.group":  "myapp",
 			},
 			wantErr: nil,
 		},
@@ -134,6 +170,17 @@ func TestKubernetesProvider_InspectStatefulSet(t *testing.T) {
 			}
 
 			tt.want.Name = name
+			tt.want.Provider = "kubernetes"
+			labels := tt.wantLabels
+			if labels == nil {
+				labels = map[string]string{}
+			}
+			tt.want.Kubernetes = &sablier.KubernetesWorkloadInfo{
+				Namespace: "default",
+				Kind:      "statefulset",
+				Image:     "sablierapp/mimic:v0.3.3",
+				Labels:    labels,
+			}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {
 				t.Errorf("DockerSwarmProvider.InstanceInspect() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/provider/kubernetes/statefulset_list.go
+++ b/pkg/provider/kubernetes/statefulset_list.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+
 	"github.com/sablierapp/sablier/pkg/sablier"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,7 +34,8 @@ func (p *Provider) StatefulSetList(ctx context.Context) ([]sablier.InstanceConfi
 func (p *Provider) statefulSetToInstance(ss *v1.StatefulSet) sablier.InstanceConfiguration {
 	var group string
 
-	if _, ok := ss.Labels["sablier.enable"]; ok {
+	enabled := ss.Labels["sablier.enable"]
+	if enabled == "true" {
 		if g, ok := ss.Labels["sablier.group"]; ok {
 			group = g
 		} else {
@@ -44,8 +46,9 @@ func (p *Provider) statefulSetToInstance(ss *v1.StatefulSet) sablier.InstanceCon
 	parsed := StatefulSetName(ss, ParseOptions{Delimiter: p.delimiter})
 
 	return sablier.InstanceConfiguration{
-		Name:  parsed.Original,
-		Group: group,
+		Name:    parsed.Original,
+		Group:   group,
+		Enabled: enabled,
 	}
 }
 

--- a/pkg/provider/podman/container_inspect.go
+++ b/pkg/provider/podman/container_inspect.go
@@ -1,0 +1,29 @@
+package podman
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
+
+func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.InstanceInfo, error) {
+	info, err := p.Provider.InstanceInspect(ctx, name)
+	if err != nil {
+		return info, err
+	}
+
+	if info.Docker == nil {
+		return sablier.InstanceInfo{}, fmt.Errorf("podman: docker provider did not populate Docker field for %q", name)
+	}
+
+	info.Provider = sablier.ProviderPodman
+	info.Podman = &sablier.PodmanContainerInfo{
+		ID:     info.Docker.ID,
+		Image:  info.Docker.Image,
+		Labels: info.Docker.Labels,
+	}
+	info.Docker = nil
+
+	return info, nil
+}

--- a/pkg/provider/podman/container_inspect_test.go
+++ b/pkg/provider/podman/container_inspect_test.go
@@ -294,7 +294,7 @@ func TestPodmanProvider_GetState(t *testing.T) {
 			tt.want.Provider = "podman"
 			tt.want.Podman = &sablier.PodmanContainerInfo{
 				ID:    name,
-				Image: "sablierapp/mimic:v0.3.3",
+				Image: "docker.io/sablierapp/mimic:v0.3.3",
 			}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {

--- a/pkg/provider/podman/container_inspect_test.go
+++ b/pkg/provider/podman/container_inspect_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/neilotoole/slogt"
@@ -25,10 +26,11 @@ func TestPodmanProvider_GetState(t *testing.T) {
 		do func(pind *pindContainer) (string, error)
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    sablier.InstanceInfo
-		wantErr error
+		name       string
+		args       args
+		want       sablier.InstanceInfo
+		wantLabels map[string]string
+		wantErr    error
 	}{
 		{
 			name: "created container",
@@ -44,7 +46,7 @@ func TestPodmanProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStarting,
 			},
 			wantErr: nil,
 		},
@@ -98,7 +100,7 @@ func TestPodmanProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStarting,
 			},
 			wantErr: nil,
 		},
@@ -135,7 +137,7 @@ func TestPodmanProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusUnrecoverable,
+				Status:          sablier.InstanceStatusError,
 				Message:         "container is unhealthy",
 			},
 			wantErr: nil,
@@ -207,7 +209,7 @@ func TestPodmanProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusNotReady,
+				Status:          sablier.InstanceStatusStopped,
 			},
 			wantErr: nil,
 		},
@@ -241,8 +243,39 @@ func TestPodmanProvider_GetState(t *testing.T) {
 			want: sablier.InstanceInfo{
 				CurrentReplicas: 0,
 				DesiredReplicas: 1,
-				Status:          sablier.InstanceStatusUnrecoverable,
+				Status:          sablier.InstanceStatusError,
 				Message:         "container exited with code \"137\"",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "running container with sablier labels",
+			args: args{
+				do: func(pind *pindContainer) (string, error) {
+					c, err := pind.CreateMimic(ctx, MimicOptions{
+						Cmd: []string{"/mimic", "-running", "-running-after=1ms"},
+						Labels: map[string]string{
+							"sablier.enable": "true",
+							"sablier.group":  "myapp",
+						},
+					})
+					if err != nil {
+						return "", err
+					}
+					_, err = pind.client.ContainerStart(ctx, c.ID, client.ContainerStartOptions{})
+					return c.ID, err
+				},
+			},
+			want: sablier.InstanceInfo{
+				CurrentReplicas: 1,
+				DesiredReplicas: 1,
+				Status:          sablier.InstanceStatusReady,
+				Enabled:         "true",
+				Group:           "myapp",
+			},
+			wantLabels: map[string]string{
+				"sablier.enable": "true",
+				"sablier.group":  "myapp",
 			},
 			wantErr: nil,
 		},
@@ -258,12 +291,22 @@ func TestPodmanProvider_GetState(t *testing.T) {
 			assert.NilError(t, err)
 
 			tt.want.Name = name
+			tt.want.Provider = "podman"
+			tt.want.Podman = &sablier.PodmanContainerInfo{
+				ID:    name,
+				Image: "sablierapp/mimic:v0.3.3",
+			}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {
 				t.Errorf("PodmanProvider.InstanceInspect() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.DeepEqual(t, got, tt.want)
+			assert.DeepEqual(t, got, tt.want, cmpopts.IgnoreFields(sablier.PodmanContainerInfo{}, "Labels"))
+			for k, v := range tt.wantLabels {
+				if got.Podman.Labels[k] != v {
+					t.Errorf("Podman.Labels[%q] = %q, want %q", k, got.Podman.Labels[k], v)
+				}
+			}
 		})
 	}
 }

--- a/pkg/provider/podman/container_list_test.go
+++ b/pkg/provider/podman/container_list_test.go
@@ -58,12 +58,14 @@ func TestPodmanProvider_InstanceList(t *testing.T) {
 
 	want := []sablier.InstanceConfiguration{
 		{
-			Name:  strings.TrimPrefix(i1.Container.Name, "/"),
-			Group: "default",
+			Name:    strings.TrimPrefix(i1.Container.Name, "/"),
+			Group:   "default",
+			Enabled: "true",
 		},
 		{
-			Name:  strings.TrimPrefix(i2.Container.Name, "/"),
-			Group: "my-group",
+			Name:    strings.TrimPrefix(i2.Container.Name, "/"),
+			Group:   "my-group",
+			Enabled: "true",
 		},
 	}
 	// Sort both slices to ensure order-independent comparison

--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -3,52 +3,57 @@ package sablier
 type InstanceStatus string
 
 const (
-	InstanceStatusReady         = "ready"
-	InstanceStatusNotReady      = "not-ready"
-	InstanceStatusUnrecoverable = "unrecoverable"
+	InstanceStatusStopped  InstanceStatus = "stopped"
+	InstanceStatusStarting InstanceStatus = "starting"
+	InstanceStatusReady    InstanceStatus = "ready"
+	InstanceStatusError    InstanceStatus = "error"
+)
+
+// ProviderType identifies the infrastructure provider that manages an instance.
+type ProviderType = string
+
+const (
+	ProviderDocker     ProviderType = "docker"
+	ProviderSwarm      ProviderType = "swarm"
+	ProviderKubernetes ProviderType = "kubernetes"
+	ProviderPodman     ProviderType = "podman"
 )
 
 type InstanceInfo struct {
-	Name            string         `json:"name"`
-	CurrentReplicas int32          `json:"currentReplicas"`
-	DesiredReplicas int32          `json:"desiredReplicas"`
-	Status          InstanceStatus `json:"status"`
-	Message         string         `json:"message,omitempty"`
+	Name            string                  `json:"name"`
+	CurrentReplicas int32                   `json:"currentReplicas"`
+	DesiredReplicas int32                   `json:"desiredReplicas"`
+	Status          InstanceStatus          `json:"status"`
+	Group           string                  `json:"group,omitempty"`
+	Enabled         string                  `json:"enabled,omitempty"`
+	Message         string                  `json:"message,omitempty"`
+	Provider        ProviderType            `json:"provider,omitempty"`
+	Docker          *DockerContainerInfo    `json:"docker,omitempty"`
+	Swarm           *SwarmServiceInfo       `json:"swarm,omitempty"`
+	Kubernetes      *KubernetesWorkloadInfo `json:"kubernetes,omitempty"`
+	Podman          *PodmanContainerInfo    `json:"podman,omitempty"`
 }
 
 type InstanceConfiguration struct {
-	Name  string
-	Group string
+	Name    string
+	Group   string
+	Enabled string
 }
 
 func (instance InstanceInfo) IsReady() bool {
 	return instance.Status == InstanceStatusReady
 }
 
-func UnrecoverableInstanceState(name string, message string, desiredReplicas int32) InstanceInfo {
-	return InstanceInfo{
-		Name:            name,
-		CurrentReplicas: 0,
-		DesiredReplicas: desiredReplicas,
-		Status:          InstanceStatusUnrecoverable,
-		Message:         message,
-	}
-}
-
-func ReadyInstanceState(name string, replicas int32) InstanceInfo {
-	return InstanceInfo{
-		Name:            name,
-		CurrentReplicas: replicas,
-		DesiredReplicas: replicas,
-		Status:          InstanceStatusReady,
-	}
-}
-
-func NotReadyInstanceState(name string, currentReplicas int32, desiredReplicas int32) InstanceInfo {
-	return InstanceInfo{
-		Name:            name,
-		CurrentReplicas: currentReplicas,
-		DesiredReplicas: desiredReplicas,
-		Status:          InstanceStatusNotReady,
+// PopulateEnabledAndGroup reads the sablier.enable and sablier.group labels from
+// labels and writes the results into info. Centralising this logic avoids
+// duplicating the same map lookups in every provider's Inspect implementation.
+func PopulateEnabledAndGroup(info *InstanceInfo, labels map[string]string) {
+	info.Enabled = labels["sablier.enable"]
+	if info.Enabled == "true" {
+		if g := labels["sablier.group"]; g != "" {
+			info.Group = g
+		} else {
+			info.Group = "default"
+		}
 	}
 }

--- a/pkg/sablier/instance_provider.go
+++ b/pkg/sablier/instance_provider.go
@@ -1,0 +1,30 @@
+package sablier
+
+// DockerContainerInfo holds Docker-specific container metadata.
+type DockerContainerInfo struct {
+	ID     string            `json:"id"`
+	Image  string            `json:"image"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// SwarmServiceInfo holds Docker Swarm-specific service metadata.
+type SwarmServiceInfo struct {
+	ID     string            `json:"id"`
+	Image  string            `json:"image"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// KubernetesWorkloadInfo holds Kubernetes-specific workload metadata.
+type KubernetesWorkloadInfo struct {
+	Namespace string            `json:"namespace"`
+	Kind      string            `json:"kind"`
+	Image     string            `json:"image"`
+	Labels    map[string]string `json:"labels,omitempty"`
+}
+
+// PodmanContainerInfo holds Podman-specific container metadata.
+type PodmanContainerInfo struct {
+	ID     string            `json:"id"`
+	Image  string            `json:"image"`
+	Labels map[string]string `json:"labels,omitempty"`
+}

--- a/pkg/sablier/instance_request.go
+++ b/pkg/sablier/instance_request.go
@@ -13,6 +13,7 @@ import (
 type pendingStart struct {
 	done chan struct{}
 	err  error
+	info InstanceInfo // set at creation time; used to return consistent data while starting
 }
 
 // consumePendingError checks whether a pending start exists for the given
@@ -44,9 +45,10 @@ func (s *Sablier) consumePendingError(name string) (bool, error) {
 }
 
 func (s *Sablier) requestStart(ctx context.Context, name string) (InstanceInfo, error) {
+	// First critical section: check whether a start is already in progress.
+	// We release the lock before doing the remote inspect to avoid holding a
+	// mutex across a potentially slow network call.
 	s.pendingMu.Lock()
-	defer s.pendingMu.Unlock()
-
 	if ps, exists := s.pendingStarts[name]; exists {
 		select {
 		case <-ps.done:
@@ -54,19 +56,50 @@ func (s *Sablier) requestStart(ctx context.Context, name string) (InstanceInfo, 
 			if ps.err != nil {
 				err := ps.err
 				delete(s.pendingStarts, name)
+				s.pendingMu.Unlock()
 				return InstanceInfo{}, fmt.Errorf("instance start failed: %w", err)
 			}
-			// Succeeded previously but instance is no longer in store — start a new one
+			// Succeeded previously but instance is no longer in store — fall through to restart
 			delete(s.pendingStarts, name)
 		default:
-			// Still running — don't start another goroutine
+			// Still running — return the cached InstanceInfo to preserve provider fields
 			s.l.DebugContext(ctx, "instance start already in progress", slog.String("instance", name))
-			return NotReadyInstanceState(name, 0, 1), nil
+			info := ps.info
+			s.pendingMu.Unlock()
+			return info, nil
 		}
 	}
+	s.pendingMu.Unlock()
 
-	ps := &pendingStart{done: make(chan struct{})}
+	// Inspect outside the lock: this may be a slow remote network call.
+	// If inspect fails (e.g. first boot), fall back to a minimal struct so
+	// the start still proceeds.
+	info, err := s.provider.InstanceInspect(ctx, name)
+	if err != nil {
+		s.l.DebugContext(ctx, "pre-start inspect failed, using bare info", slog.String("instance", name), slog.Any("error", err))
+		info = InstanceInfo{Name: name, CurrentReplicas: 0, DesiredReplicas: 1}
+	}
+	info.Status = InstanceStatusStarting
+
+	// Second critical section: register the pending entry. Re-check in case
+	// another goroutine raced past the first unlock and registered first.
+	s.pendingMu.Lock()
+	if existing, exists := s.pendingStarts[name]; exists {
+		select {
+		case <-existing.done:
+			// The racing goroutine already finished; proceed with our own entry.
+			delete(s.pendingStarts, name)
+		default:
+			// A concurrent goroutine won the race; return its cached info.
+			s.l.DebugContext(ctx, "instance start already in progress (post-inspect race)", slog.String("instance", name))
+			existingInfo := existing.info
+			s.pendingMu.Unlock()
+			return existingInfo, nil
+		}
+	}
+	ps := &pendingStart{done: make(chan struct{}), info: info}
 	s.pendingStarts[name] = ps
+	s.pendingMu.Unlock()
 
 	// Detach from the request context to avoid retaining HTTP request values,
 	// but use a bounded timeout to prevent goroutine leaks.
@@ -90,7 +123,7 @@ func (s *Sablier) requestStart(ctx context.Context, name string) (InstanceInfo, 
 		}
 	}()
 
-	return NotReadyInstanceState(name, 0, 1), nil
+	return info, nil
 }
 
 func (s *Sablier) InstanceRequest(ctx context.Context, name string, duration time.Duration) (InstanceInfo, error) {

--- a/pkg/sablier/instance_request_test.go
+++ b/pkg/sablier/instance_request_test.go
@@ -41,18 +41,26 @@ func TestInstanceRequest_NewInstance_StartsAsync(t *testing.T) {
 
 	startCalled := make(chan struct{})
 
+	stoppedInfo := sablier.InstanceInfo{
+		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+	}
+	notReady := stoppedInfo
+	notReady.Status = sablier.InstanceStatusStarting
+
 	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(stoppedInfo, nil)
 
 	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
 		close(startCalled)
 		return nil
 	})
 
-	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil)
+	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
 
 	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 	assert.Equal(t, info.Name, "nginx")
 
 	select {
@@ -69,7 +77,15 @@ func TestInstanceRequest_NewInstance_ReturnsBeforeStartCompletes(t *testing.T) {
 	startBlocking := make(chan struct{})
 	startCalled := make(chan struct{})
 
+	stoppedInfo := sablier.InstanceInfo{
+		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+	}
+	notReady := stoppedInfo
+	notReady.Status = sablier.InstanceStatusStarting
+
 	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(stoppedInfo, nil)
 
 	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
 		close(startCalled)
@@ -77,11 +93,11 @@ func TestInstanceRequest_NewInstance_ReturnsBeforeStartCompletes(t *testing.T) {
 		return nil
 	})
 
-	sessions.EXPECT().Put(ctx, sablier.NotReadyInstanceState("nginx", 0, 1), time.Minute).Return(nil)
+	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
 
 	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 
 	select {
 	case <-startCalled:
@@ -99,7 +115,12 @@ func TestInstanceRequest_DuplicateCallsDoNotHammerProvider(t *testing.T) {
 	startBlocking := make(chan struct{})
 	startCalled := make(chan struct{})
 
-	notReady := sablier.NotReadyInstanceState("nginx", 0, 1)
+	stoppedInfo := sablier.InstanceInfo{
+		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+	}
+	notReady := stoppedInfo
+	notReady.Status = sablier.InstanceStatusStarting
 
 	// First call: store miss -> triggers requestStart
 	// Second call: store returns the not-ready state written by Put -> hits status != ready path
@@ -107,6 +128,9 @@ func TestInstanceRequest_DuplicateCallsDoNotHammerProvider(t *testing.T) {
 		sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound),
 		sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil),
 	)
+
+	// InstanceInspect: exactly once during requestStart (second call must not trigger another)
+	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(stoppedInfo, nil).Times(1)
 
 	// InstanceStart: exactly once (second call must not trigger another)
 	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
@@ -121,7 +145,7 @@ func TestInstanceRequest_DuplicateCallsDoNotHammerProvider(t *testing.T) {
 	// First call — starts the goroutine
 	info1, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
-	assert.Equal(t, info1.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+	assert.Equal(t, info1.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 
 	// Wait for the goroutine to enter InstanceStart
 	select {
@@ -133,7 +157,7 @@ func TestInstanceRequest_DuplicateCallsDoNotHammerProvider(t *testing.T) {
 	// Second call — start still pending, skips inspect, no duplicate InstanceStart
 	info2, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
-	assert.Equal(t, info2.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+	assert.Equal(t, info2.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 
 	close(startBlocking)
 }
@@ -142,10 +166,16 @@ func TestInstanceRequest_AsyncErrorSurfacedOnNotReadyPath(t *testing.T) {
 	manager, sessions, provider := setupSablier(t)
 	ctx := t.Context()
 
-	notReady := sablier.NotReadyInstanceState("nginx", 0, 1)
+	stoppedInfo := sablier.InstanceInfo{
+		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+	}
+	notReady := stoppedInfo
+	notReady.Status = sablier.InstanceStatusStarting
 
 	// First call: store miss -> requestStart
 	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(stoppedInfo, nil)
 	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
 
 	// Goroutine fails immediately
@@ -153,7 +183,7 @@ func TestInstanceRequest_AsyncErrorSurfacedOnNotReadyPath(t *testing.T) {
 
 	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 
 	// Subsequent calls: store returns the stored not-ready state (realistic behavior).
 	// While goroutine is still running, polling returns not-ready with Put.
@@ -172,12 +202,18 @@ func TestInstanceRequest_RetryAfterErrorConsumed(t *testing.T) {
 	manager, sessions, provider := setupSablier(t)
 	ctx := t.Context()
 
-	notReady := sablier.NotReadyInstanceState("nginx", 0, 1)
+	stoppedInfo := sablier.InstanceInfo{
+		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+	}
+	notReady := stoppedInfo
+	notReady.Status = sablier.InstanceStatusStarting
 	secondDone := make(chan struct{})
 
-	// All Get/Put calls use AnyTimes since polling may hit them multiple times
+	// All Get/Put/Inspect calls use AnyTimes since polling may hit them multiple times
 	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
 	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil).AnyTimes()
+	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(stoppedInfo, nil).AnyTimes()
 
 	gomock.InOrder(
 		// First attempt — fails immediately
@@ -203,7 +239,7 @@ func TestInstanceRequest_RetryAfterErrorConsumed(t *testing.T) {
 	// 3rd call: entry cleared, store miss again -> requestStart retries
 	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 
 	select {
 	case <-secondDone:
@@ -216,14 +252,23 @@ func TestInstanceRequest_SuccessfulStartCleansUpPendingEntry(t *testing.T) {
 	manager, sessions, provider := setupSablier(t)
 	ctx := t.Context()
 
-	notReady := sablier.NotReadyInstanceState("nginx", 0, 1)
-	ready := sablier.ReadyInstanceState("nginx", 1)
+	stoppedInfo := sablier.InstanceInfo{
+		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+	}
+	notReady := stoppedInfo
+	notReady.Status = sablier.InstanceStatusStarting
+	ready := sablier.InstanceInfo{Name: "nginx", CurrentReplicas: 1, DesiredReplicas: 1, Status: sablier.InstanceStatusReady}
 
 	// 1st call: store miss -> requestStart (goroutine succeeds)
 	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
 	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
 
 	startDone := make(chan struct{})
+	gomock.InOrder(
+		provider.EXPECT().InstanceInspect(ctx, "nginx").Return(stoppedInfo, nil), // pre-start inspect
+		provider.EXPECT().InstanceInspect(ctx, "nginx").Return(ready, nil),       // post-start inspect in not-ready path
+	)
 	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ interface{}, _ string) error {
 		close(startDone)
 		return nil
@@ -231,7 +276,7 @@ func TestInstanceRequest_SuccessfulStartCleansUpPendingEntry(t *testing.T) {
 
 	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 
 	// Wait for goroutine to finish and self-clean
 	select {
@@ -244,7 +289,6 @@ func TestInstanceRequest_SuccessfulStartCleansUpPendingEntry(t *testing.T) {
 
 	// 2nd call: store returns not-ready, no pending entry exists, goes straight to inspect
 	sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil)
-	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(ready, nil)
 	sessions.EXPECT().Put(ctx, ready, time.Minute).Return(nil)
 
 	info, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
@@ -257,9 +301,15 @@ func TestInstanceRequest_StartTimeoutSurfacesError(t *testing.T) {
 	manager.InstanceStartTimeout = 100 * time.Millisecond
 	ctx := t.Context()
 
-	notReady := sablier.NotReadyInstanceState("nginx", 0, 1)
+	stoppedInfo := sablier.InstanceInfo{
+		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+	}
+	notReady := stoppedInfo
+	notReady.Status = sablier.InstanceStatusStarting
 
 	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(stoppedInfo, nil)
 	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
 
 	// InstanceStart blocks until context is cancelled
@@ -270,7 +320,7 @@ func TestInstanceRequest_StartTimeoutSurfacesError(t *testing.T) {
 
 	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
 	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusNotReady))
+	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 
 	// Subsequent calls: store returns not-ready; polling may get not-ready while
 	// the goroutine is still in progress, or the timeout error once it completes.
@@ -290,7 +340,7 @@ func TestInstanceRequest_ExistingNotReady_InspectsProvider(t *testing.T) {
 
 	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{
 		Name:   "nginx",
-		Status: sablier.InstanceStatusNotReady,
+		Status: sablier.InstanceStatusStarting,
 	}, nil)
 
 	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(sablier.InstanceInfo{

--- a/pkg/sablier/session_request_test.go
+++ b/pkg/sablier/session_request_test.go
@@ -2,10 +2,11 @@ package sablier_test
 
 import (
 	"context"
-	"github.com/sablierapp/sablier/pkg/sablier"
-	"go.uber.org/mock/gomock"
 	"testing"
 	"time"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"go.uber.org/mock/gomock"
 
 	"gotest.tools/v3/assert"
 )
@@ -35,7 +36,7 @@ func TestSessionState_IsReady(t *testing.T) {
 			fields: fields{
 				Instances: createMap([]sablier.InstanceInfo{
 					{Name: "nginx", Status: sablier.InstanceStatusReady},
-					{Name: "apache", Status: sablier.InstanceStatusNotReady},
+					{Name: "apache", Status: sablier.InstanceStatusStarting},
 				}),
 			},
 			want: false,
@@ -51,7 +52,7 @@ func TestSessionState_IsReady(t *testing.T) {
 			name: "one instance has an error",
 			fields: fields{
 				Instances: createMap([]sablier.InstanceInfo{
-					{Name: "nginx-error", Status: sablier.InstanceStatusUnrecoverable, Message: "connection timeout"},
+					{Name: "nginx-error", Status: sablier.InstanceStatusError, Message: "connection timeout"},
 					{Name: "apache", Status: sablier.InstanceStatusReady},
 				}),
 			},
@@ -96,10 +97,10 @@ func TestSessionsManager_RequestReadySessionCancelledByUser(t *testing.T) {
 	t.Run("request ready session is cancelled by user", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		manager, store, provider := setupSablier(t)
-		store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusNotReady}, nil).AnyTimes()
+		store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil).AnyTimes()
 		store.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-		provider.EXPECT().InstanceInspect(ctx, gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusNotReady}, nil)
+		provider.EXPECT().InstanceInspect(ctx, gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil)
 
 		errchan := make(chan error)
 		go func() {
@@ -118,10 +119,10 @@ func TestSessionsManager_RequestReadySessionCancelledByTimeout(t *testing.T) {
 
 	t.Run("request ready session is cancelled by timeout", func(t *testing.T) {
 		manager, store, provider := setupSablier(t)
-		store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusNotReady}, nil).AnyTimes()
+		store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil).AnyTimes()
 		store.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-		provider.EXPECT().InstanceInspect(t.Context(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusNotReady}, nil)
+		provider.EXPECT().InstanceInspect(t.Context(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil)
 
 		errchan := make(chan error)
 		go func() {

--- a/pkg/theme/types.go
+++ b/pkg/theme/types.go
@@ -1,6 +1,10 @@
 package theme
 
-import "time"
+import (
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
 
 // Theme represents an available theme
 type Theme struct {
@@ -15,6 +19,11 @@ type Instance struct {
 	Error           error
 	CurrentReplicas int32
 	DesiredReplicas int32
+	Provider        string
+	Docker          *sablier.DockerContainerInfo
+	Swarm           *sablier.SwarmServiceInfo
+	Kubernetes      *sablier.KubernetesWorkloadInfo
+	Podman          *sablier.PodmanContainerInfo
 }
 
 // Options holds the customizable input to template


### PR DESCRIPTION
This will provide themes raw data to the underlying instance type (container, service, k8s deployment, etc.)