### PR TITLE
Remove volume declaration from Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,5 @@ COPY --chmod=0644 build/sablier.yaml /etc/sablier/sablier.yaml
 
 EXPOSE 10000
 
-VOLUME [ "/etc/sablier/state.json", "/etc/sablier/themes" ]
-
 ENTRYPOINT [ "/bin/sablier" ]
 CMD [ "--configFile=/etc/sablier/sablier.yaml", "start" ]


### PR DESCRIPTION
volumes are not needed and can be mounted by user

/etc/sablier/state.json was considered as a directory