### PR TITLE
feat: add --auto-stop-externally-started flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,11 @@ sablier --configFile=path/to/myconfigfile.yml
 provider:
   # Provider to use to manage containers (docker, swarm, kubernetes, podman, proxmox_lxc)
   name: docker
+  # Stop all sablier.enable=true instances that are running at startup and were not started by Sablier (default: true)
+  auto-stop-on-startup: true
+  # Continuously stop instances with sablier.enable=true that are running but were not started by Sablier (default: false)
+  # Uses both event-driven detection and a periodic reconciliation scan (every 30 seconds) as a safety net.
+  auto-stop-externally-started: false
   docker:
     # Strategy to use for stopping Docker containers: stop or pause (default: stop)
     strategy: stop
@@ -185,6 +190,8 @@ sablier start --strategy.dynamic.custom-themes-path /my/path
 
 ```
   -h, --help                                                  help for start
+      --provider.auto-stop-on-startup                         Stop all sablier.enable=true instances running at startup that were not started by Sablier (default true)
+  --provider.auto-stop-externally-started                 Continuously stop instances with sablier.enable=true that are running but were not started by Sablier (default false)
       --provider.docker.strategy string                       Strategy to use to stop docker containers (stop or pause) (default "stop")
       --provider.name string                                  Provider to use to manage containers [docker swarm kubernetes podman proxmox_lxc] (default "docker")
       --server.base-path string                               The base path for the API (default "/")

--- a/examples/auto-stop-externally-started/Makefile
+++ b/examples/auto-stop-externally-started/Makefile
@@ -1,0 +1,30 @@
+.DEFAULT_GOAL := help
+
+COMPOSE := docker compose
+
+.PHONY: help
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
+
+.PHONY: up
+up: ## Start the full stack (managed will be stopped automatically by Sablier)
+	$(COMPOSE) up -d
+
+.PHONY: logs
+logs: ## Follow Sablier logs
+	$(COMPOSE) logs -f sablier
+
+.PHONY: status
+status: ## Show running container status
+	$(COMPOSE) ps -a
+
+.PHONY: start-managed
+start-managed: ## Start 'managed' externally to demonstrate the continuous watch
+	$(COMPOSE) start managed
+	@echo ""
+	@echo "Watch the Sablier logs — 'managed' will be stopped within seconds."
+	@echo "Run: make logs"
+
+.PHONY: down
+down: ## Tear down the stack
+	$(COMPOSE) down

--- a/examples/auto-stop-externally-started/README.md
+++ b/examples/auto-stop-externally-started/README.md
@@ -1,0 +1,85 @@
+# `auto-stop-externally-started` Example
+
+This example demonstrates the `--provider.auto-stop-externally-started` flag.
+
+Sablier manages containers that carry the `sablier.enable=true` label. If such
+a container starts without Sablier having initiated the start (e.g. via
+`docker compose up`, a restart policy, or a manual `docker start`), Sablier
+will stop it automatically so that traffic is only served once a client
+explicitly requests the instance.
+
+Two containers illustrate the difference:
+
+| Service | Labels | Behaviour |
+|---------|--------|-----------|
+| `managed` | `sablier.enable=true` | Stopped automatically by Sablier |
+| `unmanaged` | *(none)* | Left running; Sablier ignores it |
+
+## Flags used
+
+| Flag | Value | Purpose |
+|------|-------|---------|
+| `--provider.auto-stop-on-startup` | `true` | Stop unregistered managed instances already running at startup |
+| `--provider.auto-stop-externally-started` | `true` | Continuously stop managed instances that start while Sablier is running |
+
+## Prerequisites
+
+- Docker with the Compose plugin (`docker compose version`)
+
+## Walkthrough
+
+### Scenario 1 — Startup behaviour
+
+Start the full stack:
+
+```bash
+make up
+```
+
+Both `managed` and `unmanaged` start via Compose. Because Sablier did not
+initiate the `managed` start, `--provider.auto-stop-on-startup` stops it
+within seconds of Sablier booting.
+
+Verify:
+
+```bash
+make status
+```
+
+Expected output (abridged):
+
+```
+NAME           STATUS
+sablier        Up
+managed        Exited
+unmanaged      Up
+```
+
+### Scenario 2 — Continuous watch
+
+With the stack already running, start `managed` externally:
+
+```bash
+make start-managed
+```
+
+Sablier receives the Docker `start` event, recognises that it did not initiate
+the start, and stops the container again — usually within a second.
+
+Watch it happen in real time:
+
+```bash
+make logs
+```
+
+You should see a log line similar to:
+
+```
+level=INFO msg="externally started instance detected, stopping" instance=managed
+```
+
+### Tear down
+
+```bash
+make down
+```

--- a/examples/auto-stop-externally-started/compose.yml
+++ b/examples/auto-stop-externally-started/compose.yml
@@ -1,0 +1,35 @@
+services:
+  sablier:
+    image: ${SABLIER_IMAGE:-sablierapp/sablier:latest}
+    command:
+      - start
+      - --provider.name=docker
+      - --logging.level=debug
+      - --sessions.default-duration=1m
+      - --sessions.expiration-interval=10s
+      # Stop instances that are already running at startup and were not started by Sablier.
+      - --provider.auto-stop-on-startup=true
+      # Continuously stop instances that start after Sablier is running and were not started by Sablier.
+      - --provider.auto-stop-externally-started=true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "10000:10000"
+
+  # managed has sablier.enable=true.
+  # Sablier will stop it on startup (auto-stop-on-startup) and again if
+  # it is started externally while Sablier is running (auto-stop-externally-started).
+  managed:
+    image: acouvreur/whoami:v1.10.2
+    labels:
+      - "sablier.enable=true"
+      - "sablier.group=managed"
+    ports:
+      - "8080:80"
+
+  # unmanaged has no sablier labels.
+  # Sablier ignores it completely; it keeps running regardless.
+  unmanaged:
+    image: acouvreur/whoami:v1.10.2
+    ports:
+      - "8081:80"

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect; indirectit
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -8,12 +8,13 @@ import (
 type Provider struct {
 	// The provider name to use
 	// It can be either docker, swarm, kubernetes, podman or proxmox_lxc. Defaults to "docker"
-	Name              string `mapstructure:"NAME" yaml:"name,omitempty" default:"docker"`
-	AutoStopOnStartup bool   `yaml:"auto-stop-on-startup,omitempty" default:"true"`
-	Kubernetes        Kubernetes
-	Podman            Podman
-	Docker            Docker
-	ProxmoxLXC        ProxmoxLXC `mapstructure:"PROXMOX_LXC" yaml:"proxmox-lxc,omitempty"`
+	Name                      string `mapstructure:"NAME" yaml:"name,omitempty" default:"docker"`
+	AutoStopOnStartup         bool   `yaml:"auto-stop-on-startup,omitempty" default:"true"`
+	AutoStopExternallyStarted bool   `yaml:"auto-stop-externally-started,omitempty" default:"false"`
+	Kubernetes                Kubernetes
+	Podman                    Podman
+	Docker                    Docker
+	ProxmoxLXC                ProxmoxLXC `mapstructure:"PROXMOX_LXC" yaml:"proxmox-lxc,omitempty"`
 }
 
 type Kubernetes struct {
@@ -57,8 +58,8 @@ var dockerStrategies = []string{"stop", "pause"}
 
 func NewProviderConfig() Provider {
 	return Provider{
-
-		Name: "docker",
+		Name:              "docker",
+		AutoStopOnStartup: true,
 		Kubernetes: Kubernetes{
 			QPS:       5,
 			Burst:     10,

--- a/pkg/config/provider_test.go
+++ b/pkg/config/provider_test.go
@@ -180,3 +180,16 @@ func TestDocker_IsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestNewProviderConfig_Defaults(t *testing.T) {
+	c := NewProviderConfig()
+
+	assert.Equal(t, c.Name, "docker")
+	assert.Equal(t, c.AutoStopOnStartup, true)
+	assert.Equal(t, c.AutoStopExternallyStarted, false)
+	assert.Equal(t, c.Docker.Strategy, "stop")
+	assert.Equal(t, c.Kubernetes.QPS, float32(5))
+	assert.Equal(t, c.Kubernetes.Burst, 10)
+	assert.Equal(t, c.Kubernetes.Delimiter, "_")
+	assert.Equal(t, c.Podman.Uri, "unix:///run/podman/podman.sock")
+}

--- a/pkg/provider/docker/events.go
+++ b/pkg/provider/docker/events.go
@@ -16,29 +16,49 @@ import (
 )
 
 func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEventsOptions) sablier.InstanceEventStream {
+	wantStopped := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStopped)
+	wantStarted := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStarted)
+
 	dial := func(ctx context.Context) client.EventsResult {
 		filters := client.Filters{}
 		filters.Add("type", string(events.ContainerEventType))
-		// Map InstanceEventStopped -> docker "die" event.
-		// An empty Types slice means all event types.
-		if len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStopped) {
+		if wantStopped {
 			filters.Add("event", "die")
+		}
+		if wantStarted {
+			filters.Add("event", "start")
 		}
 		return p.Client.Events(ctx, client.EventsListOptions{Filters: filters})
 	}
-	// "die" events fire while the container still exists (exited state), so we
-	// can inspect to get the full InstanceInfo including Docker-specific fields.
 	build := func(ctx context.Context, msg events.Message) (sablier.InstanceInfo, bool) {
 		name := strings.TrimPrefix(msg.Actor.Attributes["name"], "/")
 		if name == "" {
 			return sablier.InstanceInfo{}, false
 		}
-		info, err := p.InstanceInspect(ctx, name)
-		if err != nil {
-			p.l.WarnContext(ctx, "inspect after die event failed, using bare info", "container", name, "error", err)
-			return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderDocker}, true
+		switch msg.Action {
+		case "die":
+			if !wantStopped {
+				return sablier.InstanceInfo{}, false
+			}
+			info, err := p.InstanceInspect(ctx, name)
+			if err != nil {
+				p.l.WarnContext(ctx, "inspect after die event failed, using bare info", "container", name, "error", err)
+				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderDocker}, true
+			}
+			return info, true
+		case "start":
+			if !wantStarted {
+				return sablier.InstanceInfo{}, false
+			}
+			info, err := p.InstanceInspect(ctx, name)
+			if err != nil {
+				p.l.WarnContext(ctx, "inspect after start event failed, using bare info", "container", name, "error", err)
+				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderDocker}, true
+			}
+			return info, true
+		default:
+			return sablier.InstanceInfo{}, false
 		}
-		return info, true
 	}
 	return streamEvents(ctx, p.l, dial, build, linearBackoff)
 }

--- a/pkg/provider/docker/events_test.go
+++ b/pkg/provider/docker/events_test.go
@@ -52,3 +52,40 @@ func TestDockerClassicProvider_InstanceEvents(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestDockerClassicProvider_InstanceEvents_Started(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	dind := sharedDinD
+	p, err := docker.New(ctx, dind.client, slogt.New(t), "stop")
+	assert.NilError(t, err)
+
+	c, err := dind.CreateMimic(ctx, MimicOptions{})
+	assert.NilError(t, err)
+
+	inspected, err := dind.client.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+
+	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	})
+
+	_, err = dind.client.ContainerStart(ctx, c.ID, client.ContainerStartOptions{})
+	assert.NilError(t, err)
+
+	err = WaitForContainerRunning(ctx, dind.client, c.ID)
+	assert.NilError(t, err)
+
+	select {
+	case info := <-stream.Events:
+		assert.Equal(t, "/"+info.Name, inspected.Container.Name)
+		assert.Equal(t, info.Provider, "docker")
+		assert.Assert(t, info.Docker != nil)
+	case err := <-stream.Err:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/provider/dockerswarm/events.go
+++ b/pkg/provider/dockerswarm/events.go
@@ -19,6 +19,7 @@ const maxReconnectAttempts = 10
 
 func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEventsOptions) sablier.InstanceEventStream {
 	wantStopped := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStopped)
+	wantStarted := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStarted)
 	dial := func(ctx context.Context) client.EventsResult {
 		filters := client.Filters{}
 		filters.Add("scope", "swarm")
@@ -26,25 +27,33 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 		return p.Client.Events(ctx, client.EventsListOptions{Filters: filters})
 	}
 	// InstanceEventStopped maps to: replicas scaled to 0, or service removed.
-	// When scaled to 0 the service still exists and we can inspect it for full info.
-	// When removed the service is gone; emit a bare stopped InstanceInfo instead.
+	// InstanceEventStarted maps to: replicas scaled from 0 to >0.
 	build := func(ctx context.Context, msg events.Message) (sablier.InstanceInfo, bool) {
-		if !wantStopped {
-			return sablier.InstanceInfo{}, false
-		}
 		name := msg.Actor.Attributes["name"]
 		if name == "" {
 			return sablier.InstanceInfo{}, false
 		}
 		if msg.Action == "remove" {
-			// Service is gone; inspect would fail.
-			return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderSwarm}, true
+			if wantStopped {
+				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderSwarm}, true
+			}
+			return sablier.InstanceInfo{}, false
 		}
-		if msg.Actor.Attributes["replicas.new"] == "0" {
+		replicasNew := msg.Actor.Attributes["replicas.new"]
+		replicasOld := msg.Actor.Attributes["replicas.old"]
+		if replicasNew == "0" && wantStopped {
 			info, err := p.InstanceInspect(ctx, name)
 			if err != nil {
 				p.l.WarnContext(ctx, "inspect after scale-to-0 event failed, using bare info", "service", name, "error", err)
 				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderSwarm}, true
+			}
+			return info, true
+		}
+		if replicasOld == "0" && replicasNew != "" && replicasNew != "0" && wantStarted {
+			info, err := p.InstanceInspect(ctx, name)
+			if err != nil {
+				p.l.WarnContext(ctx, "inspect after scale-from-0 event failed, using bare info", "service", name, "error", err)
+				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderSwarm}, true
 			}
 			return info, true
 		}

--- a/pkg/provider/dockerswarm/events_test.go
+++ b/pkg/provider/dockerswarm/events_test.go
@@ -68,3 +68,51 @@ func TestDockerSwarmProvider_InstanceEvents(t *testing.T) {
 		}
 	})
 }
+
+func TestDockerSwarmProvider_InstanceEvents_Started(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	dind := sharedDinD
+	p, err := dockerswarm.New(ctx, dind.client, slogt.New(t))
+	assert.NilError(t, err)
+
+	c, err := dind.CreateMimic(ctx, MimicOptions{})
+	assert.NilError(t, err)
+
+	inspectResult, err := dind.client.ServiceInspect(ctx, c.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	service := inspectResult.Service
+
+	replicas := uint64(0)
+	service.Spec.Mode.Replicated.Replicas = &replicas
+	_, err = p.Client.ServiceUpdate(ctx, service.ID, client.ServiceUpdateOptions{Version: service.Version, Spec: service.Spec})
+	assert.NilError(t, err)
+
+	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	})
+
+	inspectResult, err = dind.client.ServiceInspect(ctx, c.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	service = inspectResult.Service
+	replicas = uint64(1)
+	service.Spec.Mode.Replicated.Replicas = &replicas
+	_, err = p.Client.ServiceUpdate(ctx, service.ID, client.ServiceUpdateOptions{Version: service.Version, Spec: service.Spec})
+	assert.NilError(t, err)
+
+	err = WaitForServiceRunning(ctx, dind.client, service.Spec.Name, 1)
+	assert.NilError(t, err)
+
+	select {
+	case info := <-stream.Events:
+		assert.Equal(t, info.Name, service.Spec.Name)
+		assert.Equal(t, info.Provider, "swarm")
+		assert.Assert(t, info.Swarm != nil)
+	case err := <-stream.Err:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/provider/kubernetes/deployment_events.go
+++ b/pkg/provider/kubernetes/deployment_events.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
-func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier.InstanceInfo) cache.SharedIndexInformer {
+func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier.InstanceInfo, wantStopped, wantStarted bool) cache.SharedIndexInformer {
 	handler := cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
 			newDeployment := new.(*appsv1.Deployment)
@@ -22,17 +22,25 @@ func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier
 				return
 			}
 
-			if *oldDeployment.Spec.Replicas == 0 {
-				return
-			}
+			oldReplicas := *oldDeployment.Spec.Replicas
+			newReplicas := *newDeployment.Spec.Replicas
 
-			if *newDeployment.Spec.Replicas == 0 {
+			if wantStopped && oldReplicas != 0 && newReplicas == 0 {
 				parsed := DeploymentName(newDeployment, ParseOptions{Delimiter: p.delimiter})
-				// Deployment still exists (scaled to 0); inspect for full info.
 				info, err := p.InstanceInspect(ctx, parsed.Original)
 				if err != nil {
 					p.l.WarnContext(ctx, "inspect after scale-to-0 event failed, using bare info", "deployment", parsed.Original, "error", err)
 					instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderKubernetes}
+					return
+				}
+				instance <- info
+			}
+			if wantStarted && oldReplicas == 0 && newReplicas != 0 {
+				parsed := DeploymentName(newDeployment, ParseOptions{Delimiter: p.delimiter})
+				info, err := p.InstanceInspect(ctx, parsed.Original)
+				if err != nil {
+					p.l.WarnContext(ctx, "inspect after scale-from-0 event failed, using bare info", "deployment", parsed.Original, "error", err)
+					instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderKubernetes}
 					return
 				}
 				instance <- info

--- a/pkg/provider/kubernetes/instance_events.go
+++ b/pkg/provider/kubernetes/instance_events.go
@@ -2,17 +2,20 @@ package kubernetes
 
 import (
 	"context"
+	"slices"
 
 	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
-func (p *Provider) InstanceEvents(ctx context.Context, _ provider.InstanceEventsOptions) sablier.InstanceEventStream {
+func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEventsOptions) sablier.InstanceEventStream {
+	wantStopped := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStopped)
+	wantStarted := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStarted)
 	eventsC := make(chan sablier.InstanceInfo)
 	errC := make(chan error, 1)
-	informer := p.watchDeployments(ctx, eventsC)
+	informer := p.watchDeployments(ctx, eventsC, wantStopped, wantStarted)
 	go informer.Run(ctx.Done())
-	informer = p.watchStatefulSets(ctx, eventsC)
+	informer = p.watchStatefulSets(ctx, eventsC, wantStopped, wantStarted)
 	go informer.Run(ctx.Done())
 	return sablier.InstanceEventStream{Events: eventsC, Err: errC}
 }

--- a/pkg/provider/kubernetes/instance_events_test.go
+++ b/pkg/provider/kubernetes/instance_events_test.go
@@ -117,3 +117,92 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 		}
 	})
 }
+
+func TestKubernetesProvider_InstanceEvents_Started(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	kind := sharedKinD
+	conf := config.NewProviderConfig().Kubernetes
+	conf.QPS = 100
+	conf.Burst = 100
+	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), conf)
+	assert.NilError(t, err)
+
+	t.Run("deployment is scaled from 0 replicas", func(t *testing.T) {
+		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{})
+		assert.NilError(t, err)
+
+		err = WaitForDeploymentReady(ctx, kind.client, d.Namespace, d.Name)
+		assert.NilError(t, err)
+
+		s, err := p.Client.AppsV1().Deployments(d.Namespace).GetScale(ctx, d.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		s.Spec.Replicas = 0
+		_, err = p.Client.AppsV1().Deployments(d.Namespace).UpdateScale(ctx, d.Name, s, metav1.UpdateOptions{})
+		assert.NilError(t, err)
+		err = WaitForDeploymentScale(ctx, kind.client, d.Namespace, d.Name, 0)
+		assert.NilError(t, err)
+
+		s, err = p.Client.AppsV1().Deployments(d.Namespace).GetScale(ctx, d.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+		})
+
+		s.Spec.Replicas = 1
+		_, err = p.Client.AppsV1().Deployments(d.Namespace).UpdateScale(ctx, d.Name, s, metav1.UpdateOptions{})
+		assert.NilError(t, err)
+
+		select {
+		case info := <-stream.Events:
+			assert.Equal(t, info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Provider, "kubernetes")
+			assert.Assert(t, info.Kubernetes != nil)
+		case err := <-stream.Err:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("statefulSet is scaled from 0 replicas", func(t *testing.T) {
+		ss, err := kind.CreateMimicStatefulSet(ctx, MimicOptions{})
+		assert.NilError(t, err)
+
+		err = WaitForStatefulSetReady(ctx, kind.client, ss.Namespace, ss.Name)
+		assert.NilError(t, err)
+
+		s, err := p.Client.AppsV1().StatefulSets(ss.Namespace).GetScale(ctx, ss.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		s.Spec.Replicas = 0
+		_, err = p.Client.AppsV1().StatefulSets(ss.Namespace).UpdateScale(ctx, ss.Name, s, metav1.UpdateOptions{})
+		assert.NilError(t, err)
+		err = WaitForStatefulSetScale(ctx, kind.client, ss.Namespace, ss.Name, 0)
+		assert.NilError(t, err)
+
+		s, err = p.Client.AppsV1().StatefulSets(ss.Namespace).GetScale(ctx, ss.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+		})
+
+		s.Spec.Replicas = 1
+		_, err = p.Client.AppsV1().StatefulSets(ss.Namespace).UpdateScale(ctx, ss.Name, s, metav1.UpdateOptions{})
+		assert.NilError(t, err)
+
+		select {
+		case info := <-stream.Events:
+			assert.Equal(t, info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Provider, "kubernetes")
+			assert.Assert(t, info.Kubernetes != nil)
+		case err := <-stream.Err:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/pkg/provider/kubernetes/instance_events_test.go
+++ b/pkg/provider/kubernetes/instance_events_test.go
@@ -133,30 +133,33 @@ func TestKubernetesProvider_InstanceEvents_Started(t *testing.T) {
 	assert.NilError(t, err)
 
 	t.Run("deployment is scaled from 0 replicas", func(t *testing.T) {
-		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{})
+		testCtx, testCancel := context.WithTimeout(ctx, 20*time.Second)
+		defer testCancel()
+
+		d, err := kind.CreateMimicDeployment(testCtx, MimicOptions{})
 		assert.NilError(t, err)
 
-		err = WaitForDeploymentReady(ctx, kind.client, d.Namespace, d.Name)
+		err = WaitForDeploymentReady(testCtx, kind.client, d.Namespace, d.Name)
 		assert.NilError(t, err)
 
-		s, err := p.Client.AppsV1().Deployments(d.Namespace).GetScale(ctx, d.Name, metav1.GetOptions{})
-		assert.NilError(t, err)
-
-		s.Spec.Replicas = 0
-		_, err = p.Client.AppsV1().Deployments(d.Namespace).UpdateScale(ctx, d.Name, s, metav1.UpdateOptions{})
-		assert.NilError(t, err)
-		err = WaitForDeploymentScale(ctx, kind.client, d.Namespace, d.Name, 0)
-		assert.NilError(t, err)
-
-		s, err = p.Client.AppsV1().Deployments(d.Namespace).GetScale(ctx, d.Name, metav1.GetOptions{})
-		assert.NilError(t, err)
-
-		stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		stream := p.InstanceEvents(testCtx, provider.InstanceEventsOptions{
 			Types: []provider.InstanceEventType{provider.InstanceEventStarted},
 		})
 
+		s, err := p.Client.AppsV1().Deployments(d.Namespace).GetScale(testCtx, d.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		s.Spec.Replicas = 0
+		_, err = p.Client.AppsV1().Deployments(d.Namespace).UpdateScale(testCtx, d.Name, s, metav1.UpdateOptions{})
+		assert.NilError(t, err)
+		err = WaitForDeploymentScale(testCtx, kind.client, d.Namespace, d.Name, 0)
+		assert.NilError(t, err)
+
+		s, err = p.Client.AppsV1().Deployments(d.Namespace).GetScale(testCtx, d.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
 		s.Spec.Replicas = 1
-		_, err = p.Client.AppsV1().Deployments(d.Namespace).UpdateScale(ctx, d.Name, s, metav1.UpdateOptions{})
+		_, err = p.Client.AppsV1().Deployments(d.Namespace).UpdateScale(testCtx, d.Name, s, metav1.UpdateOptions{})
 		assert.NilError(t, err)
 
 		select {
@@ -166,34 +169,39 @@ func TestKubernetesProvider_InstanceEvents_Started(t *testing.T) {
 			assert.Assert(t, info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
+		case <-testCtx.Done():
+			t.Fatalf("timed out waiting for deployment started event: %v", testCtx.Err())
 		}
 	})
 
 	t.Run("statefulSet is scaled from 0 replicas", func(t *testing.T) {
-		ss, err := kind.CreateMimicStatefulSet(ctx, MimicOptions{})
+		testCtx, testCancel := context.WithTimeout(ctx, 20*time.Second)
+		defer testCancel()
+
+		ss, err := kind.CreateMimicStatefulSet(testCtx, MimicOptions{})
 		assert.NilError(t, err)
 
-		err = WaitForStatefulSetReady(ctx, kind.client, ss.Namespace, ss.Name)
+		err = WaitForStatefulSetReady(testCtx, kind.client, ss.Namespace, ss.Name)
 		assert.NilError(t, err)
 
-		s, err := p.Client.AppsV1().StatefulSets(ss.Namespace).GetScale(ctx, ss.Name, metav1.GetOptions{})
-		assert.NilError(t, err)
-
-		s.Spec.Replicas = 0
-		_, err = p.Client.AppsV1().StatefulSets(ss.Namespace).UpdateScale(ctx, ss.Name, s, metav1.UpdateOptions{})
-		assert.NilError(t, err)
-		err = WaitForStatefulSetScale(ctx, kind.client, ss.Namespace, ss.Name, 0)
-		assert.NilError(t, err)
-
-		s, err = p.Client.AppsV1().StatefulSets(ss.Namespace).GetScale(ctx, ss.Name, metav1.GetOptions{})
-		assert.NilError(t, err)
-
-		stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		stream := p.InstanceEvents(testCtx, provider.InstanceEventsOptions{
 			Types: []provider.InstanceEventType{provider.InstanceEventStarted},
 		})
 
+		s, err := p.Client.AppsV1().StatefulSets(ss.Namespace).GetScale(testCtx, ss.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		s.Spec.Replicas = 0
+		_, err = p.Client.AppsV1().StatefulSets(ss.Namespace).UpdateScale(testCtx, ss.Name, s, metav1.UpdateOptions{})
+		assert.NilError(t, err)
+		err = WaitForStatefulSetScale(testCtx, kind.client, ss.Namespace, ss.Name, 0)
+		assert.NilError(t, err)
+
+		s, err = p.Client.AppsV1().StatefulSets(ss.Namespace).GetScale(testCtx, ss.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
 		s.Spec.Replicas = 1
-		_, err = p.Client.AppsV1().StatefulSets(ss.Namespace).UpdateScale(ctx, ss.Name, s, metav1.UpdateOptions{})
+		_, err = p.Client.AppsV1().StatefulSets(ss.Namespace).UpdateScale(testCtx, ss.Name, s, metav1.UpdateOptions{})
 		assert.NilError(t, err)
 
 		select {
@@ -203,6 +211,8 @@ func TestKubernetesProvider_InstanceEvents_Started(t *testing.T) {
 			assert.Assert(t, info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
+		case <-testCtx.Done():
+			t.Fatalf("timed out waiting for statefulset started event: %v", testCtx.Err())
 		}
 	})
 }

--- a/pkg/provider/kubernetes/statefulset_events.go
+++ b/pkg/provider/kubernetes/statefulset_events.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
-func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablier.InstanceInfo) cache.SharedIndexInformer {
+func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablier.InstanceInfo, wantStopped, wantStarted bool) cache.SharedIndexInformer {
 	handler := cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(old, new interface{}) {
 			newStatefulSet := new.(*appsv1.StatefulSet)
@@ -22,17 +22,26 @@ func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablie
 				return
 			}
 
-			if *oldStatefulSet.Spec.Replicas == 0 {
-				return
-			}
+			oldReplicas := *oldStatefulSet.Spec.Replicas
+			newReplicas := *newStatefulSet.Spec.Replicas
 
-			if *newStatefulSet.Spec.Replicas == 0 {
+			if wantStopped && oldReplicas != 0 && newReplicas == 0 {
 				parsed := StatefulSetName(newStatefulSet, ParseOptions{Delimiter: p.delimiter})
 				// StatefulSet still exists (scaled to 0); inspect for full info.
 				info, err := p.InstanceInspect(ctx, parsed.Original)
 				if err != nil {
 					p.l.WarnContext(ctx, "inspect after scale-to-0 event failed, using bare info", "statefulset", parsed.Original, "error", err)
 					instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderKubernetes}
+					return
+				}
+				instance <- info
+			}
+			if wantStarted && oldReplicas == 0 && newReplicas != 0 {
+				parsed := StatefulSetName(newStatefulSet, ParseOptions{Delimiter: p.delimiter})
+				info, err := p.InstanceInspect(ctx, parsed.Original)
+				if err != nil {
+					p.l.WarnContext(ctx, "inspect after scale-from-0 event failed, using bare info", "statefulset", parsed.Original, "error", err)
+					instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderKubernetes}
 					return
 				}
 				instance <- info

--- a/pkg/provider/podman/events_test.go
+++ b/pkg/provider/podman/events_test.go
@@ -51,3 +51,38 @@ func TestPodmanProvider_InstanceEvents(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestPodmanProvider_InstanceEvents_Started(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	pind := sharedPinD
+	p, err := podman.New(ctx, pind.client, slogt.New(t))
+	assert.NilError(t, err)
+
+	c, err := pind.CreateMimic(ctx, MimicOptions{})
+	assert.NilError(t, err)
+
+	inspected, err := pind.client.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+
+	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	})
+
+	_, err = pind.client.ContainerStart(ctx, c.ID, client.ContainerStartOptions{})
+	assert.NilError(t, err)
+
+	err = WaitForContainerRunning(ctx, pind.client, c.ID)
+	assert.NilError(t, err)
+
+	select {
+	case info := <-stream.Events:
+		assert.Equal(t, info.Name, strings.TrimPrefix(inspected.Container.Name, "/"))
+	case err := <-stream.Err:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/provider/proxmoxlxc/events.go
+++ b/pkg/provider/proxmoxlxc/events.go
@@ -15,19 +15,20 @@ import (
 const maxConsecutivePollErrors = 5
 
 // InstanceEvents polls Proxmox for status changes and emits events when
-// instances transition from running to stopped. Proxmox VE does not provide
-// a real-time event stream, so polling is used.
+// instances transition from running to stopped (or vice versa). Proxmox VE
+// does not provide a real-time event stream, so polling is used.
 func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEventsOptions) sablier.InstanceEventStream {
 	eventsC := make(chan sablier.InstanceInfo)
 	errC := make(chan error, 1)
 
 	wantStopped := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStopped)
+	wantStarted := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStarted)
 
 	go func() {
 		defer close(eventsC)
 		defer close(errC)
 
-		if !wantStopped {
+		if !wantStopped && !wantStarted {
 			<-ctx.Done()
 			return
 		}
@@ -82,18 +83,39 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 				}
 
 				// Detect containers that were running but are no longer
-				for name := range running {
-					if !currentRunning[name] {
-						p.l.DebugContext(ctx, "container stopped detected", slog.String("name", name))
-						select {
-						case eventsC <- sablier.InstanceInfo{
-							Name:            name,
-							CurrentReplicas: 0,
-							DesiredReplicas: p.desiredReplicas,
-							Status:          sablier.InstanceStatusStopped,
-						}:
-						case <-ctx.Done():
-							return
+				if wantStopped {
+					for name := range running {
+						if !currentRunning[name] {
+							p.l.DebugContext(ctx, "container stopped detected", slog.String("name", name))
+							select {
+							case eventsC <- sablier.InstanceInfo{
+								Name:            name,
+								CurrentReplicas: 0,
+								DesiredReplicas: p.desiredReplicas,
+								Status:          sablier.InstanceStatusStopped,
+							}:
+							case <-ctx.Done():
+								return
+							}
+						}
+					}
+				}
+
+				// Detect containers that were not running but are now
+				if wantStarted {
+					for name := range currentRunning {
+						if !running[name] {
+							p.l.DebugContext(ctx, "container started detected", slog.String("name", name))
+							select {
+							case eventsC <- sablier.InstanceInfo{
+								Name:            name,
+								CurrentReplicas: p.desiredReplicas,
+								DesiredReplicas: p.desiredReplicas,
+								Status:          sablier.InstanceStatusStarting,
+							}:
+							case <-ctx.Done():
+								return
+							}
 						}
 					}
 				}

--- a/pkg/provider/proxmoxlxc/events_test.go
+++ b/pkg/provider/proxmoxlxc/events_test.go
@@ -47,3 +47,74 @@ func TestProxmoxLXCProvider_InstanceEvents_ContextCancel(t *testing.T) {
 		}
 	}
 }
+
+func TestProxmoxLXCProvider_InstanceEvents_Started_ContextCancel(t *testing.T) {
+	t.Parallel()
+
+	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
+		{VMID: 100, Name: "web", Status: "running", Tags: "sablier", Node: "pve1"},
+	})
+	defer server.Close()
+
+	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
+	assert.NilError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	})
+
+	// Cancel context and verify both channels are closed
+	cancel()
+
+	deadline := time.After(3 * time.Second)
+	eventsClosed, errClosed := false, false
+	for !eventsClosed || !errClosed {
+		select {
+		case _, ok := <-stream.Events:
+			if !ok {
+				eventsClosed = true
+			}
+		case _, ok := <-stream.Err:
+			if !ok {
+				errClosed = true
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for stream channels to close")
+		}
+	}
+}
+
+func TestProxmoxLXCProvider_InstanceEvents_AllTypes_ContextCancel(t *testing.T) {
+	t.Parallel()
+
+	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
+		{VMID: 100, Name: "web", Status: "running", Tags: "sablier", Node: "pve1"},
+	})
+	defer server.Close()
+
+	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
+	assert.NilError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{})
+
+	cancel()
+
+	deadline := time.After(3 * time.Second)
+	eventsClosed, errClosed := false, false
+	for !eventsClosed || !errClosed {
+		select {
+		case _, ok := <-stream.Events:
+			if !ok {
+				eventsClosed = true
+			}
+		case _, ok := <-stream.Err:
+			if !ok {
+				errClosed = true
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for stream channels to close")
+		}
+	}
+}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -10,6 +10,8 @@ type InstanceEventType string
 const (
 	// InstanceEventStopped fires when an instance transitions to stopped / scaled-to-zero.
 	InstanceEventStopped InstanceEventType = "stopped"
+	// InstanceEventStarted fires when an instance transitions to started / running / scaled-from-zero.
+	InstanceEventStarted InstanceEventType = "started"
 )
 
 // InstanceEventsOptions controls which events InstanceEvents streams.

--- a/pkg/sablier/autostop.go
+++ b/pkg/sablier/autostop.go
@@ -3,10 +3,12 @@ package sablier
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"time"
+
 	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/store"
 	"golang.org/x/sync/errgroup"
-	"log/slog"
 )
 
 // StopAllUnregisteredInstances stops all auto-discovered running instances that are not yet registered
@@ -50,5 +52,79 @@ func (s *Sablier) stopFunc(ctx context.Context, name string) func() error {
 		s.metrics.RecordInstanceStop(name, "unregistered")
 		s.l.InfoContext(ctx, "stopped unregistered instance", slog.String("instance", name), slog.String("reason", "instance is enabled but not started by Sablier"))
 		return nil
+	}
+}
+
+// isStartedByUs returns true if the instance was initiated by Sablier:
+// either it has an in-progress start goroutine (pendingStarts) or it is
+// already registered in the sessions store.
+// Both checks are needed to cover all timing windows between when Sablier
+// triggers a start and when the session entry is written.
+func (s *Sablier) isStartedByUs(ctx context.Context, name string) bool {
+	s.pendingMu.Lock()
+	_, pending := s.pendingStarts[name]
+	s.pendingMu.Unlock()
+	if pending {
+		return true
+	}
+	_, err := s.sessions.Get(ctx, name)
+	return err == nil
+}
+
+// WatchAndStopExternallyStarted continuously stops instances that have
+// sablier.enable=true but were not started by Sablier. It combines
+// event-driven detection (InstanceEventStarted) with a periodic
+// reconciliation ticker as a safety net.
+//
+// This is the continuous counterpart to StopAllUnregisteredInstances, which
+// only runs once at startup. Call it in a dedicated goroutine.
+func (s *Sablier) WatchAndStopExternallyStarted(ctx context.Context) {
+	stream := s.provider.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	})
+	eventsC := stream.Events
+	errC := stream.Err
+
+	ticker := time.NewTicker(s.ExternallyStartedScanInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.l.InfoContext(ctx, "stop watching for unregistered instances", slog.Any("reason", ctx.Err()))
+			return
+		case info, ok := <-eventsC:
+			if !ok {
+				s.l.WarnContext(ctx, "started event stream closed; relying on reconciliation ticker")
+				eventsC = nil // disable this select case
+				continue
+			}
+			// Only act on Sablier-managed instances.
+			if info.Enabled != "true" {
+				continue
+			}
+			if s.isStartedByUs(ctx, info.Name) {
+				s.l.DebugContext(ctx, "instance started by Sablier, skipping", slog.String("instance", info.Name))
+				continue
+			}
+			s.l.InfoContext(ctx, "externally started instance detected, stopping", slog.String("instance", info.Name))
+			if err := s.provider.InstanceStop(ctx, info.Name); err != nil {
+				s.l.ErrorContext(ctx, "failed to stop externally-started instance", slog.String("instance", info.Name), slog.Any("error", err))
+			} else {
+				s.metrics.RecordInstanceStop(info.Name, "externally-started")
+			}
+		case err, ok := <-errC:
+			if !ok {
+				errC = nil // disable this select case
+				continue
+			}
+			s.l.ErrorContext(ctx, "started event stream permanently lost; relying on reconciliation ticker", slog.Any("error", err))
+			errC = nil
+			eventsC = nil
+		case <-ticker.C:
+			if err := s.StopAllUnregisteredInstances(ctx); err != nil {
+				s.l.ErrorContext(ctx, "unregistered instance scan failed", slog.Any("error", err))
+			}
+		}
 	}
 }

--- a/pkg/sablier/autostop_test.go
+++ b/pkg/sablier/autostop_test.go
@@ -1,12 +1,16 @@
 package sablier_test
 
 import (
+	"context"
 	"errors"
+	"testing"
+	"time"
+
 	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/sablier"
 	"github.com/sablierapp/sablier/pkg/store"
+	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
-	"testing"
 )
 
 func TestStopAllUnregisteredInstances(t *testing.T) {
@@ -66,4 +70,185 @@ func TestStopAllUnregisteredInstances_WithError(t *testing.T) {
 	// Call the function under test
 	err := s.StopAllUnregisteredInstances(ctx)
 	assert.Error(t, err, "stop error")
+}
+
+// --- WatchAndStopExternallyStarted tests ---
+
+// TestWatchAndStopExternallyStarted_StopsExternalInstance verifies that when a
+// "started" event arrives for a Sablier-managed instance that is NOT in the
+// sessions store (i.e. externally started), the instance is stopped.
+func TestWatchAndStopExternallyStarted_StopsExternalInstance(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 24 * time.Hour // prevent ticker from firing
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceInfo, 1)
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	// Instance is not in the sessions store
+	sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+
+	stopped := make(chan struct{})
+	p.EXPECT().InstanceStop(gomock.Any(), "nginx").DoAndReturn(func(_ context.Context, _ string) error {
+		close(stopped)
+		return nil
+	})
+
+	// Send the event before starting the goroutine so the channel is pre-filled.
+	eventsC <- sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}
+
+	go s.WatchAndStopExternallyStarted(ctx)
+
+	select {
+	case <-stopped:
+		// success
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for externally-started instance to be stopped")
+	}
+}
+
+// TestWatchAndStopExternallyStarted_SkipsSablierStartedInstance_InStore verifies
+// that a "started" event for an instance already in the sessions store is
+// not stopped (Sablier started it).
+func TestWatchAndStopExternallyStarted_SkipsSablierStartedInstance_InStore(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceInfo, 1)
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	// Instance IS in the sessions store → started by Sablier
+	sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
+		Name:   "nginx",
+		Status: sablier.InstanceStatusReady,
+	}, nil)
+
+	// InstanceStop must NOT be called; gomock will fail the test if it is.
+	eventsC <- sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}
+
+	go s.WatchAndStopExternallyStarted(ctx)
+
+	// Give the goroutine time to process the event then verify no stop happened.
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestWatchAndStopExternallyStarted_SkipsNonSablierInstance verifies that a
+// "started" event for an instance without sablier.enable=true is ignored.
+func TestWatchAndStopExternallyStarted_SkipsNonSablierInstance(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceInfo, 1)
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	// No sessions.Get or InstanceStop expected.
+	eventsC <- sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "false"}
+
+	go s.WatchAndStopExternallyStarted(ctx)
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestWatchAndStopExternallyStarted_ReconciliationTicker verifies that even without
+// incoming events, the periodic ticker triggers a reconciliation scan.
+func TestWatchAndStopExternallyStarted_ReconciliationTicker(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 20 * time.Millisecond // fire quickly
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceInfo) // no events sent
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	instances := []sablier.InstanceConfiguration{{Name: "external"}}
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: false}).
+		Return(instances, nil).AnyTimes()
+	sessions.EXPECT().Get(gomock.Any(), "external").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
+
+	stopped := make(chan struct{}, 1)
+	p.EXPECT().InstanceStop(gomock.Any(), "external").DoAndReturn(func(_ context.Context, _ string) error {
+		select {
+		case stopped <- struct{}{}:
+		default:
+		}
+		return nil
+	}).AnyTimes()
+
+	go s.WatchAndStopExternallyStarted(ctx)
+
+	select {
+	case <-stopped:
+		// success: reconciliation ticker fired and stopped the external instance
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconciliation ticker to stop external instance")
+	}
+}
+
+// TestWatchAndStopExternallyStarted_EventStreamClosed verifies that when the
+// started event stream closes, the function falls back to ticker-only mode
+// and continues reconciliation.
+func TestWatchAndStopExternallyStarted_EventStreamClosed(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 20 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceInfo)
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	// Close the events channel immediately to simulate stream closure.
+	close(eventsC)
+
+	instances := []sablier.InstanceConfiguration{{Name: "external"}}
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: false}).
+		Return(instances, nil).AnyTimes()
+	sessions.EXPECT().Get(gomock.Any(), "external").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
+
+	stopped := make(chan struct{}, 1)
+	p.EXPECT().InstanceStop(gomock.Any(), "external").DoAndReturn(func(_ context.Context, _ string) error {
+		select {
+		case stopped <- struct{}{}:
+		default:
+		}
+		return nil
+	}).AnyTimes()
+
+	go s.WatchAndStopExternallyStarted(ctx)
+
+	select {
+	case <-stopped:
+		// success: reconciliation ticker still fires despite stream closure
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconciliation after stream closure")
+	}
 }

--- a/pkg/sablier/errors_test.go
+++ b/pkg/sablier/errors_test.go
@@ -1,0 +1,25 @@
+package sablier_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"gotest.tools/v3/assert"
+)
+
+func TestErrGroupNotFound_Error(t *testing.T) {
+	err := sablier.ErrGroupNotFound{Group: "missing"}
+	assert.Equal(t, err.Error(), "group missing not found")
+}
+
+func TestErrRequestBinding_Error(t *testing.T) {
+	err := sablier.ErrRequestBinding{Err: errors.New("invalid payload")}
+	assert.Equal(t, err.Error(), "invalid payload")
+}
+
+func TestErrTimeout_Error(t *testing.T) {
+	err := sablier.ErrTimeout{Duration: 3 * time.Second}
+	assert.Equal(t, err.Error(), "timeout after 3s")
+}

--- a/pkg/sablier/group_watch_test.go
+++ b/pkg/sablier/group_watch_test.go
@@ -1,4 +1,3 @@
-package sablier
 package sablier_test
 
 import (

--- a/pkg/sablier/group_watch_test.go
+++ b/pkg/sablier/group_watch_test.go
@@ -1,0 +1,86 @@
+package sablier
+package sablier_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+)
+
+func TestGroupWatch_ContextDone(t *testing.T) {
+	s, _, _ := setupSablier(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		s.GroupWatch(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("group watch did not stop on context cancellation")
+	}
+}
+
+func TestGroupWatch_UpdatesGroupsOnTick(t *testing.T) {
+	s, _, p := setupSablier(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	called := make(chan struct{}, 1)
+	p.EXPECT().InstanceGroups(gomock.Any()).DoAndReturn(func(context.Context) (map[string][]string, error) {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+		return map[string][]string{"g": {"a", "b"}}, nil
+	}).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	select {
+	case <-called:
+		cancel()
+	case <-time.After(3 * time.Second):
+		t.Fatal("group watch did not poll provider")
+	}
+
+	assert.DeepEqual(t, s.Groups(), map[string][]string{"g": {"a", "b"}})
+}
+
+func TestGroupWatch_ProviderErrorDoesNotUpdateGroups(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.SetGroups(map[string][]string{"existing": {"x"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	called := make(chan struct{}, 1)
+	p.EXPECT().InstanceGroups(gomock.Any()).DoAndReturn(func(context.Context) (map[string][]string, error) {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+		return nil, errors.New("provider down")
+	}).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	select {
+	case <-called:
+		cancel()
+	case <-time.After(3 * time.Second):
+		t.Fatal("group watch did not poll provider")
+	}
+
+	assert.DeepEqual(t, s.Groups(), map[string][]string{"existing": {"x"}})
+}

--- a/pkg/sablier/instance_expired_test.go
+++ b/pkg/sablier/instance_expired_test.go
@@ -1,0 +1,74 @@
+package sablier_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/neilotoole/slogt"
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+)
+
+func TestOnInstanceExpired_StopsAndRecordsMetrics(t *testing.T) {
+	_, _, p, rec := setupSablierWithMetrics(t)
+	ctx := t.Context()
+
+	stopped := make(chan struct{}, 1)
+	p.EXPECT().InstanceStop(gomock.Any(), "i1").DoAndReturn(func(_ any, _ string) error {
+		stopped <- struct{}{}
+		return nil
+	})
+
+	cb := sablier.OnInstanceExpired(ctx, p, rec, slogt.New(t))
+	cb("i1")
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("instance stop was not invoked")
+	}
+
+	// Let recorder calls complete in the callback goroutine.
+	time.Sleep(20 * time.Millisecond)
+	calls := rec.snapshot()
+	assert.Assert(t, containsCall(calls, "stop:i1/expired"))
+	assert.Assert(t, containsCall(calls, "active-:i1"))
+	assert.Assert(t, containsCall(calls, "ready_discard:i1"))
+}
+
+func TestOnInstanceExpired_ProviderStopErrorStillRecordsMetrics(t *testing.T) {
+	_, _, p, rec := setupSablierWithMetrics(t)
+	ctx := t.Context()
+
+	stopped := make(chan struct{}, 1)
+	p.EXPECT().InstanceStop(gomock.Any(), "i2").DoAndReturn(func(_ any, _ string) error {
+		stopped <- struct{}{}
+		return errors.New("cannot stop")
+	})
+
+	cb := sablier.OnInstanceExpired(ctx, p, rec, slogt.New(t))
+	cb("i2")
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("instance stop was not invoked")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	calls := rec.snapshot()
+	assert.Assert(t, containsCall(calls, "stop:i2/expired"))
+	assert.Assert(t, containsCall(calls, "active-:i2"))
+	assert.Assert(t, containsCall(calls, "ready_discard:i2"))
+}
+
+func containsCall(calls []string, want string) bool {
+	for _, c := range calls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -28,6 +28,10 @@ type Sablier struct {
 	// call before it is cancelled. Defaults to 5 minutes.
 	InstanceStartTimeout time.Duration
 
+	// ExternallyStartedScanInterval is how often WatchAndStopExternallyStarted performs a
+	// full reconciliation scan. Defaults to 30 seconds.
+	ExternallyStartedScanInterval time.Duration
+
 	metrics metrics.Recorder
 
 	l *slog.Logger
@@ -35,15 +39,16 @@ type Sablier struct {
 
 func New(logger *slog.Logger, store Store, provider Provider) *Sablier {
 	return &Sablier{
-		provider:                 provider,
-		sessions:                 store,
-		groupsMu:                 sync.RWMutex{},
-		groups:                   map[string][]string{},
-		pendingStarts:            map[string]*pendingStart{},
-		l:                        logger,
-		metrics:                  metrics.Noop{},
-		BlockingRefreshFrequency: 5 * time.Second,
-		InstanceStartTimeout:     5 * time.Minute,
+		provider:                      provider,
+		sessions:                      store,
+		groupsMu:                      sync.RWMutex{},
+		groups:                        map[string][]string{},
+		pendingStarts:                 map[string]*pendingStart{},
+		l:                             logger,
+		metrics:                       metrics.Noop{},
+		BlockingRefreshFrequency:      5 * time.Second,
+		InstanceStartTimeout:          5 * time.Minute,
+		ExternallyStartedScanInterval: 30 * time.Second,
 	}
 }
 

--- a/pkg/sablier/session_test.go
+++ b/pkg/sablier/session_test.go
@@ -1,0 +1,97 @@
+package sablier_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"gotest.tools/v3/assert"
+)
+
+func TestSessionState_IsReady_NilInstances(t *testing.T) {
+	s := &sablier.SessionState{}
+	assert.Assert(t, s.IsReady())
+	assert.Assert(t, s.Instances != nil)
+}
+
+func TestSessionState_IsReady_FalseWhenInstanceHasError(t *testing.T) {
+	s := &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"a": {
+				Instance: sablier.InstanceInfo{Status: sablier.InstanceStatusReady},
+				Error:    errors.New("boom"),
+			},
+		},
+	}
+	assert.Assert(t, !s.IsReady())
+}
+
+func TestSessionState_IsReady_FalseWhenInstanceNotReady(t *testing.T) {
+	s := &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"a": {
+				Instance: sablier.InstanceInfo{Status: sablier.InstanceStatusStarting},
+			},
+		},
+	}
+	assert.Assert(t, !s.IsReady())
+}
+
+func TestSessionState_InstanceErrors(t *testing.T) {
+	s := &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"a": {
+				Instance: sablier.InstanceInfo{Status: sablier.InstanceStatusReady},
+				Error:    errors.New("first"),
+			},
+			"b": {
+				Instance: sablier.InstanceInfo{Status: sablier.InstanceStatusReady},
+				Error:    errors.New("second"),
+			},
+		},
+	}
+
+	err := s.InstanceErrors()
+	assert.Assert(t, err != nil)
+	assert.Assert(t, contains(err.Error(), "a: first") || contains(err.Error(), "b: second"))
+}
+
+func TestSessionState_Status(t *testing.T) {
+	ready := &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"a": {Instance: sablier.InstanceInfo{Status: sablier.InstanceStatusReady}},
+		},
+	}
+	notReady := &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"a": {Instance: sablier.InstanceInfo{Status: sablier.InstanceStatusStarting}},
+		},
+	}
+
+	assert.Equal(t, ready.Status(), "ready")
+	assert.Equal(t, notReady.Status(), "not-ready")
+}
+
+func TestSessionState_MarshalJSON(t *testing.T) {
+	s := &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"a": {Instance: sablier.InstanceInfo{Name: "a", Status: sablier.InstanceStatusReady}},
+		},
+	}
+
+	_, err := s.MarshalJSON()
+	assert.Assert(t, err != nil)
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && (indexOf(s, sub) >= 0))
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/sabliercmd/root.go
+++ b/pkg/sabliercmd/root.go
@@ -42,6 +42,8 @@ It provides integrations with multiple reverse proxies and different loading str
 	_ = viper.BindPFlag("provider.name", startCmd.Flags().Lookup("provider.name"))
 	startCmd.Flags().BoolVar(&conf.Provider.AutoStopOnStartup, "provider.auto-stop-on-startup", true, "")
 	_ = viper.BindPFlag("provider.auto-stop-on-startup", startCmd.Flags().Lookup("provider.auto-stop-on-startup"))
+	startCmd.Flags().BoolVar(&conf.Provider.AutoStopExternallyStarted, "provider.auto-stop-externally-started", false, "Continuously stop instances with sablier.enable=true that are running but were not started by Sablier")
+	_ = viper.BindPFlag("provider.auto-stop-externally-started", startCmd.Flags().Lookup("provider.auto-stop-externally-started"))
 	startCmd.Flags().Float32Var(&conf.Provider.Kubernetes.QPS, "provider.kubernetes.qps", 5, "QPS limit for K8S API access client-side throttling")
 	_ = viper.BindPFlag("provider.kubernetes.qps", startCmd.Flags().Lookup("provider.kubernetes.qps"))
 	startCmd.Flags().IntVar(&conf.Provider.Kubernetes.Burst, "provider.kubernetes.burst", 10, "Maximum burst for K8S API acees client-side throttling")

--- a/pkg/sabliercmd/start.go
+++ b/pkg/sabliercmd/start.go
@@ -103,6 +103,10 @@ func Start(ctx context.Context, conf config.Config) error {
 		}
 	}
 
+	if conf.Provider.AutoStopExternallyStarted {
+		go s.WatchAndStopExternallyStarted(ctx)
+	}
+
 	t, err := setupTheme(ctx, conf, logger)
 	if err != nil {
 		return fmt.Errorf("cannot setup theme: %w", err)

--- a/pkg/sabliercmd/testdata/config_cli_wanted.json
+++ b/pkg/sabliercmd/testdata/config_cli_wanted.json
@@ -12,6 +12,7 @@
   "Provider": {
     "Name": "cli",
     "AutoStopOnStartup": false,
+    "AutoStopExternallyStarted": false,
     "Kubernetes": {
       "QPS": 256,
       "Burst": 512,

--- a/pkg/sabliercmd/testdata/config_default.json
+++ b/pkg/sabliercmd/testdata/config_default.json
@@ -12,6 +12,7 @@
   "Provider": {
     "Name": "docker",
     "AutoStopOnStartup": true,
+    "AutoStopExternallyStarted": false,
     "Kubernetes": {
       "QPS": 5,
       "Burst": 10,

--- a/pkg/sabliercmd/testdata/config_env_wanted.json
+++ b/pkg/sabliercmd/testdata/config_env_wanted.json
@@ -12,6 +12,7 @@
   "Provider": {
     "Name": "envvar",
     "AutoStopOnStartup": false,
+    "AutoStopExternallyStarted": false,
     "Kubernetes": {
       "QPS": 16,
       "Burst": 32,

--- a/pkg/sabliercmd/testdata/config_yaml_wanted.json
+++ b/pkg/sabliercmd/testdata/config_yaml_wanted.json
@@ -12,6 +12,7 @@
   "Provider": {
     "Name": "configfile",
     "AutoStopOnStartup": false,
+    "AutoStopExternallyStarted": false,
     "Kubernetes": {
       "QPS": 64,
       "Burst": 128,


### PR DESCRIPTION
You can now enable Sablier to automatically shutdown instances that are tracked by Sablier with the sablier.enable label if they are started externally (i.e. not by Sablier)

Closes #713 
Closes #842

Note for self: This could have been split into more smaller PRs:
- Add new event types
- Increase overall code coverage
- Add the flag