### PR TITLE
feat: add running-hours keep-warm windows and timezone support

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,6 +5,9 @@ ARG TARGETPLATFORM
 # Copy binary and config
 COPY --chmod=0755 $TARGETPLATFORM/sablier /bin/sablier
 
+# Default timezone can still be overridden at runtime with -e TZ=...
+ENV TZ=UTC
+
 EXPOSE 10000
 
 ENTRYPOINT [ "/bin/sablier" ]

--- a/cmd/sablier/cmd.go
+++ b/cmd/sablier/cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata"
 
 	"github.com/sablierapp/sablier/pkg/sabliercmd"
 )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ Instance labels are applied directly to your containers or workloads. They contr
 | `sablier.enable` | Yes | `"true"` | Opt the instance into Sablier management. Any value other than `"true"` is ignored. |
 | `sablier.group` | No | `"myapp"` | Assign the instance to a named group. Defaults to `"default"` when `sablier.enable=true` and no group is set. |
 | `sablier.ready-after` | No | `"30s"` | Minimum duration to wait after the instance first reports ready before Sablier considers it truly ready. Accepts any Go duration string (`"500ms"`, `"1m30s"`, …). Useful for services that are started or pass their health check before they can actually serve traffic. |
+| `sablier.running-hours` | No | `"09:00-18:00"` | Daily keep-warm window in local time (`HH:MM-HH:MM`). Sablier starts the instance at window start and keeps it running until window end. Overnight windows like `"22:00-06:00"` are supported. |
 
 ### `sablier.ready-after`
 
@@ -49,7 +50,39 @@ If the label is absent or set to an unparseable value, no extra wait is applied.
 
 !> The `sablier.ready-after` grace period counts from when the instance **first** becomes ready in a given session. It does not reset on subsequent requests.
 
+### `sablier.running-hours`
 
+Use `sablier.running-hours` when an instance must stay available during specific daily hours.
+
+Behavior:
+
+- At the beginning of the configured period, Sablier proactively starts the instance.
+- During the running-hours period, request-triggered sessions are extended to the period end so the instance is not stopped in the middle of the window.
+- After the period ends, normal session expiration resumes.
+
+```yaml
+services:
+  myapp:
+    image: myapp:latest
+    labels:
+      - "sablier.enable=true"
+      - "sablier.group=myapp"
+      - "sablier.running-hours=09:00-18:00"
+```
+
+Format rules:
+
+- Use 24-hour format `HH:MM-HH:MM`.
+- If start is later than end (for example `22:00-06:00`), the window spans midnight.
+- If the label cannot be parsed, Sablier ignores it.
+
+### Timezone (`TZ`)
+
+Running-hours are evaluated in the process local timezone.
+
+- In the official Docker image, the binary embeds timezone database data and supports `TZ` out of the box.
+- The container defaults to `TZ=UTC`.
+- Override timezone with environment variables, for example `-e TZ=Europe/Paris`.
 
 ## Configuration File
 

--- a/examples/running-hours/Makefile
+++ b/examples/running-hours/Makefile
@@ -1,0 +1,28 @@
+.DEFAULT_GOAL := help
+
+COMPOSE := docker compose
+
+.PHONY: help
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-18s %s\n", $$1, $$2}'
+
+.PHONY: up
+up: ## Start the stack and stop office-app for a cold start demo
+	$(COMPOSE) up -d
+	$(COMPOSE) stop office-app
+
+.PHONY: request
+request: ## Trigger a blocking request for office-app (starts if needed)
+	curl -sf "http://localhost:10000/api/strategies/blocking?group=office-app&session_duration=1m&timeout=1m" | jq .
+
+.PHONY: status
+status: ## Show service status
+	$(COMPOSE) ps -a
+
+.PHONY: logs
+logs: ## Follow Sablier logs
+	$(COMPOSE) logs -f sablier
+
+.PHONY: down
+down: ## Tear down the stack
+	$(COMPOSE) down

--- a/examples/running-hours/README.md
+++ b/examples/running-hours/README.md
@@ -1,0 +1,87 @@
+# `sablier.running-hours` Example
+
+This example demonstrates how `sablier.running-hours` keeps an instance warm
+within a daily time window.
+
+When the current time is inside the window:
+
+- Sablier proactively starts the instance during reconciliation.
+- Any request-triggered session is extended to the window end.
+
+When the current time is outside the window:
+
+- The instance behaves normally and can expire according to session settings.
+
+## Services
+
+| Service | Role |
+|---|---|
+| `sablier` | Manages Docker containers and exposes API on `:10000` |
+| `office-app` | Managed app with `sablier.running-hours` |
+
+## Labels on `office-app`
+
+```yaml
+labels:
+  - "sablier.enable=true"
+  - "sablier.group=office-app"
+  - "sablier.running-hours=09:00-18:00"
+```
+
+## Prerequisites
+
+- Docker with Compose plugin (`docker compose version`)
+- `curl` and `jq` for API walkthrough
+
+## Configure timezone and running-hours
+
+Running-hours are evaluated in Sablier process local time.
+
+This compose stack supports both values as environment variables:
+
+```bash
+export TZ=Europe/Paris
+export RUNNING_HOURS=09:00-18:00
+```
+
+You can keep defaults by leaving them unset (`TZ=UTC`, `RUNNING_HOURS=09:00-18:00`).
+
+## Walkthrough
+
+### 1. Start the stack
+
+```bash
+make up
+```
+
+### 2. Watch logs in another terminal
+
+```bash
+make logs
+```
+
+### 3. Trigger a blocking request
+
+```bash
+make request
+```
+
+If the current time is inside `RUNNING_HOURS`, logs should include a message like:
+
+```text
+running-hours window active, extending expiration
+```
+
+### 4. Check container status
+
+```bash
+make status
+```
+
+`office-app` should remain up while inside the running-hours window.
+
+### 5. Tear down
+
+```bash
+make down
+```

--- a/examples/running-hours/compose.yml
+++ b/examples/running-hours/compose.yml
@@ -1,0 +1,27 @@
+services:
+  sablier:
+    image: ${SABLIER_IMAGE:-sablierapp/sablier:latest}
+    command:
+      - start
+      - --provider.name=docker
+      - --logging.level=debug
+      - --sessions.default-duration=1m
+      - --sessions.expiration-interval=10s
+    environment:
+      # Running-hours are evaluated in this timezone.
+      - TZ=${TZ:-UTC}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "10000:10000"
+
+  # office-app is managed by Sablier and configured to stay warm during
+  # sablier.running-hours. Outside this window, normal session expiration applies.
+  office-app:
+    image: acouvreur/whoami:v1.10.2
+    labels:
+      - "sablier.enable=true"
+      - "sablier.group=office-app"
+      - "sablier.running-hours=${RUNNING_HOURS:-09:00-18:00}"
+    ports:
+      - "8080:80"

--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -45,6 +45,10 @@ type InstanceInfo struct {
 	// ReadyAt records when the instance first transitioned to InstanceStatusReady.
 	// It is set internally by Sablier and is never populated by a provider.
 	ReadyAt *time.Time `json:"readyAt,omitempty"`
+
+	// RunningHours is a daily keep-warm window in local time, parsed from
+	// the sablier.running-hours label (format: HH:MM-HH:MM).
+	RunningHours string `json:"runningHours,omitempty"`
 }
 
 type InstanceConfiguration struct {
@@ -80,6 +84,17 @@ func PopulateEnabledAndGroup(info *InstanceInfo, labels map[string]string) {
 			info.ReadyAfter = d
 		} else {
 			slog.Warn("invalid sablier.ready-after label value, ignoring",
+				slog.String("instance", info.Name),
+				slog.String("value", v),
+				slog.Any("error", err),
+			)
+		}
+	}
+	if v := labels["sablier.running-hours"]; v != "" {
+		if _, err := ParseRunningHours(v); err == nil {
+			info.RunningHours = v
+		} else {
+			slog.Warn("invalid sablier.running-hours label value, ignoring",
 				slog.String("instance", info.Name),
 				slog.String("value", v),
 				slog.Any("error", err),

--- a/pkg/sablier/instance_request.go
+++ b/pkg/sablier/instance_request.go
@@ -178,9 +178,20 @@ func (s *Sablier) InstanceRequest(ctx context.Context, name string, duration tim
 		}
 	}
 
-	s.l.DebugContext(ctx, "set expiration for instance", slog.String("instance", name), slog.Duration("expiration", duration))
+	effectiveDuration := duration
+	if state.RunningHours != "" {
+		remaining, inWindow, runningHoursErr := runningHoursRemaining(state.RunningHours, time.Now())
+		if runningHoursErr != nil {
+			s.l.WarnContext(ctx, "invalid running-hours value in state, ignoring", slog.String("instance", name), slog.String("value", state.RunningHours), slog.Any("error", runningHoursErr))
+		} else if inWindow && remaining > effectiveDuration {
+			effectiveDuration = remaining
+			s.l.DebugContext(ctx, "running-hours window active, extending expiration", slog.String("instance", name), slog.Duration("expiration", effectiveDuration), slog.Duration("window_remaining", remaining))
+		}
+	}
 
-	err = s.sessions.Put(ctx, state, duration)
+	s.l.DebugContext(ctx, "set expiration for instance", slog.String("instance", name), slog.Duration("expiration", effectiveDuration))
+
+	err = s.sessions.Put(ctx, state, effectiveDuration)
 	if err != nil {
 		s.l.ErrorContext(ctx, "could not put instance to store, will not expire", slog.Any("error", err), slog.String("instance", state.Name))
 		return InstanceInfo{}, fmt.Errorf("could not put instance to store: %w", err)

--- a/pkg/sablier/instance_request_running_hours_test.go
+++ b/pkg/sablier/instance_request_running_hours_test.go
@@ -1,0 +1,63 @@
+package sablier_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+)
+
+func TestInstanceRequest_ExtendsExpirationInsideRunningHours(t *testing.T) {
+	manager, sessions, _ := setupSablier(t)
+	ctx := t.Context()
+
+	now := time.Now()
+	start := now.Add(-time.Minute)
+	end := now.Add(3 * time.Minute)
+	spec := fmt.Sprintf("%02d:%02d-%02d:%02d", start.Hour(), start.Minute(), end.Hour(), end.Minute())
+
+	state := sablier.InstanceInfo{
+		Name:         "nginx",
+		Status:       sablier.InstanceStatusReady,
+		RunningHours: spec,
+	}
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(state, nil)
+	sessions.EXPECT().Put(ctx, state, gomock.Any()).DoAndReturn(func(_ context.Context, _ sablier.InstanceInfo, ttl time.Duration) error {
+		if ttl <= 10*time.Second {
+			t.Fatalf("expected ttl to be extended during running-hours, got %s", ttl)
+		}
+		return nil
+	})
+
+	info, err := manager.InstanceRequest(ctx, "nginx", 10*time.Second)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Name, "nginx")
+}
+
+func TestInstanceRequest_DoesNotExtendExpirationOutsideRunningHours(t *testing.T) {
+	manager, sessions, _ := setupSablier(t)
+	ctx := t.Context()
+
+	now := time.Now()
+	start := now.Add(-4 * time.Hour)
+	end := now.Add(-2 * time.Hour)
+	spec := fmt.Sprintf("%02d:%02d-%02d:%02d", start.Hour(), start.Minute(), end.Hour(), end.Minute())
+
+	state := sablier.InstanceInfo{
+		Name:         "nginx",
+		Status:       sablier.InstanceStatusReady,
+		RunningHours: spec,
+	}
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(state, nil)
+	sessions.EXPECT().Put(ctx, state, 20*time.Second).Return(nil)
+
+	info, err := manager.InstanceRequest(ctx, "nginx", 20*time.Second)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Name, "nginx")
+}

--- a/pkg/sablier/instance_test.go
+++ b/pkg/sablier/instance_test.go
@@ -62,6 +62,7 @@ func TestPopulateEnabledAndGroup_ReadyAfter(t *testing.T) {
 		labels    map[string]string
 		wantAfter time.Duration
 	}{
+
 		{
 			name:      "label absent",
 			labels:    map[string]string{"sablier.enable": "true"},
@@ -88,6 +89,38 @@ func TestPopulateEnabledAndGroup_ReadyAfter(t *testing.T) {
 			var info sablier.InstanceInfo
 			sablier.PopulateEnabledAndGroup(&info, tt.labels)
 			assert.Equal(t, info.ReadyAfter, tt.wantAfter)
+		})
+	}
+}
+
+func TestPopulateEnabledAndGroup_RunningHours(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected string
+	}{
+		{
+			name:     "label absent",
+			labels:   map[string]string{"sablier.enable": "true"},
+			expected: "",
+		},
+		{
+			name:     "valid running-hours",
+			labels:   map[string]string{"sablier.enable": "true", "sablier.running-hours": "09:00-17:00"},
+			expected: "09:00-17:00",
+		},
+		{
+			name:     "invalid running-hours is ignored",
+			labels:   map[string]string{"sablier.enable": "true", "sablier.running-hours": "invalid"},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var info sablier.InstanceInfo
+			sablier.PopulateEnabledAndGroup(&info, tt.labels)
+			assert.Equal(t, info.RunningHours, tt.expected)
 		})
 	}
 }

--- a/pkg/sablier/running_hours.go
+++ b/pkg/sablier/running_hours.go
@@ -1,0 +1,100 @@
+package sablier
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RunningHours represents a daily window in local time where an instance
+// should be kept running.
+type RunningHours struct {
+	startMinute int
+	endMinute   int
+}
+
+// ParseRunningHours parses a value in the form "HH:MM-HH:MM".
+//
+// The window is evaluated in local time (respecting TZ when configured).
+// Overnight windows are supported, for example "22:00-06:00".
+func ParseRunningHours(v string) (RunningHours, error) {
+	parts := strings.Split(v, "-")
+	if len(parts) != 2 {
+		return RunningHours{}, fmt.Errorf("invalid running-hours %q: expected HH:MM-HH:MM", v)
+	}
+
+	start, err := parseClock(parts[0])
+	if err != nil {
+		return RunningHours{}, fmt.Errorf("invalid running-hours %q: %w", v, err)
+	}
+	end, err := parseClock(parts[1])
+	if err != nil {
+		return RunningHours{}, fmt.Errorf("invalid running-hours %q: %w", v, err)
+	}
+	if start == end {
+		return RunningHours{}, fmt.Errorf("invalid running-hours %q: start and end cannot be equal", v)
+	}
+
+	return RunningHours{startMinute: start, endMinute: end}, nil
+}
+
+func parseClock(s string) (int, error) {
+	chunks := strings.Split(strings.TrimSpace(s), ":")
+	if len(chunks) != 2 {
+		return 0, fmt.Errorf("time %q must use HH:MM", s)
+	}
+	h, err := strconv.Atoi(chunks[0])
+	if err != nil {
+		return 0, fmt.Errorf("invalid hour in %q", s)
+	}
+	m, err := strconv.Atoi(chunks[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid minute in %q", s)
+	}
+	if h < 0 || h > 23 || m < 0 || m > 59 {
+		return 0, fmt.Errorf("time %q is out of range", s)
+	}
+	return h*60 + m, nil
+}
+
+// WindowAt returns whether now is inside the running-hours window and, if so,
+// the start and end time of the active window.
+func (r RunningHours) WindowAt(now time.Time) (start time.Time, end time.Time, in bool) {
+	loc := now.Location()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+	nowMinute := now.Hour()*60 + now.Minute()
+
+	if r.startMinute < r.endMinute {
+		start = midnight.Add(time.Duration(r.startMinute) * time.Minute)
+		end = midnight.Add(time.Duration(r.endMinute) * time.Minute)
+		return start, end, !now.Before(start) && now.Before(end)
+	}
+
+	// Overnight window, e.g. 22:00-06:00.
+	if nowMinute >= r.startMinute {
+		start = midnight.Add(time.Duration(r.startMinute) * time.Minute)
+		end = midnight.Add(24*time.Hour + time.Duration(r.endMinute)*time.Minute)
+		return start, end, !now.Before(start) && now.Before(end)
+	}
+
+	start = midnight.Add(-24*time.Hour + time.Duration(r.startMinute)*time.Minute)
+	end = midnight.Add(time.Duration(r.endMinute) * time.Minute)
+	return start, end, !now.Before(start) && now.Before(end)
+}
+
+func runningHoursRemaining(spec string, now time.Time) (time.Duration, bool, error) {
+	rh, err := ParseRunningHours(spec)
+	if err != nil {
+		return 0, false, err
+	}
+	_, end, in := rh.WindowAt(now)
+	if !in {
+		return 0, false, nil
+	}
+	remaining := end.Sub(now)
+	if remaining < 0 {
+		remaining = 0
+	}
+	return remaining, true, nil
+}

--- a/pkg/sablier/running_hours_test.go
+++ b/pkg/sablier/running_hours_test.go
@@ -1,0 +1,61 @@
+package sablier_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"gotest.tools/v3/assert"
+)
+
+func TestParseRunningHours(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		err   bool
+	}{
+		{name: "valid day window", value: "08:30-17:45", err: false},
+		{name: "valid overnight window", value: "22:00-06:00", err: false},
+		{name: "invalid format", value: "08:30/17:45", err: true},
+		{name: "invalid hour", value: "25:00-26:00", err: true},
+		{name: "same start and end", value: "10:00-10:00", err: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sablier.ParseRunningHours(tt.value)
+			if tt.err {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestRunningHoursWindowAt(t *testing.T) {
+	dayWindow, err := sablier.ParseRunningHours("08:00-12:00")
+	assert.NilError(t, err)
+
+	loc := time.Local
+	_, dayEnd, in := dayWindow.WindowAt(time.Date(2025, 1, 5, 9, 30, 0, 0, loc))
+	assert.Assert(t, in)
+	assert.Equal(t, dayEnd.Hour(), 12)
+	assert.Equal(t, dayEnd.Minute(), 0)
+
+	_, _, in = dayWindow.WindowAt(time.Date(2025, 1, 5, 7, 59, 0, 0, loc))
+	assert.Assert(t, !in)
+
+	overnight, err := sablier.ParseRunningHours("22:00-06:00")
+	assert.NilError(t, err)
+
+	_, overnightEnd, in := overnight.WindowAt(time.Date(2025, 1, 5, 23, 30, 0, 0, loc))
+	assert.Assert(t, in)
+	assert.Equal(t, overnightEnd.Day(), 6)
+	assert.Equal(t, overnightEnd.Hour(), 6)
+
+	_, overnightEnd, in = overnight.WindowAt(time.Date(2025, 1, 6, 1, 30, 0, 0, loc))
+	assert.Assert(t, in)
+	assert.Equal(t, overnightEnd.Day(), 6)
+	assert.Equal(t, overnightEnd.Hour(), 6)
+}

--- a/pkg/sablier/running_hours_watch.go
+++ b/pkg/sablier/running_hours_watch.go
@@ -1,0 +1,67 @@
+package sablier
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/provider"
+)
+
+// WatchRunningHours keeps configured instances warm during their
+// sablier.running-hours window by periodically reconciling all managed
+// instances and creating/extending sessions until the window end.
+func (s *Sablier) WatchRunningHours(ctx context.Context) {
+	ticker := time.NewTicker(s.RunningHoursRefreshFrequency)
+	defer ticker.Stop()
+
+	s.reconcileRunningHours(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.l.InfoContext(ctx, "stop watching running-hours windows", slog.Any("reason", ctx.Err()))
+			return
+		case <-ticker.C:
+			s.reconcileRunningHours(ctx)
+		}
+	}
+}
+
+func (s *Sablier) reconcileRunningHours(ctx context.Context) {
+	instances, err := s.provider.InstanceList(ctx, provider.InstanceListOptions{All: true})
+	if err != nil {
+		s.l.ErrorContext(ctx, "running-hours reconciliation failed to list instances", slog.Any("error", err))
+		return
+	}
+
+	now := time.Now()
+	for _, configured := range instances {
+		if configured.Enabled != "true" {
+			continue
+		}
+
+		info, err := s.provider.InstanceInspect(ctx, configured.Name)
+		if err != nil {
+			s.l.WarnContext(ctx, "running-hours reconciliation failed to inspect instance", slog.String("instance", configured.Name), slog.Any("error", err))
+			continue
+		}
+		if info.RunningHours == "" {
+			continue
+		}
+
+		remaining, inWindow, err := runningHoursRemaining(info.RunningHours, now)
+		if err != nil {
+			s.l.WarnContext(ctx, "invalid running-hours label, skipping instance", slog.String("instance", info.Name), slog.String("value", info.RunningHours), slog.Any("error", err))
+			continue
+		}
+		if !inWindow || remaining <= 0 {
+			continue
+		}
+
+		_, err = s.InstanceRequest(ctx, info.Name, remaining)
+		if err != nil {
+			s.l.WarnContext(ctx, "running-hours reconciliation failed to keep instance warm", slog.String("instance", info.Name), slog.Any("error", err))
+		}
+	}
+}

--- a/pkg/sablier/running_hours_watch_test.go
+++ b/pkg/sablier/running_hours_watch_test.go
@@ -1,0 +1,412 @@
+package sablier_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/provider"
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"go.uber.org/mock/gomock"
+)
+
+// insideWindowSpec returns an HH:MM-HH:MM spec that contains the current
+// minute with 2-minute margins on each side.
+func insideWindowSpec() string {
+	now := time.Now()
+	start := now.Add(-2 * time.Minute)
+	end := now.Add(5 * time.Minute)
+	return fmt.Sprintf("%02d:%02d-%02d:%02d", start.Hour(), start.Minute(), end.Hour(), end.Minute())
+}
+
+// outsideWindowSpec returns an HH:MM-HH:MM spec that ended ~4 hours ago and
+// therefore cannot contain the current minute.
+func outsideWindowSpec() string {
+	base := time.Now().Add(-4 * time.Hour)
+	end := base.Add(2 * time.Minute)
+	return fmt.Sprintf("%02d:%02d-%02d:%02d", base.Hour(), base.Minute(), end.Hour(), end.Minute())
+}
+
+// TestWatchRunningHours_StartsInstanceInsideWindow verifies that when an
+// instance's running-hours window is currently active, the watcher triggers
+// an InstanceRequest which extends/creates the session.
+func TestWatchRunningHours_StartsInstanceInsideWindow(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	// Large ticker: we rely on the immediate reconcile call at watcher startup.
+	s.RunningHoursRefreshFrequency = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	spec := insideWindowSpec()
+
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		Return([]sablier.InstanceConfiguration{{Name: "myapp", Enabled: "true"}}, nil)
+
+	p.EXPECT().InstanceInspect(gomock.Any(), "myapp").
+		Return(sablier.InstanceInfo{Name: "myapp", RunningHours: spec, Status: sablier.InstanceStatusReady}, nil)
+
+	// InstanceRequest path: instance is already in the store (running) → extend TTL.
+	sessions.EXPECT().Get(gomock.Any(), "myapp").
+		Return(sablier.InstanceInfo{Name: "myapp", Status: sablier.InstanceStatusReady, RunningHours: spec}, nil)
+
+	put := make(chan time.Duration, 1)
+	sessions.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ sablier.InstanceInfo, ttl time.Duration) error {
+			put <- ttl
+			return nil
+		})
+
+	go s.WatchRunningHours(ctx)
+
+	select {
+	case ttl := <-put:
+		if ttl <= 0 {
+			t.Fatalf("expected a positive TTL from the running-hours extension, got %s", ttl)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for session to be created/extended")
+	}
+}
+
+// TestWatchRunningHours_SkipsInstanceOutsideWindow verifies that when the
+// current time is outside the running-hours window, no InstanceRequest is made.
+func TestWatchRunningHours_SkipsInstanceOutsideWindow(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.RunningHoursRefreshFrequency = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	spec := outsideWindowSpec()
+
+	inspected := make(chan struct{})
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		Return([]sablier.InstanceConfiguration{{Name: "myapp", Enabled: "true"}}, nil)
+
+	p.EXPECT().InstanceInspect(gomock.Any(), "myapp").
+		DoAndReturn(func(_ context.Context, _ string) (sablier.InstanceInfo, error) {
+			close(inspected)
+			return sablier.InstanceInfo{Name: "myapp", RunningHours: spec}, nil
+		})
+
+	// sessions.Get and sessions.Put must NOT be called (gomock strict mode enforces this).
+
+	go s.WatchRunningHours(ctx)
+
+	select {
+	case <-inspected:
+		// reconcile ran; no further calls expected
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconcile to run")
+	}
+}
+
+// TestWatchRunningHours_SkipsNonEnabledInstance verifies that instances whose
+// Enabled field is not "true" are skipped before InstanceInspect is called.
+func TestWatchRunningHours_SkipsNonEnabledInstance(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.RunningHoursRefreshFrequency = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	listed := make(chan struct{})
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		DoAndReturn(func(_ context.Context, _ provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
+			close(listed)
+			return []sablier.InstanceConfiguration{{Name: "myapp", Enabled: "false"}}, nil
+		})
+
+	// InstanceInspect must NOT be called (gomock strict mode enforces this).
+
+	go s.WatchRunningHours(ctx)
+
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconcile to run")
+	}
+}
+
+// TestWatchRunningHours_SkipsInstanceWithoutRunningHoursLabel verifies that
+// instances without the running-hours label are skipped after InstanceInspect.
+func TestWatchRunningHours_SkipsInstanceWithoutRunningHoursLabel(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.RunningHoursRefreshFrequency = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	inspected := make(chan struct{})
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		Return([]sablier.InstanceConfiguration{{Name: "myapp", Enabled: "true"}}, nil)
+
+	p.EXPECT().InstanceInspect(gomock.Any(), "myapp").
+		DoAndReturn(func(_ context.Context, _ string) (sablier.InstanceInfo, error) {
+			close(inspected)
+			return sablier.InstanceInfo{Name: "myapp", RunningHours: ""}, nil
+		})
+
+	// sessions.Get and sessions.Put must NOT be called.
+
+	go s.WatchRunningHours(ctx)
+
+	select {
+	case <-inspected:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconcile to run")
+	}
+}
+
+// TestWatchRunningHours_HandlesInstanceListError verifies that when InstanceList
+// returns an error the reconciler logs and returns without crashing.
+func TestWatchRunningHours_HandlesInstanceListError(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.RunningHoursRefreshFrequency = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	listed := make(chan struct{})
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		DoAndReturn(func(_ context.Context, _ provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
+			close(listed)
+			return nil, errors.New("provider unavailable")
+		})
+
+	go s.WatchRunningHours(ctx)
+
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconcile to run")
+	}
+}
+
+// TestWatchRunningHours_HandlesInstanceInspectError verifies that when
+// InstanceInspect fails the reconciler logs a warning and skips the instance.
+func TestWatchRunningHours_HandlesInstanceInspectError(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.RunningHoursRefreshFrequency = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	inspected := make(chan struct{})
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		Return([]sablier.InstanceConfiguration{{Name: "myapp", Enabled: "true"}}, nil)
+
+	p.EXPECT().InstanceInspect(gomock.Any(), "myapp").
+		DoAndReturn(func(_ context.Context, _ string) (sablier.InstanceInfo, error) {
+			close(inspected)
+			return sablier.InstanceInfo{}, errors.New("inspect failed")
+		})
+
+	// sessions.Get and sessions.Put must NOT be called.
+
+	go s.WatchRunningHours(ctx)
+
+	select {
+	case <-inspected:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconcile to run")
+	}
+}
+
+// TestWatchRunningHours_HandlesInvalidRunningHoursLabel verifies that an
+// unparseable running-hours label is skipped with a warning, without crashing.
+func TestWatchRunningHours_HandlesInvalidRunningHoursLabel(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.RunningHoursRefreshFrequency = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	inspected := make(chan struct{})
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		Return([]sablier.InstanceConfiguration{{Name: "myapp", Enabled: "true"}}, nil)
+
+	p.EXPECT().InstanceInspect(gomock.Any(), "myapp").
+		DoAndReturn(func(_ context.Context, _ string) (sablier.InstanceInfo, error) {
+			close(inspected)
+			return sablier.InstanceInfo{Name: "myapp", RunningHours: "not-a-valid-spec"}, nil
+		})
+
+	// sessions.Get and sessions.Put must NOT be called.
+
+	go s.WatchRunningHours(ctx)
+
+	select {
+	case <-inspected:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconcile to run")
+	}
+}
+
+// TestWatchRunningHours_TickerTriggersReconciliation verifies that after the
+// initial reconcile, the watcher fires another reconcile on each tick.
+func TestWatchRunningHours_TickerTriggersReconciliation(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.RunningHoursRefreshFrequency = 20 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	spec := insideWindowSpec()
+
+	// Expect at least 2 calls (initial + at least one tick).
+	second := make(chan struct{})
+	calls := 0
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		DoAndReturn(func(_ context.Context, _ provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
+			calls++
+			if calls == 2 {
+				close(second)
+			}
+			return []sablier.InstanceConfiguration{{Name: "myapp", Enabled: "true"}}, nil
+		}).AnyTimes()
+
+	p.EXPECT().InstanceInspect(gomock.Any(), "myapp").
+		Return(sablier.InstanceInfo{Name: "myapp", RunningHours: spec, Status: sablier.InstanceStatusReady}, nil).AnyTimes()
+
+	sessions.EXPECT().Get(gomock.Any(), "myapp").
+		Return(sablier.InstanceInfo{Name: "myapp", Status: sablier.InstanceStatusReady, RunningHours: spec}, nil).AnyTimes()
+
+	sessions.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	go s.WatchRunningHours(ctx)
+
+	select {
+	case <-second:
+		// at least two reconcile cycles ran
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for ticker to trigger a second reconciliation")
+	}
+}
+
+// TestWatchRunningHours_StopsOnContextCancellation verifies that the watcher
+// exits cleanly when its context is cancelled.
+func TestWatchRunningHours_StopsOnContextCancellation(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.RunningHoursRefreshFrequency = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	listed := make(chan struct{})
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		DoAndReturn(func(_ context.Context, _ provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
+			close(listed)
+			return []sablier.InstanceConfiguration{}, nil
+		})
+
+	done := make(chan struct{})
+	go func() {
+		s.WatchRunningHours(ctx)
+		close(done)
+	}()
+
+	// Wait for the first reconcile to run, then cancel.
+	select {
+	case <-listed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initial reconcile")
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+		// goroutine exited cleanly
+	case <-time.After(5 * time.Second):
+		t.Fatal("WatchRunningHours did not stop after context cancellation")
+	}
+}
+
+// TestWatchRunningHours_MultipleInstances_MixedWindow verifies that when
+// multiple instances are present, only those inside their window are started.
+func TestWatchRunningHours_MultipleInstances_MixedWindow(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.RunningHoursRefreshFrequency = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	inSpec := insideWindowSpec()
+	outSpec := outsideWindowSpec()
+
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		Return([]sablier.InstanceConfiguration{
+			{Name: "active-app", Enabled: "true"},
+			{Name: "inactive-app", Enabled: "true"},
+		}, nil)
+
+	p.EXPECT().InstanceInspect(gomock.Any(), "active-app").
+		Return(sablier.InstanceInfo{Name: "active-app", RunningHours: inSpec, Status: sablier.InstanceStatusReady}, nil)
+
+	p.EXPECT().InstanceInspect(gomock.Any(), "inactive-app").
+		Return(sablier.InstanceInfo{Name: "inactive-app", RunningHours: outSpec}, nil)
+
+	// Only active-app should reach InstanceRequest → sessions.Get + sessions.Put.
+	sessions.EXPECT().Get(gomock.Any(), "active-app").
+		Return(sablier.InstanceInfo{Name: "active-app", Status: sablier.InstanceStatusReady, RunningHours: inSpec}, nil)
+
+	put := make(chan struct{})
+	sessions.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ sablier.InstanceInfo, _ time.Duration) error {
+			close(put)
+			return nil
+		})
+
+	// sessions.Get for inactive-app must NOT be called.
+
+	go s.WatchRunningHours(ctx)
+
+	select {
+	case <-put:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for active-app session to be extended")
+	}
+}
+
+// TestWatchRunningHours_InstanceRequestError verifies that when InstanceRequest
+// returns an error (e.g. store failure) the reconciler logs a warning and does
+// not crash. Non-ErrKeyNotFound errors from sessions.Get cause InstanceRequest
+// to return immediately without spawning any async goroutine.
+func TestWatchRunningHours_InstanceRequestError(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.RunningHoursRefreshFrequency = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	spec := insideWindowSpec()
+
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
+		Return([]sablier.InstanceConfiguration{{Name: "myapp", Enabled: "true"}}, nil)
+
+	p.EXPECT().InstanceInspect(gomock.Any(), "myapp").
+		Return(sablier.InstanceInfo{Name: "myapp", RunningHours: spec}, nil)
+
+	// A non-ErrKeyNotFound error from sessions.Get causes InstanceRequest to
+	// return an error immediately (no async goroutine is dispatched).
+	storeErr := make(chan struct{})
+	sessions.EXPECT().Get(gomock.Any(), "myapp").
+		DoAndReturn(func(_ context.Context, _ string) (sablier.InstanceInfo, error) {
+			close(storeErr)
+			return sablier.InstanceInfo{}, errors.New("store unavailable")
+		})
+
+	// sessions.Put and InstanceStart must NOT be called.
+
+	go s.WatchRunningHours(ctx)
+
+	select {
+	case <-storeErr:
+		// Reconcile ran and hit the InstanceRequest error path; no crash expected.
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconcile to encounter InstanceRequest error")
+	}
+}

--- a/pkg/sablier/running_hours_watch_test.go
+++ b/pkg/sablier/running_hours_watch_test.go
@@ -29,6 +29,25 @@ func outsideWindowSpec() string {
 	return fmt.Sprintf("%02d:%02d-%02d:%02d", base.Hour(), base.Minute(), end.Hour(), end.Minute())
 }
 
+// startWatcher launches WatchRunningHours in a goroutine and registers a
+// t.Cleanup that cancels the context and waits for the goroutine to exit.
+// This prevents "log after test completed" panics caused by the slogt logger.
+func startWatcher(t *testing.T, s *sablier.Sablier, ctx context.Context, cancel context.CancelFunc) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		s.WatchRunningHours(ctx)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+}
+
 // TestWatchRunningHours_StartsInstanceInsideWindow verifies that when an
 // instance's running-hours window is currently active, the watcher triggers
 // an InstanceRequest which extends/creates the session.
@@ -38,7 +57,6 @@ func TestWatchRunningHours_StartsInstanceInsideWindow(t *testing.T) {
 	s.RunningHoursRefreshFrequency = 24 * time.Hour
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	spec := insideWindowSpec()
 
@@ -59,7 +77,7 @@ func TestWatchRunningHours_StartsInstanceInsideWindow(t *testing.T) {
 			return nil
 		})
 
-	go s.WatchRunningHours(ctx)
+	startWatcher(t, s, ctx, cancel)
 
 	select {
 	case ttl := <-put:
@@ -78,7 +96,6 @@ func TestWatchRunningHours_SkipsInstanceOutsideWindow(t *testing.T) {
 	s.RunningHoursRefreshFrequency = 24 * time.Hour
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	spec := outsideWindowSpec()
 
@@ -94,7 +111,7 @@ func TestWatchRunningHours_SkipsInstanceOutsideWindow(t *testing.T) {
 
 	// sessions.Get and sessions.Put must NOT be called (gomock strict mode enforces this).
 
-	go s.WatchRunningHours(ctx)
+	startWatcher(t, s, ctx, cancel)
 
 	select {
 	case <-inspected:
@@ -111,7 +128,6 @@ func TestWatchRunningHours_SkipsNonEnabledInstance(t *testing.T) {
 	s.RunningHoursRefreshFrequency = 24 * time.Hour
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	listed := make(chan struct{})
 	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
@@ -122,7 +138,7 @@ func TestWatchRunningHours_SkipsNonEnabledInstance(t *testing.T) {
 
 	// InstanceInspect must NOT be called (gomock strict mode enforces this).
 
-	go s.WatchRunningHours(ctx)
+	startWatcher(t, s, ctx, cancel)
 
 	select {
 	case <-listed:
@@ -138,7 +154,6 @@ func TestWatchRunningHours_SkipsInstanceWithoutRunningHoursLabel(t *testing.T) {
 	s.RunningHoursRefreshFrequency = 24 * time.Hour
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	inspected := make(chan struct{})
 	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
@@ -152,7 +167,7 @@ func TestWatchRunningHours_SkipsInstanceWithoutRunningHoursLabel(t *testing.T) {
 
 	// sessions.Get and sessions.Put must NOT be called.
 
-	go s.WatchRunningHours(ctx)
+	startWatcher(t, s, ctx, cancel)
 
 	select {
 	case <-inspected:
@@ -168,7 +183,6 @@ func TestWatchRunningHours_HandlesInstanceListError(t *testing.T) {
 	s.RunningHoursRefreshFrequency = 24 * time.Hour
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	listed := make(chan struct{})
 	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
@@ -177,7 +191,7 @@ func TestWatchRunningHours_HandlesInstanceListError(t *testing.T) {
 			return nil, errors.New("provider unavailable")
 		})
 
-	go s.WatchRunningHours(ctx)
+	startWatcher(t, s, ctx, cancel)
 
 	select {
 	case <-listed:
@@ -193,7 +207,6 @@ func TestWatchRunningHours_HandlesInstanceInspectError(t *testing.T) {
 	s.RunningHoursRefreshFrequency = 24 * time.Hour
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	inspected := make(chan struct{})
 	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
@@ -207,7 +220,7 @@ func TestWatchRunningHours_HandlesInstanceInspectError(t *testing.T) {
 
 	// sessions.Get and sessions.Put must NOT be called.
 
-	go s.WatchRunningHours(ctx)
+	startWatcher(t, s, ctx, cancel)
 
 	select {
 	case <-inspected:
@@ -223,7 +236,6 @@ func TestWatchRunningHours_HandlesInvalidRunningHoursLabel(t *testing.T) {
 	s.RunningHoursRefreshFrequency = 24 * time.Hour
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	inspected := make(chan struct{})
 	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: true}).
@@ -237,7 +249,7 @@ func TestWatchRunningHours_HandlesInvalidRunningHoursLabel(t *testing.T) {
 
 	// sessions.Get and sessions.Put must NOT be called.
 
-	go s.WatchRunningHours(ctx)
+	startWatcher(t, s, ctx, cancel)
 
 	select {
 	case <-inspected:
@@ -253,7 +265,6 @@ func TestWatchRunningHours_TickerTriggersReconciliation(t *testing.T) {
 	s.RunningHoursRefreshFrequency = 20 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	spec := insideWindowSpec()
 
@@ -277,7 +288,7 @@ func TestWatchRunningHours_TickerTriggersReconciliation(t *testing.T) {
 
 	sessions.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-	go s.WatchRunningHours(ctx)
+	startWatcher(t, s, ctx, cancel)
 
 	select {
 	case <-second:
@@ -332,7 +343,6 @@ func TestWatchRunningHours_MultipleInstances_MixedWindow(t *testing.T) {
 	s.RunningHoursRefreshFrequency = 24 * time.Hour
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	inSpec := insideWindowSpec()
 	outSpec := outsideWindowSpec()
@@ -362,7 +372,7 @@ func TestWatchRunningHours_MultipleInstances_MixedWindow(t *testing.T) {
 
 	// sessions.Get for inactive-app must NOT be called.
 
-	go s.WatchRunningHours(ctx)
+	startWatcher(t, s, ctx, cancel)
 
 	select {
 	case <-put:
@@ -380,7 +390,6 @@ func TestWatchRunningHours_InstanceRequestError(t *testing.T) {
 	s.RunningHoursRefreshFrequency = 24 * time.Hour
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
 
 	spec := insideWindowSpec()
 
@@ -401,7 +410,7 @@ func TestWatchRunningHours_InstanceRequestError(t *testing.T) {
 
 	// sessions.Put and InstanceStart must NOT be called.
 
-	go s.WatchRunningHours(ctx)
+	startWatcher(t, s, ctx, cancel)
 
 	select {
 	case <-storeErr:

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -32,6 +32,10 @@ type Sablier struct {
 	// full reconciliation scan. Defaults to 30 seconds.
 	ExternallyStartedScanInterval time.Duration
 
+	// RunningHoursRefreshFrequency is how often running-hours windows are
+	// reconciled. Defaults to 30 seconds.
+	RunningHoursRefreshFrequency time.Duration
+
 	metrics metrics.Recorder
 
 	l *slog.Logger
@@ -49,6 +53,7 @@ func New(logger *slog.Logger, store Store, provider Provider) *Sablier {
 		BlockingRefreshFrequency:      5 * time.Second,
 		InstanceStartTimeout:          5 * time.Minute,
 		ExternallyStartedScanInterval: 30 * time.Second,
+		RunningHoursRefreshFrequency:  30 * time.Second,
 	}
 }
 

--- a/pkg/sabliercmd/start.go
+++ b/pkg/sabliercmd/start.go
@@ -106,6 +106,7 @@ func Start(ctx context.Context, conf config.Config) error {
 	if conf.Provider.AutoStopExternallyStarted {
 		go s.WatchAndStopExternallyStarted(ctx)
 	}
+	go s.WatchRunningHours(ctx)
 
 	t, err := setupTheme(ctx, conf, logger)
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes https://github.com/sablierapp/sablier/issues/292

This PR adds **daily running-hours support** so Sablier can proactively keep selected instances warm during configured time windows.

It also includes:
- timezone support improvements for container deployments
- updated documentation with operator-focused guidance
- tests for parsing/window behavior and session-expiration extension logic
- a runnable example in `examples/running-hours`

## User Guide

### What is new

You can now set the `sablier.running-hours` label on managed instances:

```yaml
labels:
  - "sablier.enable=true"
  - "sablier.group=myapp"
  - "sablier.running-hours=09:00-18:00"
```

Behavior:
- At startup and then periodically, Sablier reconciles managed instances.
- If current local time is inside the running-hours window, Sablier ensures the instance is started.
- While in-window, request-triggered session expiration is extended up to the window end so the instance does not stop mid-window.
- Outside the window, normal session expiration behavior applies.

Supported format:
- `HH:MM-HH:MM` (24-hour clock)
- overnight windows are supported, for example `22:00-06:00`

Invalid values are ignored with a warning.

### Timezone behavior

Running-hours are evaluated in the process local timezone.

This PR ensures timezone support for container deployments by:
- embedding tz database support in the binary (`time/tzdata`)
- setting a default `TZ=UTC` in the Docker image

Override timezone as needed at runtime, for example:

```bash
docker run -e TZ=Europe/Paris ...
```

### Example added

A new runnable example is available in `examples/running-hours`.

It contains:
- `compose.yml`
- `Makefile`
- `README.md` walkthrough

The example demonstrates:
- configuring `RUNNING_HOURS`
- configuring `TZ`
- triggering requests and observing keep-warm behavior in logs

## Implementation Notes

- Added running-hours parsing and window evaluation helpers.
- Added a periodic reconciliation watcher for running-hours.
- Extended `InstanceRequest` expiration logic to respect active running-hours windows.
- Extended instance label parsing to include `sablier.running-hours`.

## Tests

Executed:
- `go test ./pkg/sablier/...`

Added tests cover:
- parsing valid/invalid running-hours strings
- day and overnight window calculations
- expiration extension while inside running-hours
- no extension outside running-hours

## Changed files

- `pkg/sablier/running_hours.go`
- `pkg/sablier/running_hours_watch.go`
- `pkg/sablier/instance.go`
- `pkg/sablier/instance_request.go`
- `pkg/sablier/running_hours_test.go`
- `pkg/sablier/instance_request_running_hours_test.go`
- `pkg/sablier/instance_test.go`
- `pkg/sabliercmd/start.go`
- `cmd/sablier/cmd.go`
- `build/Dockerfile`
- `docs/configuration.md`
- `examples/running-hours/*`
