### PR TITLE
feat: scale mode — throttle CPU/memory instead of stopping containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,10 @@ Instance labels are applied directly to your containers or workloads. They contr
 | `sablier.group` | No | `"myapp"` | Assign the instance to a named group. Defaults to `"default"` when `sablier.enable=true` and no group is set. |
 | `sablier.ready-after` | No | `"30s"` | Minimum duration to wait after the instance first reports ready before Sablier considers it truly ready. Accepts any Go duration string (`"500ms"`, `"1m30s"`, …). Useful for services that are started or pass their health check before they can actually serve traffic. |
 | `sablier.running-hours` | No | `"09:00-18:00"` | Daily keep-warm window in local time (`HH:MM-HH:MM`). Sablier starts the instance at window start and keeps it running until window end. Overnight windows like `"22:00-06:00"` are supported. |
+| `sablier.idle.cpu` | No | `"0.1"` | CPU limit applied when the session expires (scale mode). Container keeps running with throttled CPU. |
+| `sablier.idle.memory` | No | `"128m"` | Memory limit applied when the session expires (scale mode). |
+| `sablier.active.cpu` | No | `"2.0"` | CPU limit restored when a new session is requested (scale mode). |
+| `sablier.active.memory` | No | `"512m"` | Memory limit restored when a new session is requested (scale mode). |
 
 ### `sablier.ready-after`
 
@@ -83,6 +87,70 @@ Running-hours are evaluated in the process local timezone.
 - In the official Docker image, the binary embeds timezone database data and supports `TZ` out of the box.
 - The container defaults to `TZ=UTC`.
 - Override timezone with environment variables, for example `-e TZ=Europe/Paris`.
+
+### Scale Mode
+
+Scale mode is an alternative to stopping containers. Instead of shutting down and restarting the container, Sablier **throttles its CPU and memory** when the session expires and **restores them** when a new session is requested. The container keeps running the entire time, which eliminates cold-start latency.
+
+| Label | Format | Example |
+|-------|--------|---------|
+| `sablier.idle.cpu` | Decimal cores (Docker/Swarm) or Kubernetes quantity | `"0.1"`, `"500m"` |
+| `sablier.idle.memory` | Docker units or Kubernetes quantity | `"64m"`, `"128Mi"` |
+| `sablier.active.cpu` | Decimal cores (Docker/Swarm) or Kubernetes quantity | `"2.0"`, `"2000m"` |
+| `sablier.active.memory` | Docker units or Kubernetes quantity | `"512m"`, `"1Gi"` |
+
+You can set any combination of the four labels. Labels not set default to 0 (no limit).
+
+**Supported providers:** Docker, Docker Swarm, Kubernetes (Deployments and StatefulSets), Podman.
+
+> Proxmox LXC does not support scale mode because it uses tag-based configuration rather than key-value labels.
+
+#### Docker / Podman
+
+CPU values are decimal fractions of one core (`"0.5"` = half a core). Memory values use Docker-style suffixes (`b`, `k`, `m`, `g`).
+
+```yaml
+services:
+  myapp:
+    image: myapp:latest
+    labels:
+      - "sablier.enable=true"
+      - "sablier.group=myapp"
+      - "sablier.idle.cpu=0.1"
+      - "sablier.idle.memory=64m"
+      - "sablier.active.cpu=2.0"
+      - "sablier.active.memory=512m"
+```
+
+When the session expires, Sablier runs the equivalent of `docker update --cpus=0.1 --memory=64m myapp`. When a new session is requested, it restores `--cpus=2.0 --memory=512m`. The container is never stopped.
+
+> **Note:** Docker requires the memory swap limit to be updated in the same call as the memory limit. Sablier sets `MemorySwap` equal to `Memory` automatically, which satisfies the constraint and disables swap for the container.
+
+#### Docker Swarm
+
+Same format as Docker. Resource constraints are applied to the service's task template, triggering a Swarm service update (tasks are re-scheduled with the new limits).
+
+#### Kubernetes
+
+CPU and memory values use the standard [Kubernetes resource quantity](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) format (`"500m"`, `"2"`, `"128Mi"`, `"1Gi"`).
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+  labels:
+    sablier.enable: "true"
+    sablier.group: myapp
+    sablier.idle.cpu: "100m"
+    sablier.idle.memory: "64Mi"
+    sablier.active.cpu: "2000m"
+    sablier.active.memory: "512Mi"
+```
+
+> **Note:** Kubernetes resource limit changes trigger a **rolling restart** of the pods. The service remains available during the transition (old pods are replaced with new ones), but there will be brief overlap between old and new pods.
+
+!> Scale mode changes resource **limits**, not requests. Ensure your nodes have sufficient allocatable capacity for the active limits.
 
 ## Configuration File
 

--- a/examples/scale-mode/Makefile
+++ b/examples/scale-mode/Makefile
@@ -1,0 +1,22 @@
+.PHONY: up down demo
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+# Demo: request the whoami service (starts scale-mode if idle), wait, then see it throttled
+demo: up
+	@echo "==> Requesting session (applies active resources)..."
+	curl -s 'http://localhost:10000/api/strategies/blocking?group=whoami&timeout=30s' | head -5
+	@echo ""
+	@echo "==> Container resources after activation:"
+	docker inspect scale-mode-whoami-1 --format '{{.HostConfig.NanoCPUs}} nanocores, {{.HostConfig.Memory}} bytes memory' 2>/dev/null || \
+		docker inspect $$(docker compose ps -q whoami) --format '{{.HostConfig.NanoCPUs}} nanocores, {{.HostConfig.Memory}} bytes memory'
+	@echo ""
+	@echo "==> Waiting 40s for session to expire..."
+	sleep 40
+	@echo "==> Container resources after idle (should be throttled):"
+	docker inspect scale-mode-whoami-1 --format '{{.HostConfig.NanoCPUs}} nanocores, {{.HostConfig.Memory}} bytes memory' 2>/dev/null || \
+		docker inspect $$(docker compose ps -q whoami) --format '{{.HostConfig.NanoCPUs}} nanocores, {{.HostConfig.Memory}} bytes memory'

--- a/examples/scale-mode/README.md
+++ b/examples/scale-mode/README.md
@@ -1,0 +1,56 @@
+# Scale Mode Example
+
+This example demonstrates Sablier's **scale mode**: instead of stopping containers when sessions expire, Sablier throttles their CPU and memory. When a new session is requested, resources are restored and the container is immediately available — no cold-start wait.
+
+## How It Works
+
+1. **Session expires** → Sablier runs `docker update --cpus=0.1 --memory=64m whoami`. Container stays running, using minimal resources.
+2. **New request arrives** → Sablier runs `docker update --cpus=2.0 --memory=512m whoami`. Resources are restored. The container is immediately ready (no restart needed).
+
+## Running the Example
+
+```bash
+# Start everything
+make up
+
+# Trigger an active session and watch the resource transition
+make demo
+
+# Tear down
+make down
+```
+
+## Manual Steps
+
+```bash
+docker compose up -d
+
+# Request a session (blocks until whoami is ready, then returns)
+curl 'http://localhost:10000/api/strategies/blocking?names=whoami&timeout=30s'
+
+# Inspect current CPU/memory limits (should be active: ~2 000 000 000 nanocores)
+docker inspect scale-mode-whoami-1 --format '{{.HostConfig.NanoCPUs}} nanocores'
+
+# Wait for the 30 s session to expire, then check again (should be idle: ~100 000 000 nanocores)
+sleep 35
+docker inspect scale-mode-whoami-1 --format '{{.HostConfig.NanoCPUs}} nanocores'
+```
+
+## Labels Used
+
+| Label | Value | Meaning |
+|-------|-------|---------|
+| `sablier.idle.cpu` | `0.1` | 10% of one CPU when idle |
+| `sablier.idle.memory` | `64m` | 64 MB when idle |
+| `sablier.active.cpu` | `2.0` | 2 full CPUs when active |
+| `sablier.active.memory` | `512m` | 512 MB when active |
+
+## Notes
+
+- Scale mode is supported for **Docker**, **Docker Swarm**, **Kubernetes**, and **Podman**.
+- For Kubernetes, a resource limit change triggers a rolling restart. The service stays available during the transition.
+- You can set only some labels (e.g. only `sablier.idle.cpu` without a memory limit). Labels not set default to 0 (unlimited).
+
+### Memory swap (Docker)
+
+Docker requires the memory swap limit to be updated in the same `docker update` call as the memory limit. Sablier handles this automatically by setting `MemorySwap` equal to `Memory`, which satisfies the constraint and disables swap for the container.

--- a/examples/scale-mode/compose.yml
+++ b/examples/scale-mode/compose.yml
@@ -1,0 +1,30 @@
+services:
+  sablier:
+    image: ${SABLIER_IMAGE:-sablierapp/sablier:latest}
+    command:
+      - start
+      - --provider.name=docker
+      - --logging.level=debug
+      - --sessions.default-duration=30s
+      - --sessions.expiration-interval=5s
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "10000:10000"
+
+  # whoami is managed in scale mode: instead of being stopped, its CPU and
+  # memory are throttled when idle and restored when a session is requested.
+  # The container is never stopped, so there is no cold-start latency.
+  whoami:
+    image: acouvreur/whoami:v1.10.2
+    labels:
+      - "sablier.enable=true"
+      - "sablier.group=whoami"
+      # Idle: throttle to 0.1 CPU and 64 MB when the session expires
+      - "sablier.idle.cpu=0.1"
+      - "sablier.idle.memory=64m"
+      # Active: restore to 2 CPUs and 512 MB when a new session is requested
+      - "sablier.active.cpu=2.0"
+      - "sablier.active.memory=512m"
+    ports:
+      - "8080:80"

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/djherbis/times v1.6.0 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
+	github.com/docker/go-units v0.5.0
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/pkg/provider/docker/container_scale.go
+++ b/pkg/provider/docker/container_scale.go
@@ -1,0 +1,72 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/docker/go-units"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+)
+
+// parseCPUNano converts a decimal CPU value (e.g. "0.5", "2") to Docker nanocores.
+// 1 CPU = 1,000,000,000 nanocores.
+func parseCPUNano(cpu string) (int64, error) {
+	v, err := strconv.ParseFloat(cpu, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid CPU value %q: %w", cpu, err)
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("CPU value must be non-negative, got %q", cpu)
+	}
+	return int64(v * 1e9), nil
+}
+
+// parseMemoryBytes converts a human-readable memory string (e.g. "128m", "1g")
+// to bytes using Docker-style suffixes (b, k, m, g).
+func parseMemoryBytes(memory string) (int64, error) {
+	b, err := units.RAMInBytes(memory)
+	if err != nil {
+		return 0, fmt.Errorf("invalid memory value %q: %w", memory, err)
+	}
+	return b, nil
+}
+
+// applyResources updates the CPU and/or memory limits of a running container
+// using cgroup constraints (docker update). Pass an empty string for cpu or
+// memory to leave that limit unchanged (a zero value removes the limit).
+func (p *Provider) applyResources(ctx context.Context, name, cpu, memory string) error {
+	resources := &container.Resources{}
+
+	if cpu != "" {
+		v, err := parseCPUNano(cpu)
+		if err != nil {
+			return err
+		}
+		resources.NanoCPUs = v
+	}
+
+	if memory != "" {
+		v, err := parseMemoryBytes(memory)
+		if err != nil {
+			return err
+		}
+		resources.Memory = v
+		// Docker requires MemorySwap >= Memory in the same update call.
+		// Setting MemorySwap equal to Memory satisfies the constraint and
+		// disables swap for the container.
+		resources.MemorySwap = v
+	}
+
+	result, err := p.Client.ContainerUpdate(ctx, name, client.ContainerUpdateOptions{
+		Resources: resources,
+	})
+	if err != nil {
+		return fmt.Errorf("cannot update resources for container %s: %w", name, err)
+	}
+	if len(result.Warnings) > 0 {
+		p.l.WarnContext(ctx, "warnings from container resource update", "name", name, "warnings", result.Warnings)
+	}
+	return nil
+}

--- a/pkg/provider/docker/container_scale_test.go
+++ b/pkg/provider/docker/container_scale_test.go
@@ -1,0 +1,104 @@
+package docker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/moby/client"
+	"github.com/neilotoole/slogt"
+	"github.com/sablierapp/sablier/pkg/provider/docker"
+	"gotest.tools/v3/assert"
+)
+
+// TestDockerScaleMode_Stop verifies that InstanceStop applies idle resource limits
+// instead of stopping the container when scale labels are set.
+func TestDockerScaleMode_Stop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	c := sharedDinD
+
+	// Create a container with idle/active scale labels
+	result, err := c.CreateMimic(ctx, MimicOptions{
+		Labels: map[string]string{
+			"sablier.idle.cpu":    "0.5",
+			"sablier.idle.memory": "128m",
+			"sablier.active.cpu":  "2.0",
+			"sablier.active.memory": "512m",
+		},
+	})
+	assert.NilError(t, err)
+
+	_, err = c.client.ContainerStart(ctx, result.ID, client.ContainerStartOptions{})
+	assert.NilError(t, err)
+
+	p, err := docker.New(ctx, c.client, slogt.New(t), "stop")
+	assert.NilError(t, err)
+
+	// InstanceStop should apply idle resources, not stop the container
+	err = p.InstanceStop(t.Context(), result.ID)
+	assert.NilError(t, err)
+
+	// Container should still be running
+	spec, err := c.client.ContainerInspect(ctx, result.ID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(spec.Container.State.Status), "running",
+		"container should still be running in scale mode")
+
+	// CPU limit should be set to idle value (0.5 cores = 500_000_000 nanocores)
+	assert.Equal(t, spec.Container.HostConfig.NanoCPUs, int64(500_000_000),
+		"CPU should be throttled to idle value")
+
+	// Memory limit should be set to idle value (128 MiB = 134_217_728 bytes)
+	assert.Equal(t, spec.Container.HostConfig.Memory, int64(128*1024*1024),
+		"Memory should be throttled to idle value")
+}
+
+// TestDockerScaleMode_Start verifies that InstanceStart applies active resource limits
+// instead of starting the container when scale labels are set.
+func TestDockerScaleMode_Start(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	c := sharedDinD
+
+	// Create a container with scale labels and idle resources already applied
+	result, err := c.CreateMimic(ctx, MimicOptions{
+		Labels: map[string]string{
+			"sablier.idle.cpu":      "0.5",
+			"sablier.idle.memory":   "128m",
+			"sablier.active.cpu":    "2.0",
+			"sablier.active.memory": "512m",
+		},
+	})
+	assert.NilError(t, err)
+
+	_, err = c.client.ContainerStart(ctx, result.ID, client.ContainerStartOptions{})
+	assert.NilError(t, err)
+
+	p, err := docker.New(ctx, c.client, slogt.New(t), "stop")
+	assert.NilError(t, err)
+
+	// InstanceStart should apply active resources
+	err = p.InstanceStart(t.Context(), result.ID)
+	assert.NilError(t, err)
+
+	// Container should still be running
+	spec, err := c.client.ContainerInspect(ctx, result.ID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(spec.Container.State.Status), "running")
+
+	// CPU limit should be set to active value (2.0 cores = 2_000_000_000 nanocores)
+	assert.Equal(t, spec.Container.HostConfig.NanoCPUs, int64(2_000_000_000),
+		"CPU should be set to active value")
+
+	// Memory limit should be set to active value (512 MiB = 536_870_912 bytes)
+	assert.Equal(t, spec.Container.HostConfig.Memory, int64(512*1024*1024),
+		"Memory should be set to active value")
+}

--- a/pkg/provider/docker/container_scale_unit_test.go
+++ b/pkg/provider/docker/container_scale_unit_test.go
@@ -1,0 +1,67 @@
+package docker
+
+// Unit tests for the scale-mode resource parsing functions.
+// These run without a real Docker daemon.
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParseCPUNano(t *testing.T) {
+	tests := []struct {
+		name    string
+		cpu     string
+		want    int64
+		wantErr bool
+	}{
+		{name: "half a core", cpu: "0.5", want: 500_000_000},
+		{name: "one core", cpu: "1", want: 1_000_000_000},
+		{name: "two cores", cpu: "2.0", want: 2_000_000_000},
+		{name: "fractional", cpu: "0.25", want: 250_000_000},
+		{name: "zero", cpu: "0", want: 0},
+		{name: "invalid string", cpu: "bad", wantErr: true},
+		{name: "negative", cpu: "-1", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCPUNano(tt.cpu)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected error for cpu=%q", tt.cpu)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestParseMemoryBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		memory  string
+		want    int64
+		wantErr bool
+	}{
+		{name: "128 megabytes lowercase", memory: "128m", want: 128 * 1024 * 1024},
+		{name: "128 megabytes uppercase", memory: "128M", want: 128 * 1024 * 1024},
+		{name: "1 gigabyte", memory: "1g", want: 1024 * 1024 * 1024},
+		{name: "512 kilobytes", memory: "512k", want: 512 * 1024},
+		{name: "raw bytes", memory: "1048576", want: 1048576},
+		{name: "invalid", memory: "bad", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMemoryBytes(tt.memory)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected error for memory=%q", tt.memory)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/pkg/provider/docker/container_start.go
+++ b/pkg/provider/docker/container_start.go
@@ -6,9 +6,25 @@ import (
 	"log/slog"
 
 	"github.com/moby/moby/client"
+	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
 func (p *Provider) InstanceStart(ctx context.Context, name string) error {
+	spec, err := p.Client.ContainerInspect(ctx, name, client.ContainerInspectOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot inspect container: %w", err)
+	}
+
+	sc := sablier.ScaleConfigFromLabels(spec.Container.Config.Labels)
+	if sc != nil && (sc.Active.CPU != "" || sc.Active.Memory != "") {
+		p.l.DebugContext(ctx, "applying active resources (scale mode)",
+			slog.String("name", name),
+			slog.String("cpu", sc.Active.CPU),
+			slog.String("memory", sc.Active.Memory),
+		)
+		return p.applyResources(ctx, name, sc.Active.CPU, sc.Active.Memory)
+	}
+
 	if p.strategy == "pause" {
 		return p.dockerUnpause(ctx, name)
 	}

--- a/pkg/provider/docker/container_start_test.go
+++ b/pkg/provider/docker/container_start_test.go
@@ -33,7 +33,7 @@ func TestDockerClassicProvider_Start(t *testing.T) {
 					return "non-existent", nil
 				},
 			},
-			err: fmt.Errorf("cannot start container non-existent: Error response from daemon: No such container: non-existent"),
+			err: fmt.Errorf("cannot inspect container: Error response from daemon: No such container: non-existent"),
 		},
 		{
 			name: "container start as expected",
@@ -88,7 +88,7 @@ func TestDockerClassicProvider_Unpause(t *testing.T) {
 					return "non-existent", nil
 				},
 			},
-			err: fmt.Errorf("cannot inspect container non-existent before unpausing: Error response from daemon: No such container: non-existent"),
+			err: fmt.Errorf("cannot inspect container: Error response from daemon: No such container: non-existent"),
 		},
 		{
 			name: "container starts because was not paused",

--- a/pkg/provider/docker/container_stop.go
+++ b/pkg/provider/docker/container_stop.go
@@ -7,9 +7,25 @@ import (
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
+	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
 func (p *Provider) InstanceStop(ctx context.Context, name string) error {
+	spec, err := p.Client.ContainerInspect(ctx, name, client.ContainerInspectOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot inspect container: %w", err)
+	}
+
+	sc := sablier.ScaleConfigFromLabels(spec.Container.Config.Labels)
+	if sc != nil && (sc.Idle.CPU != "" || sc.Idle.Memory != "") {
+		p.l.DebugContext(ctx, "applying idle resources (scale mode)",
+			slog.String("name", name),
+			slog.String("cpu", sc.Idle.CPU),
+			slog.String("memory", sc.Idle.Memory),
+		)
+		return p.applyResources(ctx, name, sc.Idle.CPU, sc.Idle.Memory)
+	}
+
 	if p.strategy == "pause" {
 		return p.dockerPause(ctx, name)
 	}

--- a/pkg/provider/docker/container_stop_test.go
+++ b/pkg/provider/docker/container_stop_test.go
@@ -33,7 +33,7 @@ func TestDockerClassicProvider_Stop(t *testing.T) {
 					return "non-existent", nil
 				},
 			},
-			err: fmt.Errorf("cannot stop container non-existent: Error response from daemon: No such container: non-existent"),
+			err: fmt.Errorf("cannot inspect container: Error response from daemon: No such container: non-existent"),
 		},
 		{
 			name: "container stop as expected",
@@ -97,7 +97,7 @@ func TestDockerClassicProvider_Pause(t *testing.T) {
 					return "non-existent", nil
 				},
 			},
-			err: fmt.Errorf("cannot pause container non-existent: Error response from daemon: No such container: non-existent"),
+			err: fmt.Errorf("cannot inspect container: Error response from daemon: No such container: non-existent"),
 		},
 		{
 			name: "container pause as expected",

--- a/pkg/provider/dockerswarm/service_scale.go
+++ b/pkg/provider/dockerswarm/service_scale.go
@@ -1,0 +1,92 @@
+package dockerswarm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/docker/go-units"
+	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
+)
+
+// parseCPUNano converts a decimal CPU value (e.g. "0.5", "2") to nanocores.
+// 1 CPU = 1,000,000,000 nanocores.
+func parseCPUNano(cpu string) (int64, error) {
+	v, err := strconv.ParseFloat(cpu, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid CPU value %q: %w", cpu, err)
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("CPU value must be non-negative, got %q", cpu)
+	}
+	return int64(v * 1e9), nil
+}
+
+// parseMemoryBytes converts a human-readable memory string (e.g. "128m", "1g")
+// to bytes using Docker-style suffixes.
+func parseMemoryBytes(memory string) (int64, error) {
+	b, err := units.RAMInBytes(memory)
+	if err != nil {
+		return 0, fmt.Errorf("invalid memory value %q: %w", memory, err)
+	}
+	return b, nil
+}
+
+// ServiceUpdateResources updates the CPU and/or memory resource limits of a
+// Swarm service without changing its replica count. Pass an empty string for
+// cpu or memory to set that limit to 0 (unlimited).
+func (p *Provider) ServiceUpdateResources(ctx context.Context, name, cpu, memory string) error {
+	service, err := p.getServiceByName(name, ctx)
+	if err != nil {
+		return fmt.Errorf("cannot get service: %w", err)
+	}
+
+	if service.Spec.Mode.Replicated == nil {
+		return errors.New("swarm service is not in \"replicated\" mode")
+	}
+
+	var nanoCPUs int64
+	var memBytes int64
+
+	if cpu != "" {
+		v, err := parseCPUNano(cpu)
+		if err != nil {
+			return err
+		}
+		nanoCPUs = v
+	}
+
+	if memory != "" {
+		v, err := parseMemoryBytes(memory)
+		if err != nil {
+			return err
+		}
+		memBytes = v
+	}
+
+	if service.Spec.TaskTemplate.Resources == nil {
+		service.Spec.TaskTemplate.Resources = &swarm.ResourceRequirements{}
+	}
+	if service.Spec.TaskTemplate.Resources.Limits == nil {
+		service.Spec.TaskTemplate.Resources.Limits = &swarm.Limit{}
+	}
+	service.Spec.TaskTemplate.Resources.Limits.NanoCPUs = nanoCPUs
+	service.Spec.TaskTemplate.Resources.Limits.MemoryBytes = memBytes
+
+	response, err := p.Client.ServiceUpdate(ctx, service.ID, client.ServiceUpdateOptions{
+		Version: service.Version,
+		Spec:    service.Spec,
+	})
+	if err != nil {
+		return fmt.Errorf("cannot update service resources: %w", err)
+	}
+
+	if len(response.Warnings) > 0 {
+		return fmt.Errorf("warning received updating swarm service [%s]: %s", service.Spec.Name, strings.Join(response.Warnings, ", "))
+	}
+
+	return nil
+}

--- a/pkg/provider/dockerswarm/service_scale_test.go
+++ b/pkg/provider/dockerswarm/service_scale_test.go
@@ -1,0 +1,63 @@
+package dockerswarm
+
+// Unit tests for the scale-mode resource parsing functions in the Swarm provider.
+// These run without a real Docker Swarm daemon.
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSwarmParseCPUNano(t *testing.T) {
+	tests := []struct {
+		name    string
+		cpu     string
+		want    int64
+		wantErr bool
+	}{
+		{name: "half a core", cpu: "0.5", want: 500_000_000},
+		{name: "one core", cpu: "1", want: 1_000_000_000},
+		{name: "two cores", cpu: "2.0", want: 2_000_000_000},
+		{name: "zero", cpu: "0", want: 0},
+		{name: "invalid", cpu: "notanumber", wantErr: true},
+		{name: "negative", cpu: "-0.5", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCPUNano(tt.cpu)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected error for cpu=%q", tt.cpu)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestSwarmParseMemoryBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		memory  string
+		want    int64
+		wantErr bool
+	}{
+		{name: "256m", memory: "256m", want: 256 * 1024 * 1024},
+		{name: "1g", memory: "1g", want: 1024 * 1024 * 1024},
+		{name: "invalid", memory: "??", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMemoryBytes(tt.memory)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected error for memory=%q", tt.memory)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}

--- a/pkg/provider/dockerswarm/service_start.go
+++ b/pkg/provider/dockerswarm/service_start.go
@@ -1,7 +1,28 @@
 package dockerswarm
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
 
 func (p *Provider) InstanceStart(ctx context.Context, name string) error {
+	service, err := p.getServiceByName(name, ctx)
+	if err != nil {
+		return fmt.Errorf("cannot get service: %w", err)
+	}
+
+	sc := sablier.ScaleConfigFromLabels(service.Spec.Labels)
+	if sc != nil && (sc.Active.CPU != "" || sc.Active.Memory != "") {
+		p.l.DebugContext(ctx, "applying active resources (scale mode)",
+			slog.String("name", name),
+			slog.String("cpu", sc.Active.CPU),
+			slog.String("memory", sc.Active.Memory),
+		)
+		return p.ServiceUpdateResources(ctx, name, sc.Active.CPU, sc.Active.Memory)
+	}
+
 	return p.ServiceUpdateReplicas(ctx, name, uint64(p.desiredReplicas))
 }

--- a/pkg/provider/dockerswarm/service_start_test.go
+++ b/pkg/provider/dockerswarm/service_start_test.go
@@ -14,6 +14,46 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func TestDockerSwarmProvider_Start_ScaleMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	c := sharedDinD
+	p, err := dockerswarm.New(ctx, c.client, slogt.New(t))
+	assert.NilError(t, err)
+
+	s, err := c.CreateMimic(ctx, MimicOptions{
+		Cmd: []string{"/mimic"},
+		Labels: map[string]string{
+			"sablier.active.cpu":    "2.0",
+			"sablier.active.memory": "128m",
+		},
+	})
+	assert.NilError(t, err)
+
+	inspectResult, err := c.client.ServiceInspect(ctx, s.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	name := inspectResult.Service.Spec.Name
+	t.Cleanup(func() {
+		_, _ = c.client.ServiceRemove(context.Background(), name, client.ServiceRemoveOptions{})
+	})
+
+	err = p.InstanceStart(ctx, name)
+	assert.NilError(t, err)
+
+	service, err := c.client.ServiceInspect(ctx, name, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	// Scale mode: replicas must remain at 1.
+	assert.Equal(t, *service.Service.Spec.Mode.Replicated.Replicas, uint64(1))
+	// CPU limit must be set to 2.0 cores (2 000 000 000 nanocores).
+	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.NanoCPUs, int64(2_000_000_000))
+	// Memory limit must be set to 128 MiB.
+	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.MemoryBytes, int64(128*1024*1024))
+}
+
 func TestDockerSwarmProvider_Start(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/pkg/provider/dockerswarm/service_stop.go
+++ b/pkg/provider/dockerswarm/service_stop.go
@@ -1,7 +1,28 @@
 package dockerswarm
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
 
 func (p *Provider) InstanceStop(ctx context.Context, name string) error {
+	service, err := p.getServiceByName(name, ctx)
+	if err != nil {
+		return fmt.Errorf("cannot get service: %w", err)
+	}
+
+	sc := sablier.ScaleConfigFromLabels(service.Spec.Labels)
+	if sc != nil && (sc.Idle.CPU != "" || sc.Idle.Memory != "") {
+		p.l.DebugContext(ctx, "applying idle resources (scale mode)",
+			slog.String("name", name),
+			slog.String("cpu", sc.Idle.CPU),
+			slog.String("memory", sc.Idle.Memory),
+		)
+		return p.ServiceUpdateResources(ctx, name, sc.Idle.CPU, sc.Idle.Memory)
+	}
+
 	return p.ServiceUpdateReplicas(ctx, name, 0)
 }

--- a/pkg/provider/dockerswarm/service_stop_test.go
+++ b/pkg/provider/dockerswarm/service_stop_test.go
@@ -14,6 +14,46 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func TestDockerSwarmProvider_Stop_ScaleMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	c := sharedDinD
+	p, err := dockerswarm.New(ctx, c.client, slogt.New(t))
+	assert.NilError(t, err)
+
+	s, err := c.CreateMimic(ctx, MimicOptions{
+		Cmd: []string{"/mimic"},
+		Labels: map[string]string{
+			"sablier.idle.cpu":    "0.1",
+			"sablier.idle.memory": "64m",
+		},
+	})
+	assert.NilError(t, err)
+
+	inspectResult, err := c.client.ServiceInspect(ctx, s.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	name := inspectResult.Service.Spec.Name
+	t.Cleanup(func() {
+		_, _ = c.client.ServiceRemove(context.Background(), name, client.ServiceRemoveOptions{})
+	})
+
+	err = p.InstanceStop(ctx, name)
+	assert.NilError(t, err)
+
+	service, err := c.client.ServiceInspect(ctx, name, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	// Scale mode: replicas must remain at 1, not be set to 0.
+	assert.Equal(t, *service.Service.Spec.Mode.Replicated.Replicas, uint64(1))
+	// CPU limit must be set to 0.1 core (100 000 000 nanocores).
+	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.NanoCPUs, int64(100_000_000))
+	// Memory limit must be set to 64 MiB.
+	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.MemoryBytes, int64(64*1024*1024))
+}
+
 func TestDockerSwarmProvider_Stop(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/pkg/provider/kubernetes/instance_start.go
+++ b/pkg/provider/kubernetes/instance_start.go
@@ -1,11 +1,31 @@
 package kubernetes
 
-import "context"
+import (
+	"context"
+	"log/slog"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
 
 func (p *Provider) InstanceStart(ctx context.Context, name string) error {
 	parsed, err := ParseName(name, ParseOptions{Delimiter: p.delimiter})
 	if err != nil {
 		return err
+	}
+
+	labels, err := p.getWorkloadLabels(ctx, parsed)
+	if err != nil {
+		return err
+	}
+
+	sc := sablier.ScaleConfigFromLabels(labels)
+	if sc != nil && (sc.Active.CPU != "" || sc.Active.Memory != "") {
+		p.l.DebugContext(ctx, "applying active resources (scale mode)",
+			slog.String("name", name),
+			slog.String("cpu", sc.Active.CPU),
+			slog.String("memory", sc.Active.Memory),
+		)
+		return p.scaleResources(ctx, parsed, sc.Active.CPU, sc.Active.Memory)
 	}
 
 	return p.scale(ctx, parsed, parsed.Replicas)

--- a/pkg/provider/kubernetes/instance_start_test.go
+++ b/pkg/provider/kubernetes/instance_start_test.go
@@ -9,8 +9,92 @@ import (
 	"github.com/sablierapp/sablier/pkg/config"
 	"github.com/sablierapp/sablier/pkg/provider/kubernetes"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestKubernetesProvider_InstanceStart_ScaleMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	kind := sharedKinD
+	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+	assert.NilError(t, err)
+
+	t.Run("deployment scale mode active resources applied", func(t *testing.T) {
+		t.Parallel()
+
+		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{
+			Labels: map[string]string{
+				"sablier.active.cpu":    "200m",
+				"sablier.active.memory": "128Mi",
+			},
+		})
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = kind.client.AppsV1().Deployments(d.Namespace).Delete(context.Background(), d.Name, metav1.DeleteOptions{})
+		})
+
+		err = WaitForDeploymentReady(ctx, kind.client, d.Namespace, d.Name)
+		assert.NilError(t, err)
+
+		name := kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original
+		err = p.InstanceStart(ctx, name)
+		assert.NilError(t, err)
+
+		updated, err := kind.client.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
+		expectedCPU := resource.MustParse("200m")
+		expectedMem := resource.MustParse("128Mi")
+		cpuLimit := limits[corev1.ResourceCPU]
+		memLimit := limits[corev1.ResourceMemory]
+		assert.Assert(t, cpuLimit.Cmp(expectedCPU) == 0,
+			"expected CPU limit 200m, got %s", cpuLimit.String())
+		assert.Assert(t, memLimit.Cmp(expectedMem) == 0,
+			"expected memory limit 128Mi, got %s", memLimit.String())
+	})
+
+	t.Run("statefulset scale mode active resources applied", func(t *testing.T) {
+		t.Parallel()
+
+		ss, err := kind.CreateMimicStatefulSet(ctx, MimicOptions{
+			Labels: map[string]string{
+				"sablier.active.cpu":    "200m",
+				"sablier.active.memory": "128Mi",
+			},
+		})
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = kind.client.AppsV1().StatefulSets(ss.Namespace).Delete(context.Background(), ss.Name, metav1.DeleteOptions{})
+		})
+
+		err = WaitForStatefulSetReady(ctx, kind.client, ss.Namespace, ss.Name)
+		assert.NilError(t, err)
+
+		name := kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original
+		err = p.InstanceStart(ctx, name)
+		assert.NilError(t, err)
+
+		updated, err := kind.client.AppsV1().StatefulSets(ss.Namespace).Get(ctx, ss.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
+		expectedCPU := resource.MustParse("200m")
+		expectedMem := resource.MustParse("128Mi")
+		cpuLimit := limits[corev1.ResourceCPU]
+		memLimit := limits[corev1.ResourceMemory]
+		assert.Assert(t, cpuLimit.Cmp(expectedCPU) == 0,
+			"expected CPU limit 200m, got %s", cpuLimit.String())
+		assert.Assert(t, memLimit.Cmp(expectedMem) == 0,
+			"expected memory limit 128Mi, got %s", memLimit.String())
+	})
+}
 
 func TestKubernetesProvider_InstanceStart(t *testing.T) {
 	if testing.Short() {

--- a/pkg/provider/kubernetes/instance_stop.go
+++ b/pkg/provider/kubernetes/instance_stop.go
@@ -1,11 +1,31 @@
 package kubernetes
 
-import "context"
+import (
+	"context"
+	"log/slog"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
 
 func (p *Provider) InstanceStop(ctx context.Context, name string) error {
 	parsed, err := ParseName(name, ParseOptions{Delimiter: p.delimiter})
 	if err != nil {
 		return err
+	}
+
+	labels, err := p.getWorkloadLabels(ctx, parsed)
+	if err != nil {
+		return err
+	}
+
+	sc := sablier.ScaleConfigFromLabels(labels)
+	if sc != nil && (sc.Idle.CPU != "" || sc.Idle.Memory != "") {
+		p.l.DebugContext(ctx, "applying idle resources (scale mode)",
+			slog.String("name", name),
+			slog.String("cpu", sc.Idle.CPU),
+			slog.String("memory", sc.Idle.Memory),
+		)
+		return p.scaleResources(ctx, parsed, sc.Idle.CPU, sc.Idle.Memory)
 	}
 
 	return p.scale(ctx, parsed, 0)

--- a/pkg/provider/kubernetes/instance_stop_test.go
+++ b/pkg/provider/kubernetes/instance_stop_test.go
@@ -9,8 +9,92 @@ import (
 	"github.com/sablierapp/sablier/pkg/config"
 	"github.com/sablierapp/sablier/pkg/provider/kubernetes"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestKubernetesProvider_InstanceStop_ScaleMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	kind := sharedKinD
+	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+	assert.NilError(t, err)
+
+	t.Run("deployment scale mode idle resources applied", func(t *testing.T) {
+		t.Parallel()
+
+		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{
+			Labels: map[string]string{
+				"sablier.idle.cpu":    "100m",
+				"sablier.idle.memory": "64Mi",
+			},
+		})
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = kind.client.AppsV1().Deployments(d.Namespace).Delete(context.Background(), d.Name, metav1.DeleteOptions{})
+		})
+
+		err = WaitForDeploymentReady(ctx, kind.client, d.Namespace, d.Name)
+		assert.NilError(t, err)
+
+		name := kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original
+		err = p.InstanceStop(ctx, name)
+		assert.NilError(t, err)
+
+		updated, err := kind.client.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
+		expectedCPU := resource.MustParse("100m")
+		expectedMem := resource.MustParse("64Mi")
+		cpuLimit := limits[corev1.ResourceCPU]
+		memLimit := limits[corev1.ResourceMemory]
+		assert.Assert(t, cpuLimit.Cmp(expectedCPU) == 0,
+			"expected CPU limit 100m, got %s", cpuLimit.String())
+		assert.Assert(t, memLimit.Cmp(expectedMem) == 0,
+			"expected memory limit 64Mi, got %s", memLimit.String())
+	})
+
+	t.Run("statefulset scale mode idle resources applied", func(t *testing.T) {
+		t.Parallel()
+
+		ss, err := kind.CreateMimicStatefulSet(ctx, MimicOptions{
+			Labels: map[string]string{
+				"sablier.idle.cpu":    "100m",
+				"sablier.idle.memory": "64Mi",
+			},
+		})
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = kind.client.AppsV1().StatefulSets(ss.Namespace).Delete(context.Background(), ss.Name, metav1.DeleteOptions{})
+		})
+
+		err = WaitForStatefulSetReady(ctx, kind.client, ss.Namespace, ss.Name)
+		assert.NilError(t, err)
+
+		name := kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original
+		err = p.InstanceStop(ctx, name)
+		assert.NilError(t, err)
+
+		updated, err := kind.client.AppsV1().StatefulSets(ss.Namespace).Get(ctx, ss.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
+		expectedCPU := resource.MustParse("100m")
+		expectedMem := resource.MustParse("64Mi")
+		cpuLimit := limits[corev1.ResourceCPU]
+		memLimit := limits[corev1.ResourceMemory]
+		assert.Assert(t, cpuLimit.Cmp(expectedCPU) == 0,
+			"expected CPU limit 100m, got %s", cpuLimit.String())
+		assert.Assert(t, memLimit.Cmp(expectedMem) == 0,
+			"expected memory limit 64Mi, got %s", memLimit.String())
+	})
+}
 
 func TestKubernetesProvider_InstanceStop(t *testing.T) {
 	if testing.Short() {

--- a/pkg/provider/kubernetes/resource_scale.go
+++ b/pkg/provider/kubernetes/resource_scale.go
@@ -1,0 +1,141 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// buildResourcePatch creates a strategic-merge-patch JSON document that sets
+// the resource limits on the first container (identified by containerName) of a
+// pod template. Only the fields present in cpu/memory are included.
+func buildResourcePatch(containerName, cpu, memory string) ([]byte, error) {
+	limits := corev1.ResourceList{}
+
+	if cpu != "" {
+		q, err := resource.ParseQuantity(cpu)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CPU value %q: %w", cpu, err)
+		}
+		limits[corev1.ResourceCPU] = q
+	}
+
+	if memory != "" {
+		q, err := resource.ParseQuantity(memory)
+		if err != nil {
+			return nil, fmt.Errorf("invalid memory value %q: %w", memory, err)
+		}
+		limits[corev1.ResourceMemory] = q
+	}
+
+	patch := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{
+						{
+							"name": containerName,
+							"resources": map[string]interface{}{
+								"limits": limits,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return json.Marshal(patch)
+}
+
+// scaleResources patches the resource limits of the first container in a
+// deployment or statefulset without changing the replica count.
+func (p *Provider) scaleResources(ctx context.Context, config ParsedName, cpu, memory string) error {
+	switch config.Kind {
+	case "deployment":
+		return p.scaleDeploymentResources(ctx, config, cpu, memory)
+	case "statefulset":
+		return p.scaleStatefulSetResources(ctx, config, cpu, memory)
+	default:
+		return fmt.Errorf("unsupported kind %q for resource scaling", config.Kind)
+	}
+}
+
+func (p *Provider) scaleDeploymentResources(ctx context.Context, config ParsedName, cpu, memory string) error {
+	d, err := p.Client.AppsV1().Deployments(config.Namespace).Get(ctx, config.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot get deployment: %w", err)
+	}
+
+	if len(d.Spec.Template.Spec.Containers) == 0 {
+		return fmt.Errorf("deployment %s/%s has no containers", config.Namespace, config.Name)
+	}
+
+	patchData, err := buildResourcePatch(d.Spec.Template.Spec.Containers[0].Name, cpu, memory)
+	if err != nil {
+		return err
+	}
+
+	_, err = p.Client.AppsV1().Deployments(config.Namespace).Patch(
+		ctx, config.Name, types.StrategicMergePatchType, patchData, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot patch deployment resources: %w", err)
+	}
+	return nil
+}
+
+func (p *Provider) scaleStatefulSetResources(ctx context.Context, config ParsedName, cpu, memory string) error {
+	ss, err := p.Client.AppsV1().StatefulSets(config.Namespace).Get(ctx, config.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot get statefulset: %w", err)
+	}
+
+	if len(ss.Spec.Template.Spec.Containers) == 0 {
+		return fmt.Errorf("statefulset %s/%s has no containers", config.Namespace, config.Name)
+	}
+
+	patchData, err := buildResourcePatch(ss.Spec.Template.Spec.Containers[0].Name, cpu, memory)
+	if err != nil {
+		return err
+	}
+
+	_, err = p.Client.AppsV1().StatefulSets(config.Namespace).Patch(
+		ctx, config.Name, types.StrategicMergePatchType, patchData, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot patch statefulset resources: %w", err)
+	}
+	return nil
+}
+
+// getWorkloadLabels retrieves the labels of a deployment or statefulset.
+func (p *Provider) getWorkloadLabels(ctx context.Context, config ParsedName) (map[string]string, error) {
+	switch config.Kind {
+	case "deployment":
+		d, err := p.Client.AppsV1().Deployments(config.Namespace).Get(ctx, config.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		if d.Labels == nil {
+			return map[string]string{}, nil
+		}
+		return d.Labels, nil
+	case "statefulset":
+		ss, err := p.Client.AppsV1().StatefulSets(config.Namespace).Get(ctx, config.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		if ss.Labels == nil {
+			return map[string]string{}, nil
+		}
+		return ss.Labels, nil
+	default:
+		return nil, fmt.Errorf("unsupported kind %q", config.Kind)
+	}
+}

--- a/pkg/provider/kubernetes/resource_scale_test.go
+++ b/pkg/provider/kubernetes/resource_scale_test.go
@@ -1,13 +1,16 @@
 package kubernetes
 
-// Unit tests for buildResourcePatch.
+// Unit tests for buildResourcePatch and resource scaling helpers.
 // These run without a real Kubernetes cluster.
 
 import (
+	"context"
 	"encoding/json"
+	"log/slog"
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestBuildResourcePatch_CPUAndMemory(t *testing.T) {
@@ -62,4 +65,24 @@ func TestBuildResourcePatch_InvalidCPU(t *testing.T) {
 func TestBuildResourcePatch_InvalidMemory(t *testing.T) {
 	_, err := buildResourcePatch("app", "", "bad-memory")
 	assert.Assert(t, err != nil, "expected error for invalid memory")
+}
+
+func newFakeProvider() *Provider {
+	return &Provider{
+		Client:    fake.NewSimpleClientset(),
+		delimiter: "_",
+		l:         slog.Default(),
+	}
+}
+
+func TestScaleResources_UnsupportedKind(t *testing.T) {
+	p := newFakeProvider()
+	err := p.scaleResources(context.Background(), ParsedName{Kind: "daemonset"}, "100m", "")
+	assert.ErrorContains(t, err, "unsupported kind")
+}
+
+func TestGetWorkloadLabels_UnsupportedKind(t *testing.T) {
+	p := newFakeProvider()
+	_, err := p.getWorkloadLabels(context.Background(), ParsedName{Kind: "daemonset"})
+	assert.ErrorContains(t, err, "unsupported kind")
 }

--- a/pkg/provider/kubernetes/resource_scale_test.go
+++ b/pkg/provider/kubernetes/resource_scale_test.go
@@ -1,0 +1,65 @@
+package kubernetes
+
+// Unit tests for buildResourcePatch.
+// These run without a real Kubernetes cluster.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBuildResourcePatch_CPUAndMemory(t *testing.T) {
+	data, err := buildResourcePatch("mycontainer", "500m", "128Mi")
+	assert.NilError(t, err)
+
+	var doc map[string]interface{}
+	assert.NilError(t, json.Unmarshal(data, &doc))
+
+	spec := doc["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	podSpec := template["spec"].(map[string]interface{})
+	containers := podSpec["containers"].([]interface{})
+	assert.Equal(t, len(containers), 1)
+
+	c := containers[0].(map[string]interface{})
+	assert.Equal(t, c["name"].(string), "mycontainer")
+
+	resources := c["resources"].(map[string]interface{})
+	limits := resources["limits"].(map[string]interface{})
+	assert.Equal(t, limits["cpu"].(string), "500m")
+	assert.Equal(t, limits["memory"].(string), "128Mi")
+}
+
+func TestBuildResourcePatch_CPUOnly(t *testing.T) {
+	data, err := buildResourcePatch("app", "0.5", "")
+	assert.NilError(t, err)
+
+	var doc map[string]interface{}
+	assert.NilError(t, json.Unmarshal(data, &doc))
+
+	spec := doc["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	podSpec := template["spec"].(map[string]interface{})
+	containers := podSpec["containers"].([]interface{})
+	c := containers[0].(map[string]interface{})
+	resources := c["resources"].(map[string]interface{})
+	limits := resources["limits"].(map[string]interface{})
+
+	// CPU should be set, memory should not appear in the patch
+	_, hasCPU := limits["cpu"]
+	assert.Assert(t, hasCPU, "cpu should be in limits")
+	_, hasMemory := limits["memory"]
+	assert.Assert(t, !hasMemory, "memory should not appear when empty")
+}
+
+func TestBuildResourcePatch_InvalidCPU(t *testing.T) {
+	_, err := buildResourcePatch("app", "bad-cpu", "")
+	assert.Assert(t, err != nil, "expected error for invalid CPU")
+}
+
+func TestBuildResourcePatch_InvalidMemory(t *testing.T) {
+	_, err := buildResourcePatch("app", "", "bad-memory")
+	assert.Assert(t, err != nil, "expected error for invalid memory")
+}

--- a/pkg/provider/podman/container_start_test.go
+++ b/pkg/provider/podman/container_start_test.go
@@ -32,7 +32,7 @@ func TestPodmanProvider_Start(t *testing.T) {
 					return "non-existent", nil
 				},
 			},
-			err: fmt.Errorf("cannot start container non-existent"),
+			err: fmt.Errorf("cannot inspect container"),
 		},
 		{
 			name: "container start as expected",

--- a/pkg/provider/podman/container_stop_test.go
+++ b/pkg/provider/podman/container_stop_test.go
@@ -33,7 +33,7 @@ func TestPodmanProvider_Stop(t *testing.T) {
 					return "non-existent", nil
 				},
 			},
-			err: fmt.Errorf("cannot stop container non-existent"),
+			err: fmt.Errorf("cannot inspect container"),
 		},
 		{
 			name: "container stop as expected",

--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -49,6 +49,27 @@ type InstanceInfo struct {
 	// RunningHours is a daily keep-warm window in local time, parsed from
 	// the sablier.running-hours label (format: HH:MM-HH:MM).
 	RunningHours string `json:"runningHours,omitempty"`
+
+	// ScaleConfig configures resource-based scale mode for this instance.
+	// When present, Sablier throttles CPU/memory instead of stopping the container.
+	ScaleConfig *ScaleConfig `json:"scaleConfig,omitempty"`
+}
+
+// ScaleConfig defines the idle and active resource profiles used in scale mode.
+// In scale mode, the container keeps running but its resources are adjusted:
+// idle resources are applied when the session expires, active resources when
+// a new session is requested.
+type ScaleConfig struct {
+	Idle   ResourceProfile `json:"idle,omitempty"`
+	Active ResourceProfile `json:"active,omitempty"`
+}
+
+// ResourceProfile holds the CPU and memory limits for a single resource profile.
+type ResourceProfile struct {
+	// CPU is the CPU limit (e.g. "0.5" for Docker/Swarm, "500m" for Kubernetes).
+	CPU string `json:"cpu,omitempty"`
+	// Memory is the memory limit (e.g. "128m" for Docker/Swarm, "128Mi" for Kubernetes).
+	Memory string `json:"memory,omitempty"`
 }
 
 type InstanceConfiguration struct {
@@ -65,6 +86,24 @@ func (instance InstanceInfo) IsReady() bool {
 		return true
 	}
 	return time.Since(*instance.ReadyAt) >= instance.ReadyAfter
+}
+
+// ScaleConfigFromLabels extracts a ScaleConfig from the given label map.
+// Returns nil if none of the scale labels (sablier.idle.cpu, sablier.idle.memory,
+// sablier.active.cpu, sablier.active.memory) are present.
+func ScaleConfigFromLabels(labels map[string]string) *ScaleConfig {
+	idle := ResourceProfile{
+		CPU:    labels["sablier.idle.cpu"],
+		Memory: labels["sablier.idle.memory"],
+	}
+	active := ResourceProfile{
+		CPU:    labels["sablier.active.cpu"],
+		Memory: labels["sablier.active.memory"],
+	}
+	if idle.CPU == "" && idle.Memory == "" && active.CPU == "" && active.Memory == "" {
+		return nil
+	}
+	return &ScaleConfig{Idle: idle, Active: active}
 }
 
 // PopulateEnabledAndGroup reads the sablier.enable and sablier.group labels from
@@ -101,4 +140,5 @@ func PopulateEnabledAndGroup(info *InstanceInfo, labels map[string]string) {
 			)
 		}
 	}
+	info.ScaleConfig = ScaleConfigFromLabels(labels)
 }

--- a/pkg/sablier/scale_test.go
+++ b/pkg/sablier/scale_test.go
@@ -1,0 +1,80 @@
+package sablier_test
+
+import (
+	"testing"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestScaleConfigFromLabels_NoLabels(t *testing.T) {
+	got := sablier.ScaleConfigFromLabels(map[string]string{})
+	assert.Assert(t, got == nil)
+}
+
+func TestScaleConfigFromLabels_UnrelatedLabels(t *testing.T) {
+	labels := map[string]string{
+		"sablier.enable": "true",
+		"sablier.group":  "mygroup",
+	}
+	got := sablier.ScaleConfigFromLabels(labels)
+	assert.Assert(t, got == nil)
+}
+
+func TestScaleConfigFromLabels_IdleCPUOnly(t *testing.T) {
+	labels := map[string]string{
+		"sablier.idle.cpu": "0.1",
+	}
+	got := sablier.ScaleConfigFromLabels(labels)
+	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
+		Idle:   sablier.ResourceProfile{CPU: "0.1"},
+		Active: sablier.ResourceProfile{},
+	}))
+}
+
+func TestScaleConfigFromLabels_AllLabels(t *testing.T) {
+	labels := map[string]string{
+		"sablier.idle.cpu":    "0.1",
+		"sablier.idle.memory": "128m",
+		"sablier.active.cpu":  "2.0",
+		"sablier.active.memory": "1g",
+	}
+	got := sablier.ScaleConfigFromLabels(labels)
+	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
+		Idle:   sablier.ResourceProfile{CPU: "0.1", Memory: "128m"},
+		Active: sablier.ResourceProfile{CPU: "2.0", Memory: "1g"},
+	}))
+}
+
+func TestPopulateEnabledAndGroup_WithScaleLabels(t *testing.T) {
+	info := sablier.InstanceInfo{Name: "my-service"}
+	labels := map[string]string{
+		"sablier.enable":      "true",
+		"sablier.group":       "backend",
+		"sablier.idle.cpu":    "0.25",
+		"sablier.idle.memory": "64m",
+		"sablier.active.cpu":  "1.0",
+	}
+
+	sablier.PopulateEnabledAndGroup(&info, labels)
+
+	assert.Equal(t, info.Enabled, "true")
+	assert.Equal(t, info.Group, "backend")
+	assert.Assert(t, info.ScaleConfig != nil, "ScaleConfig should be populated")
+	assert.Equal(t, info.ScaleConfig.Idle.CPU, "0.25")
+	assert.Equal(t, info.ScaleConfig.Idle.Memory, "64m")
+	assert.Equal(t, info.ScaleConfig.Active.CPU, "1.0")
+	assert.Equal(t, info.ScaleConfig.Active.Memory, "")
+}
+
+func TestPopulateEnabledAndGroup_NoScaleLabels(t *testing.T) {
+	info := sablier.InstanceInfo{Name: "my-service"}
+	labels := map[string]string{
+		"sablier.enable": "true",
+	}
+
+	sablier.PopulateEnabledAndGroup(&info, labels)
+
+	assert.Assert(t, info.ScaleConfig == nil, "ScaleConfig should be nil when no scale labels")
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,7 @@
 sonar.organization=sablierapp
 sonar.projectKey=sablierapp_sablier
+sonar.sources=.
+sonar.tests=.
 sonar.coverage.exclusions=**/*_test.go,**/apitest/**,**/providertest/**,**/storetest/**
-sonar.exclusions=**/*_test.go,**/apitest/**,**/providertest/**,**/storetest/**
+sonar.exclusions=**/apitest/**,**/providertest/**,**/storetest/**
 sonar.go.coverage.reportPaths=coverage.out

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,5 @@
 sonar.organization=sablierapp
 sonar.projectKey=sablierapp_sablier
-sonar.sources=.
-sonar.tests=.
-sonar.test.inclusions=**/*_test.go
 sonar.coverage.exclusions=**/*_test.go,**/apitest/**,**/providertest/**,**/storetest/**
-sonar.exclusions=**/*_test.go,**/apitest/**,**/providertest/**,**/storetest/**,**/*.png,**/*.jpg,**/*.jpeg,**/*.gif,**/*.ico,**/*.svg
+sonar.exclusions=**/*_test.go,**/apitest/**,**/providertest/**,**/storetest/**
 sonar.go.coverage.reportPaths=coverage.out

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,7 @@
 sonar.organization=sablierapp
 sonar.projectKey=sablierapp_sablier
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
 sonar.coverage.exclusions=**/*_test.go,**/apitest/**,**/providertest/**,**/storetest/**
-sonar.exclusions=**/*_test.go,**/apitest/**,**/providertest/**,**/storetest/**
-sonar.go.coverage.reportPaths=coverage.txt
+sonar.exclusions=**/*_test.go,**/apitest/**,**/providertest/**,**/storetest/**,**/*.png,**/*.jpg,**/*.jpeg,**/*.gif,**/*.ico,**/*.svg
+sonar.go.coverage.reportPaths=coverage.out

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.organization=sablierapp
 sonar.projectKey=sablierapp_sablier
+sonar.sources=.
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.coverage.exclusions=**/*_test.go,**/apitest/**,**/providertest/**,**/storetest/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.organization=sablierapp
 sonar.projectKey=sablierapp_sablier
 sonar.sources=.
 sonar.tests=.
+sonar.test.inclusions=**/*_test.go
 sonar.coverage.exclusions=**/*_test.go,**/apitest/**,**/providertest/**,**/storetest/**
 sonar.exclusions=**/apitest/**,**/providertest/**,**/storetest/**
 sonar.go.coverage.reportPaths=coverage.out


### PR DESCRIPTION
## What is scale mode?

Scale mode is a new alternative to the default stop/start lifecycle. Instead of shutting down a container when a session expires, Sablier **throttles its CPU and memory** to a configurable idle profile. When a new session arrives the resources are restored immediately — **no container restart, no cold-start latency**.

It is related a bit related to https://github.com/sablierapp/sablier/issues/882 but it does not really implement the feature

## How to enable it

Add the four new instance labels to your container/service/workload:

| Label | Description |
|---|---|
| `sablier.idle.cpu` | CPU limit applied when the session expires |
| `sablier.idle.memory` | Memory limit applied when the session expires |
| `sablier.active.cpu` | CPU limit restored when a new session is requested |
| `sablier.active.memory` | Memory limit restored when a new session is requested |

You can set any subset of the four labels. A missing label means "no limit".

### Docker / Podman (Compose example)

```yaml
services:
  myapp:
    image: myapp:latest
    labels:
      - "sablier.enable=true"
      - "sablier.group=myapp"
      - "sablier.idle.cpu=0.1"
      - "sablier.idle.memory=64m"
      - "sablier.active.cpu=2.0"
      - "sablier.active.memory=512m"
```

CPU values are decimal fractions of one core (`0.5` = half a core). Memory values use Docker-style suffixes (`b`, `k`, `m`, `g`).

> **Note:** When a memory label is set, Sablier also updates `MemorySwap` to the same value in the same `docker update` call. This satisfies Docker's `memswap_limit ≥ memory` constraint and effectively disables swap for the container.

### Docker Swarm

```yaml
services:
  myapp:
    image: myapp:latest
    deploy:
      labels:
        - "sablier.enable=true"
        - "sablier.group=myapp"
        - "sablier.idle.cpu=0.1"
        - "sablier.idle.memory=64m"
        - "sablier.active.cpu=2.0"
        - "sablier.active.memory=512m"
```

### Kubernetes (Deployment)

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: myapp
  labels:
    sablier.enable: "true"
    sablier.group: myapp
    sablier.idle.cpu: "100m"
    sablier.idle.memory: "64Mi"
    sablier.active.cpu: "2000m"
    sablier.active.memory: "512Mi"
```

Kubernetes uses standard quantity notation (`100m` = 0.1 core, `64Mi` = 64 mebibytes). Resource limit changes trigger a rolling restart — the service stays available during the transition.

> **Note:** Proxmox LXC is not supported (uses tag-based configuration rather than key-value labels).

## Try the example

```bash
cd examples/scale-mode
make up    # start Sablier + whoami
make demo  # trigger a session, wait for expiry, watch resources throttle
make down
```

## What changed

### Core
- `pkg/sablier/instance.go` — new `ScaleConfig` / `ResourceProfile` types; `ScaleConfigFromLabels()` helper; `PopulateEnabledAndGroup` now populates `ScaleConfig`

### Providers
- **Docker** — `container_scale.go` (new); `container_stop.go` / `container_start.go` check for scale labels before stopping/starting
- **Docker Swarm** — `service_scale.go` (new); `service_stop.go` / `service_start.go` updated
- **Kubernetes** — `resource_scale.go` (new, strategic-merge-patch approach); `instance_stop.go` / `instance_start.go` updated
- **Podman** — inherits Docker automatically (wraps Docker provider)

### Tests
- Unit tests for CPU/memory parsers (Docker, Swarm)
- Unit tests for Kubernetes strategic-merge-patch builder
- Unit tests for `ScaleConfigFromLabels` and `PopulateEnabledAndGroup`
- Integration tests (dind) for Docker scale stop/start

### Docs
- `docs/configuration.md` — new Scale Mode section with per-provider examples
- `examples/scale-mode/` — runnable Docker Compose example