### PR TITLE
feat: add replica count to scale mode, gate resource throttling on idle.replicas >= 1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,11 @@ jobs:
 
     - name: Test
       id: test
-      env:
-        GOCOVERDIR: /tmp/gocov
       run: |
         # gotestsum reruns failing tests with --rerun-fails; when using
         # -coverprofile this can overwrite the full-suite profile with a
-        # rerun-only profile. We collect coverage in GOCOVERDIR and merge it
-        # afterwards to keep stable aggregate coverage across reruns.
+        # rerun-only profile. We write binary coverage with -test.gocoverdir
+        # and merge it afterwards to keep stable aggregate coverage across reruns.
         # See: https://github.com/gotestyourself/gotestsum/issues/274
         mkdir -p /tmp/gocov
         go tool -modfile=tools.mod gotestsum \
@@ -57,7 +55,7 @@ jobs:
           --rerun-fails-max-failures=10 \
           --packages="./..." \
           --post-run-command .github/scripts/test-summary.sh \
-          -- -tags="nomsgpack" -race -covermode=atomic -cover ./...
+          -- -tags="nomsgpack" -race -covermode=atomic -cover ./... -args -test.gocoverdir=/tmp/gocov
 
     - name: Generate coverage report
       if: ${{ !cancelled() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,15 @@ jobs:
 
     - name: Test
       id: test
+      env:
+        GOCOVERDIR: /tmp/gocov
       run: |
+        # gotestsum reruns failing tests with --rerun-fails; when using
+        # -coverprofile this can overwrite the full-suite profile with a
+        # rerun-only profile. We collect coverage in GOCOVERDIR and merge it
+        # afterwards to keep stable aggregate coverage across reruns.
+        # See: https://github.com/gotestyourself/gotestsum/issues/274
+        mkdir -p /tmp/gocov
         go tool -modfile=tools.mod gotestsum \
           --jsonfile test-report.json \
           --format testname \
@@ -49,7 +57,11 @@ jobs:
           --rerun-fails-max-failures=10 \
           --packages="./..." \
           --post-run-command .github/scripts/test-summary.sh \
-          -- -tags="nomsgpack" -race -covermode atomic -coverprofile=coverage.out ./...
+          -- -tags="nomsgpack" -race -covermode=atomic -cover ./...
+
+    - name: Generate coverage report
+      if: ${{ !cancelled() }}
+      run: go tool covdata textfmt -i=/tmp/gocov -o=coverage.out
 
     - name: Generate HTML test report
       if: ${{ !cancelled() }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,10 +20,12 @@ Instance labels are applied directly to your containers or workloads. They contr
 | `sablier.group` | No | `"myapp"` | Assign the instance to a named group. Defaults to `"default"` when `sablier.enable=true` and no group is set. |
 | `sablier.ready-after` | No | `"30s"` | Minimum duration to wait after the instance first reports ready before Sablier considers it truly ready. Accepts any Go duration string (`"500ms"`, `"1m30s"`, …). Useful for services that are started or pass their health check before they can actually serve traffic. |
 | `sablier.running-hours` | No | `"09:00-18:00"` | Daily keep-warm window in local time (`HH:MM-HH:MM`). Sablier starts the instance at window start and keeps it running until window end. Overnight windows like `"22:00-06:00"` are supported. |
-| `sablier.idle.cpu` | No | `"0.1"` | CPU limit applied when the session expires (scale mode). Container keeps running with throttled CPU. |
-| `sablier.idle.memory` | No | `"128m"` | Memory limit applied when the session expires (scale mode). |
+| `sablier.idle.cpu` | No | `"0.1"` | CPU limit applied when the session expires (scale mode). Requires `sablier.idle.replicas >= 1`. |
+| `sablier.idle.memory` | No | `"128m"` | Memory limit applied when the session expires (scale mode). Requires `sablier.idle.replicas >= 1`. |
+| `sablier.idle.replicas` | No | `"1"` | Replica count when idle. Default `0` (stop the workload). Set to `1` or higher to keep the workload running and optionally throttle its resources. |
 | `sablier.active.cpu` | No | `"2.0"` | CPU limit restored when a new session is requested (scale mode). |
 | `sablier.active.memory` | No | `"512m"` | Memory limit restored when a new session is requested (scale mode). |
+| `sablier.active.replicas` | No | `"1"` | Replica count when active. Default `1`. Increase when you need more replicas on wake-up. |
 
 ### `sablier.ready-after`
 
@@ -90,16 +92,22 @@ Running-hours are evaluated in the process local timezone.
 
 ### Scale Mode
 
-Scale mode is an alternative to stopping containers. Instead of shutting down and restarting the container, Sablier **throttles its CPU and memory** when the session expires and **restores them** when a new session is requested. The container keeps running the entire time, which eliminates cold-start latency.
+Scale mode is an alternative to stopping containers. Instead of shutting down and restarting the workload, Sablier **scales down the replica count** when the session expires and **restores it** when a new session is requested.
 
-| Label | Format | Example |
-|-------|--------|---------|
-| `sablier.idle.cpu` | Decimal cores (Docker/Swarm) or Kubernetes quantity | `"0.1"`, `"500m"` |
-| `sablier.idle.memory` | Docker units or Kubernetes quantity | `"64m"`, `"128Mi"` |
-| `sablier.active.cpu` | Decimal cores (Docker/Swarm) or Kubernetes quantity | `"2.0"`, `"2000m"` |
-| `sablier.active.memory` | Docker units or Kubernetes quantity | `"512m"`, `"1Gi"` |
+Optionally, when `sablier.idle.replicas >= 1`, the workload **keeps running** at the idle replica count with **throttled CPU and memory**, and resources are **restored** when a new session arrives. This eliminates cold-start latency at the cost of keeping the workload alive.
 
-You can set any combination of the four labels. Labels not set default to 0 (no limit).
+| Label | Format | Default | Example |
+|-------|--------|---------|----------|
+| `sablier.idle.replicas` | Integer | `0` (stop) | `"1"` |
+| `sablier.idle.cpu` | Decimal cores (Docker/Swarm) or Kubernetes quantity | — | `"0.1"`, `"500m"` |
+| `sablier.idle.memory` | Docker units or Kubernetes quantity | — | `"64m"`, `"128Mi"` |
+| `sablier.active.replicas` | Integer | `1` | `"2"` |
+| `sablier.active.cpu` | Decimal cores (Docker/Swarm) or Kubernetes quantity | — | `"2.0"`, `"2000m"` |
+| `sablier.active.memory` | Docker units or Kubernetes quantity | — | `"512m"`, `"1Gi"` |
+
+When `sablier.idle.replicas` is `0` (the default), Sablier stops the workload on session expiry and restarts it on demand — identical to the default stop behavior, but configured via scale-mode labels. Set it to `1` or higher to keep the workload running with optional resource throttling.
+
+You can set any combination of the CPU and memory labels. Labels not set default to no limit (no throttling applied).
 
 **Supported providers:** Docker, Docker Swarm, Kubernetes (Deployments and StatefulSets), Podman.
 
@@ -116,19 +124,40 @@ services:
     labels:
       - "sablier.enable=true"
       - "sablier.group=myapp"
+      - "sablier.idle.replicas=1"
       - "sablier.idle.cpu=0.1"
       - "sablier.idle.memory=64m"
+      - "sablier.active.replicas=1"
       - "sablier.active.cpu=2.0"
       - "sablier.active.memory=512m"
 ```
 
-When the session expires, Sablier runs the equivalent of `docker update --cpus=0.1 --memory=64m myapp`. When a new session is requested, it restores `--cpus=2.0 --memory=512m`. The container is never stopped.
+When the session expires, Sablier sets the replica count to `sablier.idle.replicas` (≥ 1 keeps the container running) and runs the equivalent of `docker update --cpus=0.1 --memory=64m myapp`. When a new session is requested, it restores `--cpus=2.0 --memory=512m`. The container is never stopped.
 
 > **Note:** Docker requires the memory swap limit to be updated in the same call as the memory limit. Sablier sets `MemorySwap` equal to `Memory` automatically, which satisfies the constraint and disables swap for the container.
 
 #### Docker Swarm
 
-Same format as Docker. Resource constraints are applied to the service's task template, triggering a Swarm service update (tasks are re-scheduled with the new limits).
+CPU and memory values use the same format as Docker. Resource constraints are applied to the service's task template, triggering a Swarm service update (tasks are re-scheduled with the new limits).
+
+```yaml
+services:
+  myapp:
+    image: myapp:latest
+    deploy:
+      replicas: 1
+      labels:
+        - "sablier.enable=true"
+        - "sablier.group=myapp"
+        - "sablier.idle.replicas=1"
+        - "sablier.idle.cpu=0.1"
+        - "sablier.idle.memory=64m"
+        - "sablier.active.replicas=1"
+        - "sablier.active.cpu=2.0"
+        - "sablier.active.memory=512m"
+```
+
+> **Note:** In Docker Swarm, labels that control Sablier must be placed under `deploy.labels`, not the top-level `labels` key, so that they are attached to the service rather than the container.
 
 #### Kubernetes
 
@@ -142,8 +171,10 @@ metadata:
   labels:
     sablier.enable: "true"
     sablier.group: myapp
+    sablier.idle.replicas: "1"
     sablier.idle.cpu: "100m"
     sablier.idle.memory: "64Mi"
+    sablier.active.replicas: "1"
     sablier.active.cpu: "2000m"
     sablier.active.memory: "512Mi"
 ```

--- a/examples/scale-mode/README.md
+++ b/examples/scale-mode/README.md
@@ -1,11 +1,51 @@
 # Scale Mode Example
 
-This example demonstrates Sablier's **scale mode**: instead of stopping containers when sessions expire, Sablier throttles their CPU and memory. When a new session is requested, resources are restored and the container is immediately available — no cold-start wait.
+This example demonstrates Sablier's **scale mode**: instead of stopping containers when sessions expire, Sablier scales down the replica count (and optionally throttles CPU/memory). When a new session is requested, replicas and resources are restored.
 
 ## How It Works
 
-1. **Session expires** → Sablier runs `docker update --cpus=0.1 --memory=64m whoami`. Container stays running, using minimal resources.
-2. **New request arrives** → Sablier runs `docker update --cpus=2.0 --memory=512m whoami`. Resources are restored. The container is immediately ready (no restart needed).
+Scale mode is controlled by two pairs of labels: `sablier.idle.*` (applied on session expiry) and `sablier.active.*` (applied when a session is requested).
+
+The **replica count** is the primary control:
+
+| `sablier.idle.replicas` | Behaviour on session expiry |
+|-------------------------|-----------------------------|
+| `0` (default) | Workload is **stopped** (same as without scale mode) |
+| `1` or more | Workload **keeps running** at the given replica count |
+
+CPU and memory throttling only activates when `sablier.idle.replicas >= 1`. If you only set `sablier.idle.cpu` or `sablier.idle.memory` without also setting `sablier.idle.replicas=1`, no throttling is applied.
+
+### This example (throttle, don't stop)
+
+1. **Session expires** → replicas stay at 1, CPU is throttled to 0.1 core and memory to 64 MB.
+2. **New request arrives** → replicas stay at 1, CPU is restored to 2.0 cores and memory to 512 MB. Container is immediately ready — no restart needed.
+
+### Scaling to more than 1 replica
+
+You can set `sablier.active.replicas` to any value your infrastructure supports. For example, to run 3 active replicas on Docker Swarm:
+
+```yaml
+deploy:
+  labels:
+    - "sablier.enable=true"
+    - "sablier.group=myapp"
+    - "sablier.idle.replicas=1"    # keep 1 replica alive when idle
+    - "sablier.idle.cpu=0.1"
+    - "sablier.idle.memory=64m"
+    - "sablier.active.replicas=3"  # scale up to 3 when a session is requested
+    - "sablier.active.cpu=2.0"
+    - "sablier.active.memory=512m"
+```
+
+Or simply scale replicas without any CPU/memory throttling:
+
+```yaml
+labels:
+  - "sablier.enable=true"
+  - "sablier.group=myapp"
+  - "sablier.idle.replicas=1"   # keep running at 1 replica when idle
+  - "sablier.active.replicas=3" # scale up to 3 on demand
+```
 
 ## Running the Example
 
@@ -26,7 +66,7 @@ make down
 docker compose up -d
 
 # Request a session (blocks until whoami is ready, then returns)
-curl 'http://localhost:10000/api/strategies/blocking?names=whoami&timeout=30s'
+curl 'http://localhost:10000/api/strategies/blocking?group=whoami&timeout=30s'
 
 # Inspect current CPU/memory limits (should be active: ~2 000 000 000 nanocores)
 docker inspect scale-mode-whoami-1 --format '{{.HostConfig.NanoCPUs}} nanocores'
@@ -40,17 +80,27 @@ docker inspect scale-mode-whoami-1 --format '{{.HostConfig.NanoCPUs}} nanocores'
 
 | Label | Value | Meaning |
 |-------|-------|---------|
-| `sablier.idle.cpu` | `0.1` | 10% of one CPU when idle |
-| `sablier.idle.memory` | `64m` | 64 MB when idle |
-| `sablier.active.cpu` | `2.0` | 2 full CPUs when active |
-| `sablier.active.memory` | `512m` | 512 MB when active |
+| `sablier.idle.replicas` | `1` | Keep 1 replica alive when idle (required to enable resource throttling) |
+| `sablier.idle.cpu` | `0.1` | Throttle to 10% of one CPU when idle |
+| `sablier.idle.memory` | `64m` | Throttle to 64 MB when idle |
+| `sablier.active.replicas` | `1` | Replica count to restore when a session is requested |
+| `sablier.active.cpu` | `2.0` | Restore to 2 full CPUs when active |
+| `sablier.active.memory` | `512m` | Restore to 512 MB when active |
+
+## Breaking Change from Previous Versions
+
+Before this release, adding `sablier.idle.cpu` or `sablier.idle.memory` labels was enough to enable resource throttling. **You must now also set `sablier.idle.replicas=1`** (or higher) to opt into resource throttling mode.
+
+If `sablier.idle.replicas` is absent or `0`, Sablier stops the workload normally regardless of any CPU/memory labels.
+
+**Migration:** add `sablier.idle.replicas=1` to any workload that previously used `sablier.idle.cpu` / `sablier.idle.memory`.
 
 ## Notes
 
-- Scale mode is supported for **Docker**, **Docker Swarm**, **Kubernetes**, and **Podman**.
-- For Kubernetes, a resource limit change triggers a rolling restart. The service stays available during the transition.
-- You can set only some labels (e.g. only `sablier.idle.cpu` without a memory limit). Labels not set default to 0 (unlimited).
+- Scale mode is supported for **Docker**, **Docker Swarm**, **Kubernetes** (Deployments and StatefulSets), and **Podman**.
+- For Kubernetes, replica and resource changes trigger a rolling restart. The service stays available during the transition.
+- CPU/memory labels are optional. You can use replicas alone (no throttling).
 
 ### Memory swap (Docker)
 
-Docker requires the memory swap limit to be updated in the same `docker update` call as the memory limit. Sablier handles this automatically by setting `MemorySwap` equal to `Memory`, which satisfies the constraint and disables swap for the container.
+Docker requires the memory swap limit to be updated in the same `docker update` call as the memory limit. Sablier handles this automatically by setting `MemorySwap` equal to `Memory`, which disables swap for the container.

--- a/examples/scale-mode/compose.yml
+++ b/examples/scale-mode/compose.yml
@@ -21,9 +21,11 @@ services:
       - "sablier.enable=true"
       - "sablier.group=whoami"
       # Idle: throttle to 0.1 CPU and 64 MB when the session expires
+      - "sablier.idle.replicas=1"
       - "sablier.idle.cpu=0.1"
       - "sablier.idle.memory=64m"
       # Active: restore to 2 CPUs and 512 MB when a new session is requested
+      - "sablier.active.replicas=1"
       - "sablier.active.cpu=2.0"
       - "sablier.active.memory=512m"
     ports:

--- a/pkg/provider/docker/container_inspect.go
+++ b/pkg/provider/docker/container_inspect.go
@@ -25,7 +25,7 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 		info = sablier.InstanceInfo{
 			Name:            name,
 			CurrentReplicas: 0,
-			DesiredReplicas: p.desiredReplicas,
+			DesiredReplicas: 1,
 			Status:          sablier.InstanceStatusStarting,
 		}
 	case container.StateRunning:
@@ -35,15 +35,15 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 			case container.Healthy:
 				info = sablier.InstanceInfo{
 					Name:            name,
-					CurrentReplicas: p.desiredReplicas,
-					DesiredReplicas: p.desiredReplicas,
+					CurrentReplicas: 1,
+					DesiredReplicas: 1,
 					Status:          sablier.InstanceStatusReady,
 				}
 			case container.Unhealthy:
 				info = sablier.InstanceInfo{
 					Name:            name,
 					CurrentReplicas: 0,
-					DesiredReplicas: p.desiredReplicas,
+					DesiredReplicas: 1,
 					Status:          sablier.InstanceStatusError,
 					Message:         "container is unhealthy",
 				}
@@ -51,7 +51,7 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 				info = sablier.InstanceInfo{
 					Name:            name,
 					CurrentReplicas: 0,
-					DesiredReplicas: p.desiredReplicas,
+					DesiredReplicas: 1,
 					Status:          sablier.InstanceStatusStarting,
 				}
 			}
@@ -59,8 +59,8 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 			p.l.WarnContext(ctx, "container running without healthcheck, you should define a healthcheck on your container so that Sablier properly detects when the container is ready to handle requests.", slog.String("container", name))
 			info = sablier.InstanceInfo{
 				Name:            name,
-				CurrentReplicas: p.desiredReplicas,
-				DesiredReplicas: p.desiredReplicas,
+				CurrentReplicas: 1,
+				DesiredReplicas: 1,
 				Status:          sablier.InstanceStatusReady,
 			}
 		}
@@ -69,7 +69,7 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 			info = sablier.InstanceInfo{
 				Name:            name,
 				CurrentReplicas: 0,
-				DesiredReplicas: p.desiredReplicas,
+				DesiredReplicas: 1,
 				Status:          sablier.InstanceStatusError,
 				Message:         fmt.Sprintf("container exited with code \"%d\"", spec.Container.State.ExitCode),
 			}
@@ -77,7 +77,7 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 			info = sablier.InstanceInfo{
 				Name:            name,
 				CurrentReplicas: 0,
-				DesiredReplicas: p.desiredReplicas,
+				DesiredReplicas: 1,
 				Status:          sablier.InstanceStatusStopped,
 			}
 		}
@@ -85,7 +85,7 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 		info = sablier.InstanceInfo{
 			Name:            name,
 			CurrentReplicas: 0,
-			DesiredReplicas: p.desiredReplicas,
+			DesiredReplicas: 1,
 			Status:          sablier.InstanceStatusError,
 			Message:         "container in \"dead\" state cannot be restarted",
 		}
@@ -93,7 +93,7 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 		info = sablier.InstanceInfo{
 			Name:            name,
 			CurrentReplicas: 0,
-			DesiredReplicas: p.desiredReplicas,
+			DesiredReplicas: 1,
 			Status:          sablier.InstanceStatusError,
 			Message:         fmt.Sprintf("container status \"%s\" not handled", spec.Container.State.Status),
 		}

--- a/pkg/provider/docker/container_scale_test.go
+++ b/pkg/provider/docker/container_scale_test.go
@@ -24,10 +24,12 @@ func TestDockerScaleMode_Stop(t *testing.T) {
 	// Create a container with idle/active scale labels
 	result, err := c.CreateMimic(ctx, MimicOptions{
 		Labels: map[string]string{
-			"sablier.idle.cpu":    "0.5",
-			"sablier.idle.memory": "128m",
-			"sablier.active.cpu":  "2.0",
-			"sablier.active.memory": "512m",
+			"sablier.idle.replicas":   "1",
+			"sablier.idle.cpu":        "0.5",
+			"sablier.idle.memory":     "128m",
+			"sablier.active.replicas": "1",
+			"sablier.active.cpu":      "2.0",
+			"sablier.active.memory":   "512m",
 		},
 	})
 	assert.NilError(t, err)
@@ -71,10 +73,12 @@ func TestDockerScaleMode_Start(t *testing.T) {
 	// Create a container with scale labels and idle resources already applied
 	result, err := c.CreateMimic(ctx, MimicOptions{
 		Labels: map[string]string{
-			"sablier.idle.cpu":      "0.5",
-			"sablier.idle.memory":   "128m",
-			"sablier.active.cpu":    "2.0",
-			"sablier.active.memory": "512m",
+			"sablier.idle.replicas":   "1",
+			"sablier.idle.cpu":        "0.5",
+			"sablier.idle.memory":     "128m",
+			"sablier.active.replicas": "1",
+			"sablier.active.cpu":      "2.0",
+			"sablier.active.memory":   "512m",
 		},
 	})
 	assert.NilError(t, err)
@@ -101,4 +105,81 @@ func TestDockerScaleMode_Start(t *testing.T) {
 	// Memory limit should be set to active value (512 MiB = 536_870_912 bytes)
 	assert.Equal(t, spec.Container.HostConfig.Memory, int64(512*1024*1024),
 		"Memory should be set to active value")
+}
+
+// TestDockerScaleMode_Stop_ReplicasOnly verifies that InstanceStop keeps the container
+// running when only sablier.idle.replicas is set (no CPU/memory labels).
+func TestDockerScaleMode_Stop_ReplicasOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	c := sharedDinD
+
+	result, err := c.CreateMimic(ctx, MimicOptions{
+		Labels: map[string]string{
+			"sablier.idle.replicas": "1",
+		},
+	})
+	assert.NilError(t, err)
+
+	_, err = c.client.ContainerStart(ctx, result.ID, client.ContainerStartOptions{})
+	assert.NilError(t, err)
+
+	p, err := docker.New(ctx, c.client, slogt.New(t), "stop")
+	assert.NilError(t, err)
+
+	err = p.InstanceStop(t.Context(), result.ID)
+	assert.NilError(t, err)
+
+	spec, err := c.client.ContainerInspect(ctx, result.ID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(spec.Container.State.Status), "running",
+		"container should still be running in replicas-only scale mode")
+
+	// No resource limits should have been applied.
+	assert.Equal(t, spec.Container.HostConfig.NanoCPUs, int64(0),
+		"CPU limit should be unchanged (0 = no limit)")
+	assert.Equal(t, spec.Container.HostConfig.Memory, int64(0),
+		"Memory limit should be unchanged (0 = no limit)")
+}
+
+// TestDockerScaleMode_Start_ReplicasOnly verifies that InstanceStart is a no-op for
+// resources when only sablier.active.replicas is set (no CPU/memory labels).
+func TestDockerScaleMode_Start_ReplicasOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	c := sharedDinD
+
+	result, err := c.CreateMimic(ctx, MimicOptions{
+		Labels: map[string]string{
+			"sablier.active.replicas": "1",
+		},
+	})
+	assert.NilError(t, err)
+
+	_, err = c.client.ContainerStart(ctx, result.ID, client.ContainerStartOptions{})
+	assert.NilError(t, err)
+
+	p, err := docker.New(ctx, c.client, slogt.New(t), "stop")
+	assert.NilError(t, err)
+
+	err = p.InstanceStart(t.Context(), result.ID)
+	assert.NilError(t, err)
+
+	spec, err := c.client.ContainerInspect(ctx, result.ID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(spec.Container.State.Status), "running")
+
+	// No resource limits should have been applied.
+	assert.Equal(t, spec.Container.HostConfig.NanoCPUs, int64(0),
+		"CPU limit should be unchanged (0 = no limit)")
+	assert.Equal(t, spec.Container.HostConfig.Memory, int64(0),
+		"Memory limit should be unchanged (0 = no limit)")
 }

--- a/pkg/provider/docker/container_start.go
+++ b/pkg/provider/docker/container_start.go
@@ -16,7 +16,7 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(spec.Container.Config.Labels)
-	if sc != nil && sc.Active.Replicas >= 1 {
+	if sc.Idle.Replicas >= 1 || sc.Active.CPU != "" || sc.Active.Memory != "" {
 		if sc.Active.CPU != "" || sc.Active.Memory != "" {
 			p.l.DebugContext(ctx, "applying active resources (scale mode)",
 				slog.String("name", name),

--- a/pkg/provider/docker/container_start.go
+++ b/pkg/provider/docker/container_start.go
@@ -16,13 +16,16 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(spec.Container.Config.Labels)
-	if sc != nil && (sc.Active.CPU != "" || sc.Active.Memory != "") {
-		p.l.DebugContext(ctx, "applying active resources (scale mode)",
-			slog.String("name", name),
-			slog.String("cpu", sc.Active.CPU),
-			slog.String("memory", sc.Active.Memory),
-		)
-		return p.applyResources(ctx, name, sc.Active.CPU, sc.Active.Memory)
+	if sc != nil && sc.Active.Replicas >= 1 {
+		if sc.Active.CPU != "" || sc.Active.Memory != "" {
+			p.l.DebugContext(ctx, "applying active resources (scale mode)",
+				slog.String("name", name),
+				slog.String("cpu", sc.Active.CPU),
+				slog.String("memory", sc.Active.Memory),
+			)
+			return p.applyResources(ctx, name, sc.Active.CPU, sc.Active.Memory)
+		}
+		return nil
 	}
 
 	if p.strategy == "pause" {

--- a/pkg/provider/docker/container_stop.go
+++ b/pkg/provider/docker/container_stop.go
@@ -17,13 +17,16 @@ func (p *Provider) InstanceStop(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(spec.Container.Config.Labels)
-	if sc != nil && (sc.Idle.CPU != "" || sc.Idle.Memory != "") {
-		p.l.DebugContext(ctx, "applying idle resources (scale mode)",
-			slog.String("name", name),
-			slog.String("cpu", sc.Idle.CPU),
-			slog.String("memory", sc.Idle.Memory),
-		)
-		return p.applyResources(ctx, name, sc.Idle.CPU, sc.Idle.Memory)
+	if sc != nil && sc.Idle.Replicas >= 1 {
+		if sc.Idle.CPU != "" || sc.Idle.Memory != "" {
+			p.l.DebugContext(ctx, "applying idle resources (scale mode)",
+				slog.String("name", name),
+				slog.String("cpu", sc.Idle.CPU),
+				slog.String("memory", sc.Idle.Memory),
+			)
+			return p.applyResources(ctx, name, sc.Idle.CPU, sc.Idle.Memory)
+		}
+		return nil
 	}
 
 	if p.strategy == "pause" {

--- a/pkg/provider/docker/container_stop.go
+++ b/pkg/provider/docker/container_stop.go
@@ -17,7 +17,7 @@ func (p *Provider) InstanceStop(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(spec.Container.Config.Labels)
-	if sc != nil && sc.Idle.Replicas >= 1 {
+	if sc.Idle.Replicas >= 1 {
 		if sc.Idle.CPU != "" || sc.Idle.Memory != "" {
 			p.l.DebugContext(ctx, "applying idle resources (scale mode)",
 				slog.String("name", name),

--- a/pkg/provider/docker/docker.go
+++ b/pkg/provider/docker/docker.go
@@ -13,10 +13,9 @@ import (
 var _ sablier.Provider = (*Provider)(nil)
 
 type Provider struct {
-	Client          client.APIClient
-	desiredReplicas int32
-	l               *slog.Logger
-	strategy        string
+	Client   client.APIClient
+	l        *slog.Logger
+	strategy string
 }
 
 func New(ctx context.Context, cli *client.Client, logger *slog.Logger, strategy string) (*Provider, error) {
@@ -32,9 +31,8 @@ func New(ctx context.Context, cli *client.Client, logger *slog.Logger, strategy 
 		slog.String("api_version", serverVersion.APIVersion),
 	)
 	return &Provider{
-		Client:          cli,
-		desiredReplicas: 1,
-		l:               logger,
-		strategy:        strategy,
+		Client:   cli,
+		l:        logger,
+		strategy: strategy,
 	}, nil
 }

--- a/pkg/provider/dockerswarm/docker_swarm.go
+++ b/pkg/provider/dockerswarm/docker_swarm.go
@@ -2,10 +2,8 @@ package dockerswarm
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/moby/moby/client"
 	"github.com/sablierapp/sablier/pkg/sablier"
@@ -15,8 +13,7 @@ import (
 var _ sablier.Provider = (*Provider)(nil)
 
 type Provider struct {
-	Client          client.APIClient
-	desiredReplicas int32
+	Client client.APIClient
 
 	l *slog.Logger
 }
@@ -35,37 +32,8 @@ func New(ctx context.Context, cli *client.Client, logger *slog.Logger) (*Provide
 	)
 
 	return &Provider{
-		Client:          cli,
-		desiredReplicas: 1,
-		l:               logger,
+		Client: cli,
+		l:      logger,
 	}, nil
 
-}
-
-func (p *Provider) ServiceUpdateReplicas(ctx context.Context, name string, replicas uint64) error {
-	service, err := p.getServiceByName(name, ctx)
-	if err != nil {
-		return fmt.Errorf("cannot get service: %w", err)
-	}
-
-	if service.Spec.Mode.Replicated == nil {
-		return errors.New("swarm service is not in \"replicated\" mode")
-	}
-
-	p.l.DebugContext(ctx, "scaling service", "name", name, "current_replicas", service.Spec.Mode.Replicated.Replicas, "desired_replicas", p.desiredReplicas)
-	service.Spec.Mode.Replicated.Replicas = &replicas
-
-	response, err := p.Client.ServiceUpdate(ctx, service.ID, client.ServiceUpdateOptions{
-		Version: service.Version,
-		Spec:    service.Spec,
-	})
-	if err != nil {
-		return fmt.Errorf("cannot update service: %w", err)
-	}
-
-	if len(response.Warnings) > 0 {
-		return fmt.Errorf("warning received updating swarm service [%s]: %s", service.Spec.Name, strings.Join(response.Warnings, ", "))
-	}
-
-	return nil
 }

--- a/pkg/provider/dockerswarm/service_inspect.go
+++ b/pkg/provider/dockerswarm/service_inspect.go
@@ -21,26 +21,29 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 		return sablier.InstanceInfo{}, errors.New("swarm service is not in \"replicated\" mode")
 	}
 
+	sc := sablier.ScaleConfigFromLabels(service.Spec.Labels)
+	desired := sc.Active.Replicas
+
 	var info sablier.InstanceInfo
 	if service.ServiceStatus.DesiredTasks == 0 {
 		info = sablier.InstanceInfo{
 			Name:            service.Spec.Name,
 			CurrentReplicas: 0,
-			DesiredReplicas: p.desiredReplicas,
+			DesiredReplicas: desired,
 			Status:          sablier.InstanceStatusStopped,
 		}
 	} else if service.ServiceStatus.DesiredTasks != service.ServiceStatus.RunningTasks {
 		info = sablier.InstanceInfo{
 			Name:            service.Spec.Name,
 			CurrentReplicas: int32(service.ServiceStatus.RunningTasks),
-			DesiredReplicas: p.desiredReplicas,
+			DesiredReplicas: desired,
 			Status:          sablier.InstanceStatusStarting,
 		}
 	} else {
 		info = sablier.InstanceInfo{
 			Name:            service.Spec.Name,
-			CurrentReplicas: p.desiredReplicas,
-			DesiredReplicas: p.desiredReplicas,
+			CurrentReplicas: int32(service.ServiceStatus.RunningTasks),
+			DesiredReplicas: desired,
 			Status:          sablier.InstanceStatusReady,
 		}
 	}

--- a/pkg/provider/dockerswarm/service_scale.go
+++ b/pkg/provider/dockerswarm/service_scale.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -35,9 +36,9 @@ func parseMemoryBytes(memory string) (int64, error) {
 	return b, nil
 }
 
-// ServiceUpdateScale updates the replica count and/or CPU/memory resource limits
-// of a Swarm service in a single service update call. Pass an empty string for
-// cpu or memory to set that limit to 0 (unlimited).
+// ServiceUpdateScale updates the replica count and, optionally, CPU/memory resource limits
+// of a Swarm service in a single service update call. Invalid or empty cpu/memory values
+// are skipped with a warning rather than failing the call.
 func (p *Provider) ServiceUpdateScale(ctx context.Context, name string, replicas uint64, cpu, memory string) error {
 	service, err := p.getServiceByName(name, ctx)
 	if err != nil {
@@ -60,16 +61,18 @@ func (p *Provider) ServiceUpdateScale(ctx context.Context, name string, replicas
 		if cpu != "" {
 			v, err := parseCPUNano(cpu)
 			if err != nil {
-				return err
+				p.l.WarnContext(ctx, "invalid cpu label value, skipping", slog.String("cpu", cpu), slog.Any("error", err))
+			} else {
+				service.Spec.TaskTemplate.Resources.Limits.NanoCPUs = v
 			}
-			service.Spec.TaskTemplate.Resources.Limits.NanoCPUs = v
 		}
 		if memory != "" {
 			v, err := parseMemoryBytes(memory)
 			if err != nil {
-				return err
+				p.l.WarnContext(ctx, "invalid memory label value, skipping", slog.String("memory", memory), slog.Any("error", err))
+			} else {
+				service.Spec.TaskTemplate.Resources.Limits.MemoryBytes = v
 			}
-			service.Spec.TaskTemplate.Resources.Limits.MemoryBytes = v
 		}
 	}
 

--- a/pkg/provider/dockerswarm/service_scale.go
+++ b/pkg/provider/dockerswarm/service_scale.go
@@ -35,10 +35,10 @@ func parseMemoryBytes(memory string) (int64, error) {
 	return b, nil
 }
 
-// ServiceUpdateResources updates the CPU and/or memory resource limits of a
-// Swarm service without changing its replica count. Pass an empty string for
+// ServiceUpdateScale updates the replica count and/or CPU/memory resource limits
+// of a Swarm service in a single service update call. Pass an empty string for
 // cpu or memory to set that limit to 0 (unlimited).
-func (p *Provider) ServiceUpdateResources(ctx context.Context, name, cpu, memory string) error {
+func (p *Provider) ServiceUpdateScale(ctx context.Context, name string, replicas uint64, cpu, memory string) error {
 	service, err := p.getServiceByName(name, ctx)
 	if err != nil {
 		return fmt.Errorf("cannot get service: %w", err)
@@ -48,33 +48,30 @@ func (p *Provider) ServiceUpdateResources(ctx context.Context, name, cpu, memory
 		return errors.New("swarm service is not in \"replicated\" mode")
 	}
 
-	var nanoCPUs int64
-	var memBytes int64
+	service.Spec.Mode.Replicated.Replicas = &replicas
 
-	if cpu != "" {
-		v, err := parseCPUNano(cpu)
-		if err != nil {
-			return err
+	if cpu != "" || memory != "" {
+		if service.Spec.TaskTemplate.Resources == nil {
+			service.Spec.TaskTemplate.Resources = &swarm.ResourceRequirements{}
 		}
-		nanoCPUs = v
-	}
-
-	if memory != "" {
-		v, err := parseMemoryBytes(memory)
-		if err != nil {
-			return err
+		if service.Spec.TaskTemplate.Resources.Limits == nil {
+			service.Spec.TaskTemplate.Resources.Limits = &swarm.Limit{}
 		}
-		memBytes = v
+		if cpu != "" {
+			v, err := parseCPUNano(cpu)
+			if err != nil {
+				return err
+			}
+			service.Spec.TaskTemplate.Resources.Limits.NanoCPUs = v
+		}
+		if memory != "" {
+			v, err := parseMemoryBytes(memory)
+			if err != nil {
+				return err
+			}
+			service.Spec.TaskTemplate.Resources.Limits.MemoryBytes = v
+		}
 	}
-
-	if service.Spec.TaskTemplate.Resources == nil {
-		service.Spec.TaskTemplate.Resources = &swarm.ResourceRequirements{}
-	}
-	if service.Spec.TaskTemplate.Resources.Limits == nil {
-		service.Spec.TaskTemplate.Resources.Limits = &swarm.Limit{}
-	}
-	service.Spec.TaskTemplate.Resources.Limits.NanoCPUs = nanoCPUs
-	service.Spec.TaskTemplate.Resources.Limits.MemoryBytes = memBytes
 
 	response, err := p.Client.ServiceUpdate(ctx, service.ID, client.ServiceUpdateOptions{
 		Version: service.Version,

--- a/pkg/provider/dockerswarm/service_start.go
+++ b/pkg/provider/dockerswarm/service_start.go
@@ -15,13 +15,14 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(service.Spec.Labels)
-	if sc != nil && (sc.Active.CPU != "" || sc.Active.Memory != "") {
+	if sc != nil && sc.Active.Replicas >= 1 {
 		p.l.DebugContext(ctx, "applying active resources (scale mode)",
 			slog.String("name", name),
+			slog.Int("replicas", int(sc.Active.Replicas)),
 			slog.String("cpu", sc.Active.CPU),
 			slog.String("memory", sc.Active.Memory),
 		)
-		return p.ServiceUpdateResources(ctx, name, sc.Active.CPU, sc.Active.Memory)
+		return p.ServiceUpdateScale(ctx, name, uint64(sc.Active.Replicas), sc.Active.CPU, sc.Active.Memory)
 	}
 
 	return p.ServiceUpdateReplicas(ctx, name, uint64(p.desiredReplicas))

--- a/pkg/provider/dockerswarm/service_start.go
+++ b/pkg/provider/dockerswarm/service_start.go
@@ -15,15 +15,11 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(service.Spec.Labels)
-	if sc != nil && sc.Active.Replicas >= 1 {
-		p.l.DebugContext(ctx, "applying active resources (scale mode)",
-			slog.String("name", name),
-			slog.Int("replicas", int(sc.Active.Replicas)),
-			slog.String("cpu", sc.Active.CPU),
-			slog.String("memory", sc.Active.Memory),
-		)
-		return p.ServiceUpdateScale(ctx, name, uint64(sc.Active.Replicas), sc.Active.CPU, sc.Active.Memory)
-	}
-
-	return p.ServiceUpdateReplicas(ctx, name, uint64(p.desiredReplicas))
+	p.l.DebugContext(ctx, "starting service",
+		slog.String("name", name),
+		slog.Int("replicas", int(sc.Active.Replicas)),
+		slog.String("cpu", sc.Active.CPU),
+		slog.String("memory", sc.Active.Memory),
+	)
+	return p.ServiceUpdateScale(ctx, name, uint64(sc.Active.Replicas), sc.Active.CPU, sc.Active.Memory)
 }

--- a/pkg/provider/dockerswarm/service_start_test.go
+++ b/pkg/provider/dockerswarm/service_start_test.go
@@ -84,7 +84,7 @@ func TestDockerSwarmProvider_Start_ScaleMode_ReplicasOnly(t *testing.T) {
 	err = p.InstanceStart(ctx, name)
 	assert.NilError(t, err)
 
-	service, err := c.client.ServiceInspect(ctx, name, client.ServiceInspectOptions{})
+	service, err := c.client.ServiceInspect(ctx, name, client.ServiceInspectOptions{InsertDefaults: true})
 	assert.NilError(t, err)
 	// Scale mode (replicas only): replicas must remain at 1.
 	assert.Equal(t, *service.Service.Spec.Mode.Replicated.Replicas, uint64(1))

--- a/pkg/provider/dockerswarm/service_start_test.go
+++ b/pkg/provider/dockerswarm/service_start_test.go
@@ -28,8 +28,9 @@ func TestDockerSwarmProvider_Start_ScaleMode(t *testing.T) {
 	s, err := c.CreateMimic(ctx, MimicOptions{
 		Cmd: []string{"/mimic"},
 		Labels: map[string]string{
-			"sablier.active.cpu":    "2.0",
-			"sablier.active.memory": "128m",
+			"sablier.active.replicas": "1",
+			"sablier.active.cpu":      "2.0",
+			"sablier.active.memory":   "128m",
 		},
 	})
 	assert.NilError(t, err)
@@ -51,6 +52,86 @@ func TestDockerSwarmProvider_Start_ScaleMode(t *testing.T) {
 	// CPU limit must be set to 2.0 cores (2 000 000 000 nanocores).
 	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.NanoCPUs, int64(2_000_000_000))
 	// Memory limit must be set to 128 MiB.
+	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.MemoryBytes, int64(128*1024*1024))
+}
+
+func TestDockerSwarmProvider_Start_ScaleMode_ReplicasOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	c := sharedDinD
+	p, err := dockerswarm.New(ctx, c.client, slogt.New(t))
+	assert.NilError(t, err)
+
+	s, err := c.CreateMimic(ctx, MimicOptions{
+		Cmd: []string{"/mimic"},
+		Labels: map[string]string{
+			"sablier.active.replicas": "1",
+		},
+	})
+	assert.NilError(t, err)
+
+	inspectResult, err := c.client.ServiceInspect(ctx, s.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	name := inspectResult.Service.Spec.Name
+	t.Cleanup(func() {
+		_, _ = c.client.ServiceRemove(context.Background(), name, client.ServiceRemoveOptions{})
+	})
+
+	err = p.InstanceStart(ctx, name)
+	assert.NilError(t, err)
+
+	service, err := c.client.ServiceInspect(ctx, name, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	// Scale mode (replicas only): replicas must remain at 1.
+	assert.Equal(t, *service.Service.Spec.Mode.Replicated.Replicas, uint64(1))
+	// No resource limits should have been applied.
+	if limits := service.Service.Spec.TaskTemplate.Resources.Limits; limits != nil {
+		assert.Equal(t, limits.NanoCPUs, int64(0), "CPU limit should not be set")
+		assert.Equal(t, limits.MemoryBytes, int64(0), "memory limit should not be set")
+	}
+}
+
+func TestDockerSwarmProvider_Start_ScaleMode_2Replicas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	c := sharedDinD
+	p, err := dockerswarm.New(ctx, c.client, slogt.New(t))
+	assert.NilError(t, err)
+
+	s, err := c.CreateMimic(ctx, MimicOptions{
+		Cmd: []string{"/mimic"},
+		Labels: map[string]string{
+			"sablier.active.replicas": "2",
+			"sablier.active.cpu":      "2.0",
+			"sablier.active.memory":   "128m",
+		},
+	})
+	assert.NilError(t, err)
+
+	inspectResult, err := c.client.ServiceInspect(ctx, s.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	name := inspectResult.Service.Spec.Name
+	t.Cleanup(func() {
+		_, _ = c.client.ServiceRemove(context.Background(), name, client.ServiceRemoveOptions{})
+	})
+
+	err = p.InstanceStart(ctx, name)
+	assert.NilError(t, err)
+
+	service, err := c.client.ServiceInspect(ctx, name, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	// Replica count must be updated to the configured active value (2), not kept at 1.
+	assert.Equal(t, *service.Service.Spec.Mode.Replicated.Replicas, uint64(2))
+	// CPU and memory limits must be applied.
+	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.NanoCPUs, int64(2_000_000_000))
 	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.MemoryBytes, int64(128*1024*1024))
 }
 

--- a/pkg/provider/dockerswarm/service_stop.go
+++ b/pkg/provider/dockerswarm/service_stop.go
@@ -15,13 +15,14 @@ func (p *Provider) InstanceStop(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(service.Spec.Labels)
-	if sc != nil && (sc.Idle.CPU != "" || sc.Idle.Memory != "") {
+	if sc != nil && sc.Idle.Replicas >= 1 {
 		p.l.DebugContext(ctx, "applying idle resources (scale mode)",
 			slog.String("name", name),
+			slog.Int("replicas", int(sc.Idle.Replicas)),
 			slog.String("cpu", sc.Idle.CPU),
 			slog.String("memory", sc.Idle.Memory),
 		)
-		return p.ServiceUpdateResources(ctx, name, sc.Idle.CPU, sc.Idle.Memory)
+		return p.ServiceUpdateScale(ctx, name, uint64(sc.Idle.Replicas), sc.Idle.CPU, sc.Idle.Memory)
 	}
 
 	return p.ServiceUpdateReplicas(ctx, name, 0)

--- a/pkg/provider/dockerswarm/service_stop.go
+++ b/pkg/provider/dockerswarm/service_stop.go
@@ -15,15 +15,11 @@ func (p *Provider) InstanceStop(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(service.Spec.Labels)
-	if sc != nil && sc.Idle.Replicas >= 1 {
-		p.l.DebugContext(ctx, "applying idle resources (scale mode)",
-			slog.String("name", name),
-			slog.Int("replicas", int(sc.Idle.Replicas)),
-			slog.String("cpu", sc.Idle.CPU),
-			slog.String("memory", sc.Idle.Memory),
-		)
-		return p.ServiceUpdateScale(ctx, name, uint64(sc.Idle.Replicas), sc.Idle.CPU, sc.Idle.Memory)
-	}
-
-	return p.ServiceUpdateReplicas(ctx, name, 0)
+	p.l.DebugContext(ctx, "stopping service",
+		slog.String("name", name),
+		slog.Int("replicas", int(sc.Idle.Replicas)),
+		slog.String("cpu", sc.Idle.CPU),
+		slog.String("memory", sc.Idle.Memory),
+	)
+	return p.ServiceUpdateScale(ctx, name, uint64(sc.Idle.Replicas), sc.Idle.CPU, sc.Idle.Memory)
 }

--- a/pkg/provider/dockerswarm/service_stop_test.go
+++ b/pkg/provider/dockerswarm/service_stop_test.go
@@ -28,8 +28,9 @@ func TestDockerSwarmProvider_Stop_ScaleMode(t *testing.T) {
 	s, err := c.CreateMimic(ctx, MimicOptions{
 		Cmd: []string{"/mimic"},
 		Labels: map[string]string{
-			"sablier.idle.cpu":    "0.1",
-			"sablier.idle.memory": "64m",
+			"sablier.idle.replicas": "1",
+			"sablier.idle.cpu":      "0.1",
+			"sablier.idle.memory":   "64m",
 		},
 	})
 	assert.NilError(t, err)
@@ -51,6 +52,86 @@ func TestDockerSwarmProvider_Stop_ScaleMode(t *testing.T) {
 	// CPU limit must be set to 0.1 core (100 000 000 nanocores).
 	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.NanoCPUs, int64(100_000_000))
 	// Memory limit must be set to 64 MiB.
+	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.MemoryBytes, int64(64*1024*1024))
+}
+
+func TestDockerSwarmProvider_Stop_ScaleMode_ReplicasOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	c := sharedDinD
+	p, err := dockerswarm.New(ctx, c.client, slogt.New(t))
+	assert.NilError(t, err)
+
+	s, err := c.CreateMimic(ctx, MimicOptions{
+		Cmd: []string{"/mimic"},
+		Labels: map[string]string{
+			"sablier.idle.replicas": "1",
+		},
+	})
+	assert.NilError(t, err)
+
+	inspectResult, err := c.client.ServiceInspect(ctx, s.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	name := inspectResult.Service.Spec.Name
+	t.Cleanup(func() {
+		_, _ = c.client.ServiceRemove(context.Background(), name, client.ServiceRemoveOptions{})
+	})
+
+	err = p.InstanceStop(ctx, name)
+	assert.NilError(t, err)
+
+	service, err := c.client.ServiceInspect(ctx, name, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	// Scale mode (replicas only): replicas must remain at 1.
+	assert.Equal(t, *service.Service.Spec.Mode.Replicated.Replicas, uint64(1))
+	// No resource limits should have been applied.
+	if limits := service.Service.Spec.TaskTemplate.Resources.Limits; limits != nil {
+		assert.Equal(t, limits.NanoCPUs, int64(0), "CPU limit should not be set")
+		assert.Equal(t, limits.MemoryBytes, int64(0), "memory limit should not be set")
+	}
+}
+
+func TestDockerSwarmProvider_Stop_ScaleMode_2Replicas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	c := sharedDinD
+	p, err := dockerswarm.New(ctx, c.client, slogt.New(t))
+	assert.NilError(t, err)
+
+	s, err := c.CreateMimic(ctx, MimicOptions{
+		Cmd: []string{"/mimic"},
+		Labels: map[string]string{
+			"sablier.idle.replicas": "2",
+			"sablier.idle.cpu":      "0.1",
+			"sablier.idle.memory":   "64m",
+		},
+	})
+	assert.NilError(t, err)
+
+	inspectResult, err := c.client.ServiceInspect(ctx, s.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	name := inspectResult.Service.Spec.Name
+	t.Cleanup(func() {
+		_, _ = c.client.ServiceRemove(context.Background(), name, client.ServiceRemoveOptions{})
+	})
+
+	err = p.InstanceStop(ctx, name)
+	assert.NilError(t, err)
+
+	service, err := c.client.ServiceInspect(ctx, name, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	// Replica count must be updated to the configured idle value (2), not stopped (0) or kept at 1.
+	assert.Equal(t, *service.Service.Spec.Mode.Replicated.Replicas, uint64(2))
+	// CPU and memory limits must still be applied.
+	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.NanoCPUs, int64(100_000_000))
 	assert.Equal(t, service.Service.Spec.TaskTemplate.Resources.Limits.MemoryBytes, int64(64*1024*1024))
 }
 

--- a/pkg/provider/dockerswarm/service_stop_test.go
+++ b/pkg/provider/dockerswarm/service_stop_test.go
@@ -84,7 +84,7 @@ func TestDockerSwarmProvider_Stop_ScaleMode_ReplicasOnly(t *testing.T) {
 	err = p.InstanceStop(ctx, name)
 	assert.NilError(t, err)
 
-	service, err := c.client.ServiceInspect(ctx, name, client.ServiceInspectOptions{})
+	service, err := c.client.ServiceInspect(ctx, name, client.ServiceInspectOptions{InsertDefaults: true})
 	assert.NilError(t, err)
 	// Scale mode (replicas only): replicas must remain at 1.
 	assert.Equal(t, *service.Service.Spec.Mode.Replicated.Replicas, uint64(1))

--- a/pkg/provider/kubernetes/instance_start.go
+++ b/pkg/provider/kubernetes/instance_start.go
@@ -19,13 +19,20 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(labels)
-	if sc != nil && (sc.Active.CPU != "" || sc.Active.Memory != "") {
+	if sc != nil && sc.Active.Replicas >= 1 {
 		p.l.DebugContext(ctx, "applying active resources (scale mode)",
 			slog.String("name", name),
+			slog.Int("replicas", int(sc.Active.Replicas)),
 			slog.String("cpu", sc.Active.CPU),
 			slog.String("memory", sc.Active.Memory),
 		)
-		return p.scaleResources(ctx, parsed, sc.Active.CPU, sc.Active.Memory)
+		if err := p.scale(ctx, parsed, sc.Active.Replicas); err != nil {
+			return err
+		}
+		if sc.Active.CPU != "" || sc.Active.Memory != "" {
+			return p.scaleResources(ctx, parsed, sc.Active.CPU, sc.Active.Memory)
+		}
+		return nil
 	}
 
 	return p.scale(ctx, parsed, parsed.Replicas)

--- a/pkg/provider/kubernetes/instance_start.go
+++ b/pkg/provider/kubernetes/instance_start.go
@@ -19,7 +19,7 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(labels)
-	if sc != nil && sc.Active.Replicas >= 1 {
+	if sc.Idle.Replicas >= 1 || sc.Active.Replicas > 1 || sc.Active.CPU != "" || sc.Active.Memory != "" {
 		p.l.DebugContext(ctx, "applying active resources (scale mode)",
 			slog.String("name", name),
 			slog.Int("replicas", int(sc.Active.Replicas)),
@@ -35,5 +35,5 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) error {
 		return nil
 	}
 
-	return p.scale(ctx, parsed, parsed.Replicas)
+	return p.scale(ctx, parsed, sc.Active.Replicas)
 }

--- a/pkg/provider/kubernetes/instance_start_test.go
+++ b/pkg/provider/kubernetes/instance_start_test.go
@@ -30,8 +30,9 @@ func TestKubernetesProvider_InstanceStart_ScaleMode(t *testing.T) {
 
 		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{
 			Labels: map[string]string{
-				"sablier.active.cpu":    "200m",
-				"sablier.active.memory": "128Mi",
+				"sablier.active.replicas": "1",
+				"sablier.active.cpu":      "200m",
+				"sablier.active.memory":   "128Mi",
 			},
 		})
 		assert.NilError(t, err)
@@ -49,6 +50,9 @@ func TestKubernetesProvider_InstanceStart_ScaleMode(t *testing.T) {
 		updated, err := kind.client.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
 		assert.NilError(t, err)
 
+		// Scale mode: replica count must be set to active replicas (1).
+		assert.Equal(t, *updated.Spec.Replicas, int32(1))
+
 		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
 		expectedCPU := resource.MustParse("200m")
 		expectedMem := resource.MustParse("128Mi")
@@ -65,8 +69,9 @@ func TestKubernetesProvider_InstanceStart_ScaleMode(t *testing.T) {
 
 		ss, err := kind.CreateMimicStatefulSet(ctx, MimicOptions{
 			Labels: map[string]string{
-				"sablier.active.cpu":    "200m",
-				"sablier.active.memory": "128Mi",
+				"sablier.active.replicas": "1",
+				"sablier.active.cpu":      "200m",
+				"sablier.active.memory":   "128Mi",
 			},
 		})
 		assert.NilError(t, err)
@@ -83,6 +88,79 @@ func TestKubernetesProvider_InstanceStart_ScaleMode(t *testing.T) {
 
 		updated, err := kind.client.AppsV1().StatefulSets(ss.Namespace).Get(ctx, ss.Name, metav1.GetOptions{})
 		assert.NilError(t, err)
+
+		// Scale mode: replica count must be set to active replicas (1).
+		assert.Equal(t, *updated.Spec.Replicas, int32(1))
+
+		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
+		expectedCPU := resource.MustParse("200m")
+		expectedMem := resource.MustParse("128Mi")
+		cpuLimit := limits[corev1.ResourceCPU]
+		memLimit := limits[corev1.ResourceMemory]
+		assert.Assert(t, cpuLimit.Cmp(expectedCPU) == 0,
+			"expected CPU limit 200m, got %s", cpuLimit.String())
+		assert.Assert(t, memLimit.Cmp(expectedMem) == 0,
+			"expected memory limit 128Mi, got %s", memLimit.String())
+	})
+
+	t.Run("deployment scale mode replicas only", func(t *testing.T) {
+		t.Parallel()
+
+		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{
+			Labels: map[string]string{
+				"sablier.active.replicas": "1",
+			},
+		})
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = kind.client.AppsV1().Deployments(d.Namespace).Delete(context.Background(), d.Name, metav1.DeleteOptions{})
+		})
+
+		err = WaitForDeploymentReady(ctx, kind.client, d.Namespace, d.Name)
+		assert.NilError(t, err)
+
+		name := kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original
+		err = p.InstanceStart(ctx, name)
+		assert.NilError(t, err)
+
+		updated, err := kind.client.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		// Scale mode (replicas only): replica count must be set to active replicas (1).
+		assert.Equal(t, *updated.Spec.Replicas, int32(1))
+		// No resource limits should have been applied.
+		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
+		assert.Assert(t, len(limits) == 0,
+			"no resource limits should be set for replicas-only scale mode")
+	})
+
+	t.Run("deployment scale mode 2 active replicas", func(t *testing.T) {
+		t.Parallel()
+
+		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{
+			Labels: map[string]string{
+				"sablier.active.replicas": "2",
+				"sablier.active.cpu":      "200m",
+				"sablier.active.memory":   "128Mi",
+			},
+		})
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = kind.client.AppsV1().Deployments(d.Namespace).Delete(context.Background(), d.Name, metav1.DeleteOptions{})
+		})
+
+		err = WaitForDeploymentReady(ctx, kind.client, d.Namespace, d.Name)
+		assert.NilError(t, err)
+
+		name := kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original
+		err = p.InstanceStart(ctx, name)
+		assert.NilError(t, err)
+
+		updated, err := kind.client.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		// Replica count must be updated to the configured active value (2), not kept at 1.
+		assert.Equal(t, *updated.Spec.Replicas, int32(2))
 
 		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
 		expectedCPU := resource.MustParse("200m")

--- a/pkg/provider/kubernetes/instance_stop.go
+++ b/pkg/provider/kubernetes/instance_stop.go
@@ -19,7 +19,7 @@ func (p *Provider) InstanceStop(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(labels)
-	if sc != nil && sc.Idle.Replicas >= 1 {
+	if sc.Idle.Replicas >= 1 {
 		p.l.DebugContext(ctx, "applying idle resources (scale mode)",
 			slog.String("name", name),
 			slog.Int("replicas", int(sc.Idle.Replicas)),

--- a/pkg/provider/kubernetes/instance_stop.go
+++ b/pkg/provider/kubernetes/instance_stop.go
@@ -19,13 +19,20 @@ func (p *Provider) InstanceStop(ctx context.Context, name string) error {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(labels)
-	if sc != nil && (sc.Idle.CPU != "" || sc.Idle.Memory != "") {
+	if sc != nil && sc.Idle.Replicas >= 1 {
 		p.l.DebugContext(ctx, "applying idle resources (scale mode)",
 			slog.String("name", name),
+			slog.Int("replicas", int(sc.Idle.Replicas)),
 			slog.String("cpu", sc.Idle.CPU),
 			slog.String("memory", sc.Idle.Memory),
 		)
-		return p.scaleResources(ctx, parsed, sc.Idle.CPU, sc.Idle.Memory)
+		if err := p.scale(ctx, parsed, sc.Idle.Replicas); err != nil {
+			return err
+		}
+		if sc.Idle.CPU != "" || sc.Idle.Memory != "" {
+			return p.scaleResources(ctx, parsed, sc.Idle.CPU, sc.Idle.Memory)
+		}
+		return nil
 	}
 
 	return p.scale(ctx, parsed, 0)

--- a/pkg/provider/kubernetes/instance_stop_test.go
+++ b/pkg/provider/kubernetes/instance_stop_test.go
@@ -30,8 +30,9 @@ func TestKubernetesProvider_InstanceStop_ScaleMode(t *testing.T) {
 
 		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{
 			Labels: map[string]string{
-				"sablier.idle.cpu":    "100m",
-				"sablier.idle.memory": "64Mi",
+				"sablier.idle.replicas": "1",
+				"sablier.idle.cpu":      "100m",
+				"sablier.idle.memory":   "64Mi",
 			},
 		})
 		assert.NilError(t, err)
@@ -49,6 +50,9 @@ func TestKubernetesProvider_InstanceStop_ScaleMode(t *testing.T) {
 		updated, err := kind.client.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
 		assert.NilError(t, err)
 
+		// Scale mode: replica count must remain at 1.
+		assert.Equal(t, *updated.Spec.Replicas, int32(1))
+
 		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
 		expectedCPU := resource.MustParse("100m")
 		expectedMem := resource.MustParse("64Mi")
@@ -65,8 +69,9 @@ func TestKubernetesProvider_InstanceStop_ScaleMode(t *testing.T) {
 
 		ss, err := kind.CreateMimicStatefulSet(ctx, MimicOptions{
 			Labels: map[string]string{
-				"sablier.idle.cpu":    "100m",
-				"sablier.idle.memory": "64Mi",
+				"sablier.idle.replicas": "1",
+				"sablier.idle.cpu":      "100m",
+				"sablier.idle.memory":   "64Mi",
 			},
 		})
 		assert.NilError(t, err)
@@ -83,6 +88,79 @@ func TestKubernetesProvider_InstanceStop_ScaleMode(t *testing.T) {
 
 		updated, err := kind.client.AppsV1().StatefulSets(ss.Namespace).Get(ctx, ss.Name, metav1.GetOptions{})
 		assert.NilError(t, err)
+
+		// Scale mode: replica count must remain at 1.
+		assert.Equal(t, *updated.Spec.Replicas, int32(1))
+
+		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
+		expectedCPU := resource.MustParse("100m")
+		expectedMem := resource.MustParse("64Mi")
+		cpuLimit := limits[corev1.ResourceCPU]
+		memLimit := limits[corev1.ResourceMemory]
+		assert.Assert(t, cpuLimit.Cmp(expectedCPU) == 0,
+			"expected CPU limit 100m, got %s", cpuLimit.String())
+		assert.Assert(t, memLimit.Cmp(expectedMem) == 0,
+			"expected memory limit 64Mi, got %s", memLimit.String())
+	})
+
+	t.Run("deployment scale mode replicas only", func(t *testing.T) {
+		t.Parallel()
+
+		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{
+			Labels: map[string]string{
+				"sablier.idle.replicas": "1",
+			},
+		})
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = kind.client.AppsV1().Deployments(d.Namespace).Delete(context.Background(), d.Name, metav1.DeleteOptions{})
+		})
+
+		err = WaitForDeploymentReady(ctx, kind.client, d.Namespace, d.Name)
+		assert.NilError(t, err)
+
+		name := kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original
+		err = p.InstanceStop(ctx, name)
+		assert.NilError(t, err)
+
+		updated, err := kind.client.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		// Scale mode (replicas only): replica count must remain at 1.
+		assert.Equal(t, *updated.Spec.Replicas, int32(1))
+		// No resource limits should have been applied.
+		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
+		assert.Assert(t, len(limits) == 0,
+			"no resource limits should be set for replicas-only scale mode")
+	})
+
+	t.Run("deployment scale mode 2 idle replicas", func(t *testing.T) {
+		t.Parallel()
+
+		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{
+			Labels: map[string]string{
+				"sablier.idle.replicas": "2",
+				"sablier.idle.cpu":      "100m",
+				"sablier.idle.memory":   "64Mi",
+			},
+		})
+		assert.NilError(t, err)
+		t.Cleanup(func() {
+			_ = kind.client.AppsV1().Deployments(d.Namespace).Delete(context.Background(), d.Name, metav1.DeleteOptions{})
+		})
+
+		err = WaitForDeploymentReady(ctx, kind.client, d.Namespace, d.Name)
+		assert.NilError(t, err)
+
+		name := kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original
+		err = p.InstanceStop(ctx, name)
+		assert.NilError(t, err)
+
+		updated, err := kind.client.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		// Replica count must be updated to the configured idle value (2), not stopped (0) or kept at 1.
+		assert.Equal(t, *updated.Spec.Replicas, int32(2))
 
 		limits := updated.Spec.Template.Spec.Containers[0].Resources.Limits
 		expectedCPU := resource.MustParse("100m")

--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -95,27 +95,23 @@ func (instance InstanceInfo) IsReady() bool {
 }
 
 // ScaleConfigFromLabels extracts a ScaleConfig from the given label map.
-// Returns nil if none of the scale labels (sablier.idle.{cpu,memory,replicas},
-// sablier.active.{cpu,memory,replicas}) are present.
-//
-// Defaults:
+// It always returns a value. When none of the scale labels
+// (sablier.idle.{cpu,memory,replicas}, sablier.active.{cpu,memory,replicas})
+// are present it returns a zero-value struct with defaults:
 //   - Idle.Replicas = 0 (workload is stopped when idle)
 //   - Active.Replicas = 1 (workload runs with a single replica when active)
 //
+// Callers detect whether scale mode is active via field values:
+//   - Stop path:  sc.Idle.Replicas >= 1
+//   - Start path: sc.Idle.Replicas >= 1 || sc.Active.Replicas > 1 || sc.Active.CPU != "" || sc.Active.Memory != ""
+//
 // Resource scaling (CPU/memory throttling instead of stopping) is only applied
 // when Idle.Replicas ≥ 1.
-func ScaleConfigFromLabels(labels map[string]string) *ScaleConfig {
+func ScaleConfigFromLabels(labels map[string]string) ScaleConfig {
 	idleCPU := labels["sablier.idle.cpu"]
 	idleMemory := labels["sablier.idle.memory"]
 	activeCPU := labels["sablier.active.cpu"]
 	activeMemory := labels["sablier.active.memory"]
-	_, hasIdleReplicas := labels["sablier.idle.replicas"]
-	_, hasActiveReplicas := labels["sablier.active.replicas"]
-
-	if idleCPU == "" && idleMemory == "" && !hasIdleReplicas &&
-		activeCPU == "" && activeMemory == "" && !hasActiveReplicas {
-		return nil
-	}
 
 	idleReplicas := int32(0) // default: stop the workload
 	if v, ok := labels["sablier.idle.replicas"]; ok {
@@ -131,7 +127,7 @@ func ScaleConfigFromLabels(labels map[string]string) *ScaleConfig {
 		}
 	}
 
-	return &ScaleConfig{
+	return ScaleConfig{
 		Idle: ResourceProfile{
 			Replicas: idleReplicas,
 			CPU:      idleCPU,
@@ -179,5 +175,12 @@ func PopulateEnabledAndGroup(info *InstanceInfo, labels map[string]string) {
 			)
 		}
 	}
-	info.ScaleConfig = ScaleConfigFromLabels(labels)
+	// Only expose ScaleConfig in the response when at least one non-default
+	// scale label is present. Detects configuration by checking for values
+	// that differ from the zero-value defaults (Idle.Replicas=0, Active.Replicas=1).
+	sc := ScaleConfigFromLabels(labels)
+	if sc.Idle.Replicas > 0 || sc.Idle.CPU != "" || sc.Idle.Memory != "" ||
+		sc.Active.Replicas > 1 || sc.Active.CPU != "" || sc.Active.Memory != "" {
+		info.ScaleConfig = &sc
+	}
 }

--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -2,6 +2,7 @@ package sablier
 
 import (
 	"log/slog"
+	"strconv"
 	"time"
 )
 
@@ -66,6 +67,11 @@ type ScaleConfig struct {
 
 // ResourceProfile holds the CPU and memory limits for a single resource profile.
 type ResourceProfile struct {
+	// Replicas is the desired replica count for this profile.
+	// For idle: 0 (default) stops the workload; ≥ 1 keeps it running with
+	// throttled resources (resource scaling mode).
+	// For active: defaults to 1.
+	Replicas int32 `json:"replicas,omitempty"`
 	// CPU is the CPU limit (e.g. "0.5" for Docker/Swarm, "500m" for Kubernetes).
 	CPU string `json:"cpu,omitempty"`
 	// Memory is the memory limit (e.g. "128m" for Docker/Swarm, "128Mi" for Kubernetes).
@@ -89,21 +95,54 @@ func (instance InstanceInfo) IsReady() bool {
 }
 
 // ScaleConfigFromLabels extracts a ScaleConfig from the given label map.
-// Returns nil if none of the scale labels (sablier.idle.cpu, sablier.idle.memory,
-// sablier.active.cpu, sablier.active.memory) are present.
+// Returns nil if none of the scale labels (sablier.idle.{cpu,memory,replicas},
+// sablier.active.{cpu,memory,replicas}) are present.
+//
+// Defaults:
+//   - Idle.Replicas = 0 (workload is stopped when idle)
+//   - Active.Replicas = 1 (workload runs with a single replica when active)
+//
+// Resource scaling (CPU/memory throttling instead of stopping) is only applied
+// when Idle.Replicas ≥ 1.
 func ScaleConfigFromLabels(labels map[string]string) *ScaleConfig {
-	idle := ResourceProfile{
-		CPU:    labels["sablier.idle.cpu"],
-		Memory: labels["sablier.idle.memory"],
-	}
-	active := ResourceProfile{
-		CPU:    labels["sablier.active.cpu"],
-		Memory: labels["sablier.active.memory"],
-	}
-	if idle.CPU == "" && idle.Memory == "" && active.CPU == "" && active.Memory == "" {
+	idleCPU := labels["sablier.idle.cpu"]
+	idleMemory := labels["sablier.idle.memory"]
+	activeCPU := labels["sablier.active.cpu"]
+	activeMemory := labels["sablier.active.memory"]
+	_, hasIdleReplicas := labels["sablier.idle.replicas"]
+	_, hasActiveReplicas := labels["sablier.active.replicas"]
+
+	if idleCPU == "" && idleMemory == "" && !hasIdleReplicas &&
+		activeCPU == "" && activeMemory == "" && !hasActiveReplicas {
 		return nil
 	}
-	return &ScaleConfig{Idle: idle, Active: active}
+
+	idleReplicas := int32(0) // default: stop the workload
+	if v, ok := labels["sablier.idle.replicas"]; ok {
+		if n, err := strconv.ParseInt(v, 10, 32); err == nil && n >= 0 {
+			idleReplicas = int32(n)
+		}
+	}
+
+	activeReplicas := int32(1) // default: one running replica
+	if v, ok := labels["sablier.active.replicas"]; ok {
+		if n, err := strconv.ParseInt(v, 10, 32); err == nil && n >= 0 {
+			activeReplicas = int32(n)
+		}
+	}
+
+	return &ScaleConfig{
+		Idle: ResourceProfile{
+			Replicas: idleReplicas,
+			CPU:      idleCPU,
+			Memory:   idleMemory,
+		},
+		Active: ResourceProfile{
+			Replicas: activeReplicas,
+			CPU:      activeCPU,
+			Memory:   activeMemory,
+		},
+	}
 }
 
 // PopulateEnabledAndGroup reads the sablier.enable and sablier.group labels from

--- a/pkg/sablier/scale_test.go
+++ b/pkg/sablier/scale_test.go
@@ -28,33 +28,71 @@ func TestScaleConfigFromLabels_IdleCPUOnly(t *testing.T) {
 	}
 	got := sablier.ScaleConfigFromLabels(labels)
 	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
-		Idle:   sablier.ResourceProfile{CPU: "0.1"},
-		Active: sablier.ResourceProfile{},
+		Idle:   sablier.ResourceProfile{Replicas: 0, CPU: "0.1"},
+		Active: sablier.ResourceProfile{Replicas: 1},
 	}))
 }
 
 func TestScaleConfigFromLabels_AllLabels(t *testing.T) {
 	labels := map[string]string{
-		"sablier.idle.cpu":    "0.1",
-		"sablier.idle.memory": "128m",
-		"sablier.active.cpu":  "2.0",
+		"sablier.idle.cpu":      "0.1",
+		"sablier.idle.memory":   "128m",
+		"sablier.active.cpu":    "2.0",
 		"sablier.active.memory": "1g",
 	}
 	got := sablier.ScaleConfigFromLabels(labels)
 	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
-		Idle:   sablier.ResourceProfile{CPU: "0.1", Memory: "128m"},
-		Active: sablier.ResourceProfile{CPU: "2.0", Memory: "1g"},
+		Idle:   sablier.ResourceProfile{Replicas: 0, CPU: "0.1", Memory: "128m"},
+		Active: sablier.ResourceProfile{Replicas: 1, CPU: "2.0", Memory: "1g"},
+	}))
+}
+
+func TestScaleConfigFromLabels_ReplicasOnly(t *testing.T) {
+	labels := map[string]string{
+		"sablier.idle.replicas": "1",
+	}
+	got := sablier.ScaleConfigFromLabels(labels)
+	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
+		Idle:   sablier.ResourceProfile{Replicas: 1},
+		Active: sablier.ResourceProfile{Replicas: 1},
+	}))
+}
+
+func TestScaleConfigFromLabels_CustomReplicas(t *testing.T) {
+	labels := map[string]string{
+		"sablier.idle.replicas":   "2",
+		"sablier.active.replicas": "4",
+		"sablier.idle.cpu":        "0.1",
+		"sablier.active.cpu":      "2.0",
+	}
+	got := sablier.ScaleConfigFromLabels(labels)
+	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
+		Idle:   sablier.ResourceProfile{Replicas: 2, CPU: "0.1"},
+		Active: sablier.ResourceProfile{Replicas: 4, CPU: "2.0"},
+	}))
+}
+
+func TestScaleConfigFromLabels_ActiveReplicasOverride(t *testing.T) {
+	labels := map[string]string{
+		"sablier.idle.replicas":   "1",
+		"sablier.active.replicas": "3",
+	}
+	got := sablier.ScaleConfigFromLabels(labels)
+	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
+		Idle:   sablier.ResourceProfile{Replicas: 1},
+		Active: sablier.ResourceProfile{Replicas: 3},
 	}))
 }
 
 func TestPopulateEnabledAndGroup_WithScaleLabels(t *testing.T) {
 	info := sablier.InstanceInfo{Name: "my-service"}
 	labels := map[string]string{
-		"sablier.enable":      "true",
-		"sablier.group":       "backend",
-		"sablier.idle.cpu":    "0.25",
-		"sablier.idle.memory": "64m",
-		"sablier.active.cpu":  "1.0",
+		"sablier.enable":        "true",
+		"sablier.group":         "backend",
+		"sablier.idle.replicas": "1",
+		"sablier.idle.cpu":      "0.25",
+		"sablier.idle.memory":   "64m",
+		"sablier.active.cpu":    "1.0",
 	}
 
 	sablier.PopulateEnabledAndGroup(&info, labels)
@@ -62,8 +100,10 @@ func TestPopulateEnabledAndGroup_WithScaleLabels(t *testing.T) {
 	assert.Equal(t, info.Enabled, "true")
 	assert.Equal(t, info.Group, "backend")
 	assert.Assert(t, info.ScaleConfig != nil, "ScaleConfig should be populated")
+	assert.Equal(t, info.ScaleConfig.Idle.Replicas, int32(1))
 	assert.Equal(t, info.ScaleConfig.Idle.CPU, "0.25")
 	assert.Equal(t, info.ScaleConfig.Idle.Memory, "64m")
+	assert.Equal(t, info.ScaleConfig.Active.Replicas, int32(1))
 	assert.Equal(t, info.ScaleConfig.Active.CPU, "1.0")
 	assert.Equal(t, info.ScaleConfig.Active.Memory, "")
 }

--- a/pkg/sablier/scale_test.go
+++ b/pkg/sablier/scale_test.go
@@ -10,7 +10,10 @@ import (
 
 func TestScaleConfigFromLabels_NoLabels(t *testing.T) {
 	got := sablier.ScaleConfigFromLabels(map[string]string{})
-	assert.Assert(t, got == nil)
+	assert.Assert(t, cmp.DeepEqual(got, sablier.ScaleConfig{
+		Idle:   sablier.ResourceProfile{Replicas: 0},
+		Active: sablier.ResourceProfile{Replicas: 1},
+	}))
 }
 
 func TestScaleConfigFromLabels_UnrelatedLabels(t *testing.T) {
@@ -19,7 +22,10 @@ func TestScaleConfigFromLabels_UnrelatedLabels(t *testing.T) {
 		"sablier.group":  "mygroup",
 	}
 	got := sablier.ScaleConfigFromLabels(labels)
-	assert.Assert(t, got == nil)
+	assert.Assert(t, cmp.DeepEqual(got, sablier.ScaleConfig{
+		Idle:   sablier.ResourceProfile{Replicas: 0},
+		Active: sablier.ResourceProfile{Replicas: 1},
+	}))
 }
 
 func TestScaleConfigFromLabels_IdleCPUOnly(t *testing.T) {
@@ -27,7 +33,7 @@ func TestScaleConfigFromLabels_IdleCPUOnly(t *testing.T) {
 		"sablier.idle.cpu": "0.1",
 	}
 	got := sablier.ScaleConfigFromLabels(labels)
-	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
+	assert.Assert(t, cmp.DeepEqual(got, sablier.ScaleConfig{
 		Idle:   sablier.ResourceProfile{Replicas: 0, CPU: "0.1"},
 		Active: sablier.ResourceProfile{Replicas: 1},
 	}))
@@ -41,7 +47,7 @@ func TestScaleConfigFromLabels_AllLabels(t *testing.T) {
 		"sablier.active.memory": "1g",
 	}
 	got := sablier.ScaleConfigFromLabels(labels)
-	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
+	assert.Assert(t, cmp.DeepEqual(got, sablier.ScaleConfig{
 		Idle:   sablier.ResourceProfile{Replicas: 0, CPU: "0.1", Memory: "128m"},
 		Active: sablier.ResourceProfile{Replicas: 1, CPU: "2.0", Memory: "1g"},
 	}))
@@ -52,7 +58,7 @@ func TestScaleConfigFromLabels_ReplicasOnly(t *testing.T) {
 		"sablier.idle.replicas": "1",
 	}
 	got := sablier.ScaleConfigFromLabels(labels)
-	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
+	assert.Assert(t, cmp.DeepEqual(got, sablier.ScaleConfig{
 		Idle:   sablier.ResourceProfile{Replicas: 1},
 		Active: sablier.ResourceProfile{Replicas: 1},
 	}))
@@ -66,7 +72,7 @@ func TestScaleConfigFromLabels_CustomReplicas(t *testing.T) {
 		"sablier.active.cpu":      "2.0",
 	}
 	got := sablier.ScaleConfigFromLabels(labels)
-	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
+	assert.Assert(t, cmp.DeepEqual(got, sablier.ScaleConfig{
 		Idle:   sablier.ResourceProfile{Replicas: 2, CPU: "0.1"},
 		Active: sablier.ResourceProfile{Replicas: 4, CPU: "2.0"},
 	}))
@@ -78,7 +84,7 @@ func TestScaleConfigFromLabels_ActiveReplicasOverride(t *testing.T) {
 		"sablier.active.replicas": "3",
 	}
 	got := sablier.ScaleConfigFromLabels(labels)
-	assert.Assert(t, cmp.DeepEqual(got, &sablier.ScaleConfig{
+	assert.Assert(t, cmp.DeepEqual(got, sablier.ScaleConfig{
 		Idle:   sablier.ResourceProfile{Replicas: 1},
 		Active: sablier.ResourceProfile{Replicas: 3},
 	}))


### PR DESCRIPTION
## Summary

Extends scale mode with a first-class **replica count**, making it possible to scale workloads to any replica count on session start/stop — not just toggle CPU/memory limits.

Closes #28
Closes #258

### New labels

| Label | Default | Description |
|-------|---------|-------------|
| `sablier.idle.replicas` | `0` | Replica count when idle. `0` stops the workload (default). `≥ 1` keeps it running with optional resource throttling. |
| `sablier.active.replicas` | `1` | Replica count when a session is requested. |

### Behavior change

Resource throttling (`sablier.idle.cpu` / `sablier.idle.memory`) now **only activates when `sablier.idle.replicas >= 1`**.

Previously, adding CPU/memory labels alone was enough. Now you must also set `sablier.idle.replicas=1` explicitly.

**Migration:** add `sablier.idle.replicas=1` to any workload that used `sablier.idle.cpu` or `sablier.idle.memory`.

### Scaling to more than 1 replica

```yaml
labels:
  - "sablier.enable=true"
  - "sablier.group=myapp"
  - "sablier.idle.replicas=1"    # keep 1 replica alive when idle
  - "sablier.idle.cpu=0.1"
  - "sablier.idle.memory=64m"
  - "sablier.active.replicas=3"  # scale up to 3 on demand
  - "sablier.active.cpu=2.0"
  - "sablier.active.memory=512m"
```

Replicas-only mode (no CPU/memory throttling) is also supported:
```yaml
labels:
  - "sablier.idle.replicas=1"
  - "sablier.active.replicas=3"
```

### Provider changes

- **Docker / Podman**: `ContainerUpdate` is skipped when no CPU/memory labels are set (replicas only)
- **Docker Swarm**: `ServiceUpdateScale` replaces the separate replica + resource update calls — one `ServiceUpdate` round-trip. Fixes nil-pointer panic and missing memory parsing when CPU label is absent
- **Kubernetes**: `scale()` then optional `scaleResources()` called sequentially; resources step is skipped when no CPU/memory labels are present

### Tests added

- Unit tests for new `sablier.idle.replicas` / `sablier.active.replicas` label parsing
- Integration tests for replicas-only scale mode (no CPU/memory) on Docker, Swarm, and Kubernetes
- Integration tests for 2-replica scale mode on Swarm and Kubernetes

### Documentation

- Updated `docs/configuration.md`: new label table rows, updated scale mode section, added Docker Swarm example
- Updated `examples/scale-mode/README.md`: documents the breaking change, shows multi-replica usage, replicas-only usage