### PR TITLE
refactor: watch groups through events

### DIFF
--- a/pkg/provider/docker/container_inspect_test.go
+++ b/pkg/provider/docker/container_inspect_test.go
@@ -293,7 +293,10 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 						return "", err
 					}
 					_, err = dind.client.ContainerStart(ctx, c.ID, client.ContainerStartOptions{})
-					return c.ID, err
+					if err != nil {
+						return c.ID, err
+					}
+					return c.ID, WaitForContainerRunning(ctx, dind.client, c.ID)
 				},
 			},
 			want: sablier.InstanceInfo{

--- a/pkg/provider/docker/events.go
+++ b/pkg/provider/docker/events.go
@@ -18,6 +18,8 @@ import (
 func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEventsOptions) sablier.InstanceEventStream {
 	wantStopped := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStopped)
 	wantStarted := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStarted)
+	wantCreated := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventCreated)
+	wantRemoved := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventRemoved)
 
 	dial := func(ctx context.Context) client.EventsResult {
 		filters := client.Filters{}
@@ -28,36 +30,58 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 		if wantStarted {
 			filters.Add("event", "start")
 		}
+		if wantCreated {
+			filters.Add("event", "create")
+		}
+		if wantRemoved {
+			filters.Add("event", "destroy")
+		}
 		return p.Client.Events(ctx, client.EventsListOptions{Filters: filters})
 	}
-	build := func(ctx context.Context, msg events.Message) (sablier.InstanceInfo, bool) {
+	build := func(ctx context.Context, msg events.Message) (sablier.InstanceEvent, bool) {
 		name := strings.TrimPrefix(msg.Actor.Attributes["name"], "/")
 		if name == "" {
-			return sablier.InstanceInfo{}, false
+			return sablier.InstanceEvent{}, false
 		}
 		switch msg.Action {
 		case "die":
 			if !wantStopped {
-				return sablier.InstanceInfo{}, false
+				return sablier.InstanceEvent{}, false
 			}
 			info, err := p.InstanceInspect(ctx, name)
 			if err != nil {
 				p.l.WarnContext(ctx, "inspect after die event failed, using bare info", "container", name, "error", err)
-				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderDocker}, true
+				return sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderDocker}}, true
 			}
-			return info, true
+			return sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: info}, true
 		case "start":
 			if !wantStarted {
-				return sablier.InstanceInfo{}, false
+				return sablier.InstanceEvent{}, false
 			}
 			info, err := p.InstanceInspect(ctx, name)
 			if err != nil {
 				p.l.WarnContext(ctx, "inspect after start event failed, using bare info", "container", name, "error", err)
-				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderDocker}, true
+				return sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderDocker}}, true
 			}
-			return info, true
+			return sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: info}, true
+		case "create":
+			if !wantCreated {
+				return sablier.InstanceEvent{}, false
+			}
+			info, err := p.InstanceInspect(ctx, name)
+			if err != nil {
+				p.l.WarnContext(ctx, "inspect after create event failed, using bare info", "container", name, "error", err)
+				return sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: sablier.InstanceInfo{Name: name, Provider: sablier.ProviderDocker}}, true
+			}
+			return sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: info}, true
+		case "destroy":
+			if !wantRemoved {
+				return sablier.InstanceEvent{}, false
+			}
+			// Container is already gone; only the name is available.
+			return sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: sablier.InstanceInfo{Name: name, Provider: sablier.ProviderDocker}}, true
 		default:
-			return sablier.InstanceInfo{}, false
+			return sablier.InstanceEvent{}, false
 		}
 	}
 	return streamEvents(ctx, p.l, dial, build, linearBackoff)
@@ -73,10 +97,10 @@ func streamEvents(
 	ctx context.Context,
 	l *slog.Logger,
 	dial func(ctx context.Context) client.EventsResult,
-	build func(context.Context, events.Message) (sablier.InstanceInfo, bool),
+	build func(context.Context, events.Message) (sablier.InstanceEvent, bool),
 	backoff func(attempt int) time.Duration,
 ) sablier.InstanceEventStream {
-	eventsC := make(chan sablier.InstanceInfo)
+	eventsC := make(chan sablier.InstanceEvent)
 	errC := make(chan error, 1)
 	go func() {
 		defer close(eventsC)
@@ -100,15 +124,15 @@ func streamEvents(
 	return sablier.InstanceEventStream{Events: eventsC, Err: errC}
 }
 
-// consumeEvents drains an EventsResult, forwarding instance info built by the
+// consumeEvents drains an EventsResult, forwarding instance events built by the
 // build function. Returns true when the stream ended and the caller should
 // reconnect, or false when the context was cancelled and the caller should stop.
 func consumeEvents(
 	ctx context.Context,
 	l *slog.Logger,
-	instance chan<- sablier.InstanceInfo,
+	instance chan<- sablier.InstanceEvent,
 	result client.EventsResult,
-	build func(context.Context, events.Message) (sablier.InstanceInfo, bool),
+	build func(context.Context, events.Message) (sablier.InstanceEvent, bool),
 ) (reconnect bool) {
 	for {
 		select {
@@ -118,8 +142,8 @@ func consumeEvents(
 				return true
 			}
 			l.DebugContext(ctx, "event received", "event", msg)
-			if info, ok := build(ctx, msg); ok {
-				instance <- info
+			if event, ok := build(ctx, msg); ok {
+				instance <- event
 			}
 		case err, ok := <-result.Err:
 			if !ok || errors.Is(err, io.EOF) {

--- a/pkg/provider/docker/events.go
+++ b/pkg/provider/docker/events.go
@@ -25,16 +25,16 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 		filters := client.Filters{}
 		filters.Add("type", string(events.ContainerEventType))
 		if wantStopped {
-			filters.Add("event", "die")
+			filters.Add("event", string(events.ActionDie))
 		}
 		if wantStarted {
-			filters.Add("event", "start")
+			filters.Add("event", string(events.ActionStart))
 		}
 		if wantCreated {
-			filters.Add("event", "create")
+			filters.Add("event", string(events.ActionCreate))
 		}
 		if wantRemoved {
-			filters.Add("event", "destroy")
+			filters.Add("event", string(events.ActionDestroy))
 		}
 		return p.Client.Events(ctx, client.EventsListOptions{Filters: filters})
 	}
@@ -44,7 +44,7 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 			return sablier.InstanceEvent{}, false
 		}
 		switch msg.Action {
-		case "die":
+		case events.ActionDie:
 			if !wantStopped {
 				return sablier.InstanceEvent{}, false
 			}
@@ -54,7 +54,7 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 				return sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderDocker}}, true
 			}
 			return sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: info}, true
-		case "start":
+		case events.ActionStart:
 			if !wantStarted {
 				return sablier.InstanceEvent{}, false
 			}
@@ -64,7 +64,7 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 				return sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderDocker}}, true
 			}
 			return sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: info}, true
-		case "create":
+		case events.ActionCreate:
 			if !wantCreated {
 				return sablier.InstanceEvent{}, false
 			}
@@ -74,13 +74,14 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 				return sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: sablier.InstanceInfo{Name: name, Provider: sablier.ProviderDocker}}, true
 			}
 			return sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: info}, true
-		case "destroy":
+		case events.ActionDestroy:
 			if !wantRemoved {
 				return sablier.InstanceEvent{}, false
 			}
 			// Container is already gone; only the name is available.
 			return sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: sablier.InstanceInfo{Name: name, Provider: sablier.ProviderDocker}}, true
 		default:
+			p.l.WarnContext(ctx, "unhandled event", "action", msg.Action, "container", name)
 			return sablier.InstanceEvent{}, false
 		}
 	}

--- a/pkg/provider/docker/events_test.go
+++ b/pkg/provider/docker/events_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/neilotoole/slogt"
 	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/provider/docker"
+	"github.com/sablierapp/sablier/pkg/sablier"
 	"gotest.tools/v3/assert"
 )
 
@@ -46,7 +47,7 @@ func TestDockerClassicProvider_InstanceEvents(t *testing.T) {
 	case info := <-stream.Events:
 		// Docker container name is prefixed with a slash, but we don't use it
 		assert.Equal(t, "/"+info.Info.Name, inspected.Container.Name)
-		assert.Equal(t, info.Info.Provider, "docker")
+		assert.Equal(t, info.Info.Provider, sablier.ProviderDocker)
 		assert.Assert(t, info.Info.Docker != nil)
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
@@ -83,7 +84,7 @@ func TestDockerClassicProvider_InstanceEvents_Started(t *testing.T) {
 	select {
 	case info := <-stream.Events:
 		assert.Equal(t, "/"+info.Info.Name, inspected.Container.Name)
-		assert.Equal(t, info.Info.Provider, "docker")
+		assert.Equal(t, info.Info.Provider, sablier.ProviderDocker)
 		assert.Assert(t, info.Info.Docker != nil)
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
@@ -114,11 +115,47 @@ func TestDockerClassicProvider_InstanceEvents_Created(t *testing.T) {
 	select {
 	case info := <-stream.Events:
 		assert.Equal(t, "/"+info.Info.Name, inspected.Container.Name)
-		assert.Equal(t, info.Info.Provider, "docker")
+		assert.Equal(t, info.Info.Provider, sablier.ProviderDocker)
 		assert.Assert(t, info.Info.Docker != nil)
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
 	case <-ctx.Done():
 		t.Fatalf("timed out waiting for container created event: %v", ctx.Err())
+	}
+}
+
+func TestDockerClassicProvider_InstanceEvents_Removed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	dind := sharedDinD
+	p, err := docker.New(ctx, dind.client, slogt.New(t), "stop")
+	assert.NilError(t, err)
+
+	c, err := dind.CreateMimic(ctx, MimicOptions{})
+	assert.NilError(t, err)
+
+	inspected, err := dind.client.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+
+	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventRemoved},
+	})
+
+	_, err = dind.client.ContainerRemove(ctx, c.ID, client.ContainerRemoveOptions{})
+	assert.NilError(t, err)
+
+	select {
+	case info := <-stream.Events:
+		// Container is gone; only the name is available, no Docker-specific info.
+		assert.Equal(t, "/"+info.Info.Name, inspected.Container.Name)
+		assert.Equal(t, info.Info.Provider, sablier.ProviderDocker)
+	case err := <-stream.Err:
+		t.Fatalf("unexpected error: %v", err)
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for container removed event: %v", ctx.Err())
 	}
 }

--- a/pkg/provider/docker/events_test.go
+++ b/pkg/provider/docker/events_test.go
@@ -89,3 +89,36 @@ func TestDockerClassicProvider_InstanceEvents_Started(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestDockerClassicProvider_InstanceEvents_Created(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	dind := sharedDinD
+	p, err := docker.New(ctx, dind.client, slogt.New(t), "stop")
+	assert.NilError(t, err)
+
+	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated},
+	})
+
+	c, err := dind.CreateMimic(ctx, MimicOptions{})
+	assert.NilError(t, err)
+
+	inspected, err := dind.client.ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+
+	select {
+	case info := <-stream.Events:
+		assert.Equal(t, "/"+info.Info.Name, inspected.Container.Name)
+		assert.Equal(t, info.Info.Provider, "docker")
+		assert.Assert(t, info.Info.Docker != nil)
+	case err := <-stream.Err:
+		t.Fatalf("unexpected error: %v", err)
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for container created event: %v", ctx.Err())
+	}
+}

--- a/pkg/provider/docker/events_test.go
+++ b/pkg/provider/docker/events_test.go
@@ -45,9 +45,9 @@ func TestDockerClassicProvider_InstanceEvents(t *testing.T) {
 	select {
 	case info := <-stream.Events:
 		// Docker container name is prefixed with a slash, but we don't use it
-		assert.Equal(t, "/"+info.Name, inspected.Container.Name)
-		assert.Equal(t, info.Provider, "docker")
-		assert.Assert(t, info.Docker != nil)
+		assert.Equal(t, "/"+info.Info.Name, inspected.Container.Name)
+		assert.Equal(t, info.Info.Provider, "docker")
+		assert.Assert(t, info.Info.Docker != nil)
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -82,9 +82,9 @@ func TestDockerClassicProvider_InstanceEvents_Started(t *testing.T) {
 
 	select {
 	case info := <-stream.Events:
-		assert.Equal(t, "/"+info.Name, inspected.Container.Name)
-		assert.Equal(t, info.Provider, "docker")
-		assert.Assert(t, info.Docker != nil)
+		assert.Equal(t, "/"+info.Info.Name, inspected.Container.Name)
+		assert.Equal(t, info.Info.Provider, "docker")
+		assert.Assert(t, info.Info.Docker != nil)
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/provider/docker/events_unit_test.go
+++ b/pkg/provider/docker/events_unit_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/client"
 	"github.com/neilotoole/slogt"
+	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/sablier"
 	"gotest.tools/v3/assert"
 )
@@ -24,12 +25,12 @@ func makeResult(msgs chan events.Message, errs chan error) client.EventsResult {
 	return client.EventsResult{Messages: msgs, Err: errs}
 }
 
-func build(_ context.Context, msg events.Message) (sablier.InstanceInfo, bool) {
+func build(_ context.Context, msg events.Message) (sablier.InstanceEvent, bool) {
 	name := strings.TrimPrefix(msg.Actor.Attributes["name"], "/")
 	if name == "" {
-		return sablier.InstanceInfo{}, false
+		return sablier.InstanceEvent{}, false
 	}
-	return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped}, true
+	return sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped}}, true
 }
 
 // TestStreamEvents_Reconnect verifies that when the first connection drops
@@ -69,8 +70,8 @@ func TestStreamEvents_Reconnect(t *testing.T) {
 	select {
 	case info, ok := <-stream.Events:
 		assert.Assert(t, ok, "events channel closed unexpectedly")
-		assert.Equal(t, info.Name, "web")
-		assert.Equal(t, string(info.Status), string(sablier.InstanceStatusStopped))
+		assert.Equal(t, info.Info.Name, "web")
+		assert.Equal(t, string(info.Info.Status), string(sablier.InstanceStatusStopped))
 		// Clean up: cancel the context so the goroutine exits.
 		cancel()
 	case err := <-stream.Err:

--- a/pkg/provider/dockerswarm/events.go
+++ b/pkg/provider/dockerswarm/events.go
@@ -34,7 +34,7 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 			return sablier.InstanceEvent{}, false
 		}
 		switch msg.Action {
-		case "create":
+		case events.ActionCreate:
 			if !wantCreated {
 				return sablier.InstanceEvent{}, false
 			}
@@ -44,12 +44,16 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 				return sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: sablier.InstanceInfo{Name: name, Provider: sablier.ProviderSwarm}}, true
 			}
 			return sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: info}, true
-		case "remove":
-			if !wantRemoved {
-				return sablier.InstanceEvent{}, false
-			}
+		case events.ActionRemove:
 			// Service is already gone; only the name is available.
-			return sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: sablier.InstanceInfo{Name: name, Provider: sablier.ProviderSwarm}}, true
+			if wantRemoved {
+				return sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: sablier.InstanceInfo{Name: name, Provider: sablier.ProviderSwarm}}, true
+			}
+			// Removal implies the instance is stopped — emit a stopped event for subscribers that care.
+			if wantStopped {
+				return sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderSwarm}}, true
+			}
+			return sablier.InstanceEvent{}, false
 		default:
 			// "update" action — check replicas attributes for scale events.
 			replicasNew := msg.Actor.Attributes["replicas.new"]

--- a/pkg/provider/dockerswarm/events.go
+++ b/pkg/provider/dockerswarm/events.go
@@ -20,44 +20,58 @@ const maxReconnectAttempts = 10
 func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEventsOptions) sablier.InstanceEventStream {
 	wantStopped := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStopped)
 	wantStarted := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStarted)
+	wantCreated := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventCreated)
+	wantRemoved := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventRemoved)
 	dial := func(ctx context.Context) client.EventsResult {
 		filters := client.Filters{}
 		filters.Add("scope", "swarm")
 		filters.Add("type", "service")
 		return p.Client.Events(ctx, client.EventsListOptions{Filters: filters})
 	}
-	// InstanceEventStopped maps to: replicas scaled to 0, or service removed.
-	// InstanceEventStarted maps to: replicas scaled from 0 to >0.
-	build := func(ctx context.Context, msg events.Message) (sablier.InstanceInfo, bool) {
+	build := func(ctx context.Context, msg events.Message) (sablier.InstanceEvent, bool) {
 		name := msg.Actor.Attributes["name"]
 		if name == "" {
-			return sablier.InstanceInfo{}, false
+			return sablier.InstanceEvent{}, false
 		}
-		if msg.Action == "remove" {
-			if wantStopped {
-				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderSwarm}, true
+		switch msg.Action {
+		case "create":
+			if !wantCreated {
+				return sablier.InstanceEvent{}, false
 			}
-			return sablier.InstanceInfo{}, false
-		}
-		replicasNew := msg.Actor.Attributes["replicas.new"]
-		replicasOld := msg.Actor.Attributes["replicas.old"]
-		if replicasNew == "0" && wantStopped {
 			info, err := p.InstanceInspect(ctx, name)
 			if err != nil {
-				p.l.WarnContext(ctx, "inspect after scale-to-0 event failed, using bare info", "service", name, "error", err)
-				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderSwarm}, true
+				p.l.WarnContext(ctx, "inspect after create event failed, using bare info", "service", name, "error", err)
+				return sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: sablier.InstanceInfo{Name: name, Provider: sablier.ProviderSwarm}}, true
 			}
-			return info, true
-		}
-		if replicasOld == "0" && replicasNew != "" && replicasNew != "0" && wantStarted {
-			info, err := p.InstanceInspect(ctx, name)
-			if err != nil {
-				p.l.WarnContext(ctx, "inspect after scale-from-0 event failed, using bare info", "service", name, "error", err)
-				return sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderSwarm}, true
+			return sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: info}, true
+		case "remove":
+			if !wantRemoved {
+				return sablier.InstanceEvent{}, false
 			}
-			return info, true
+			// Service is already gone; only the name is available.
+			return sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: sablier.InstanceInfo{Name: name, Provider: sablier.ProviderSwarm}}, true
+		default:
+			// "update" action — check replicas attributes for scale events.
+			replicasNew := msg.Actor.Attributes["replicas.new"]
+			replicasOld := msg.Actor.Attributes["replicas.old"]
+			if replicasNew == "0" && wantStopped {
+				info, err := p.InstanceInspect(ctx, name)
+				if err != nil {
+					p.l.WarnContext(ctx, "inspect after scale-to-0 event failed, using bare info", "service", name, "error", err)
+					return sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderSwarm}}, true
+				}
+				return sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: info}, true
+			}
+			if replicasOld == "0" && replicasNew != "" && replicasNew != "0" && wantStarted {
+				info, err := p.InstanceInspect(ctx, name)
+				if err != nil {
+					p.l.WarnContext(ctx, "inspect after scale-from-0 event failed, using bare info", "service", name, "error", err)
+					return sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: name, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderSwarm}}, true
+				}
+				return sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: info}, true
+			}
+			return sablier.InstanceEvent{}, false
 		}
-		return sablier.InstanceInfo{}, false
 	}
 	return streamEvents(ctx, p.l, dial, build, linearBackoff)
 }
@@ -72,10 +86,10 @@ func streamEvents(
 	ctx context.Context,
 	l *slog.Logger,
 	dial func(ctx context.Context) client.EventsResult,
-	build func(context.Context, events.Message) (sablier.InstanceInfo, bool),
+	build func(context.Context, events.Message) (sablier.InstanceEvent, bool),
 	backoff func(attempt int) time.Duration,
 ) sablier.InstanceEventStream {
-	eventsC := make(chan sablier.InstanceInfo)
+	eventsC := make(chan sablier.InstanceEvent)
 	errC := make(chan error, 1)
 	go func() {
 		defer close(eventsC)
@@ -106,9 +120,9 @@ func streamEvents(
 func consumeEvents(
 	ctx context.Context,
 	l *slog.Logger,
-	instance chan<- sablier.InstanceInfo,
+	instance chan<- sablier.InstanceEvent,
 	result client.EventsResult,
-	build func(context.Context, events.Message) (sablier.InstanceInfo, bool),
+	build func(context.Context, events.Message) (sablier.InstanceEvent, bool),
 ) (reconnect bool) {
 	for {
 		select {
@@ -118,8 +132,8 @@ func consumeEvents(
 				return true
 			}
 			l.DebugContext(ctx, "event received", "event", msg)
-			if info, ok := build(ctx, msg); ok {
-				instance <- info
+			if event, ok := build(ctx, msg); ok {
+				instance <- event
 			}
 		case err, ok := <-result.Err:
 			if !ok || errors.Is(err, io.EOF) {

--- a/pkg/provider/dockerswarm/events_test.go
+++ b/pkg/provider/dockerswarm/events_test.go
@@ -118,3 +118,40 @@ func TestDockerSwarmProvider_InstanceEvents_Started(t *testing.T) {
 		t.Fatalf("timed out waiting for service started event: %v", ctx.Err())
 	}
 }
+
+func TestDockerSwarmProvider_InstanceEvents_Created(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	dind := sharedDinD
+	p, err := dockerswarm.New(ctx, dind.client, slogt.New(t))
+	assert.NilError(t, err)
+
+	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated},
+	})
+
+	c, err := dind.CreateMimic(ctx, MimicOptions{})
+	assert.NilError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = dind.client.ServiceRemove(context.Background(), c.ID, client.ServiceRemoveOptions{})
+	})
+
+	inspectResult, err := dind.client.ServiceInspect(ctx, c.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+
+	select {
+	case info := <-stream.Events:
+		assert.Equal(t, info.Info.Name, inspectResult.Service.Spec.Name)
+		assert.Equal(t, info.Info.Provider, "swarm")
+		assert.Assert(t, info.Info.Swarm != nil)
+	case err := <-stream.Err:
+		t.Fatalf("unexpected error: %v", err)
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for service created event: %v", ctx.Err())
+	}
+}

--- a/pkg/provider/dockerswarm/events_test.go
+++ b/pkg/provider/dockerswarm/events_test.go
@@ -43,9 +43,9 @@ func TestDockerSwarmProvider_InstanceEvents(t *testing.T) {
 
 		select {
 		case info := <-stream.Events:
-			assert.Equal(t, info.Name, service.Spec.Name)
-			assert.Equal(t, info.Provider, "swarm")
-			assert.Assert(t, info.Swarm != nil)
+			assert.Equal(t, info.Info.Name, service.Spec.Name)
+			assert.Equal(t, info.Info.Provider, "swarm")
+			assert.Assert(t, info.Info.Swarm != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -61,8 +61,8 @@ func TestDockerSwarmProvider_InstanceEvents(t *testing.T) {
 
 		select {
 		case info := <-stream.Events:
-			assert.Equal(t, info.Name, service.Spec.Name) // Service is removed; provider is still set.
-			assert.Equal(t, info.Provider, "swarm")
+			assert.Equal(t, info.Info.Name, service.Spec.Name) // Service is removed; provider is still set.
+			assert.Equal(t, info.Info.Provider, "swarm")
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -109,9 +109,9 @@ func TestDockerSwarmProvider_InstanceEvents_Started(t *testing.T) {
 
 	select {
 	case info := <-stream.Events:
-		assert.Equal(t, info.Name, service.Spec.Name)
-		assert.Equal(t, info.Provider, "swarm")
-		assert.Assert(t, info.Swarm != nil)
+		assert.Equal(t, info.Info.Name, service.Spec.Name)
+		assert.Equal(t, info.Info.Provider, "swarm")
+		assert.Assert(t, info.Info.Swarm != nil)
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/provider/dockerswarm/events_test.go
+++ b/pkg/provider/dockerswarm/events_test.go
@@ -114,5 +114,7 @@ func TestDockerSwarmProvider_InstanceEvents_Started(t *testing.T) {
 		assert.Assert(t, info.Info.Swarm != nil)
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for service started event: %v", ctx.Err())
 	}
 }

--- a/pkg/provider/dockerswarm/events_test.go
+++ b/pkg/provider/dockerswarm/events_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/neilotoole/slogt"
 	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/provider/dockerswarm"
+	"github.com/sablierapp/sablier/pkg/sablier"
 	"gotest.tools/v3/assert"
 )
 
@@ -44,7 +45,7 @@ func TestDockerSwarmProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Info.Name, service.Spec.Name)
-			assert.Equal(t, info.Info.Provider, "swarm")
+			assert.Equal(t, info.Info.Provider, sablier.ProviderSwarm)
 			assert.Assert(t, info.Info.Swarm != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
@@ -62,7 +63,7 @@ func TestDockerSwarmProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Info.Name, service.Spec.Name) // Service is removed; provider is still set.
-			assert.Equal(t, info.Info.Provider, "swarm")
+			assert.Equal(t, info.Info.Provider, sablier.ProviderSwarm)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -110,7 +111,7 @@ func TestDockerSwarmProvider_InstanceEvents_Started(t *testing.T) {
 	select {
 	case info := <-stream.Events:
 		assert.Equal(t, info.Info.Name, service.Spec.Name)
-		assert.Equal(t, info.Info.Provider, "swarm")
+		assert.Equal(t, info.Info.Provider, sablier.ProviderSwarm)
 		assert.Assert(t, info.Info.Swarm != nil)
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
@@ -147,7 +148,7 @@ func TestDockerSwarmProvider_InstanceEvents_Created(t *testing.T) {
 	select {
 	case info := <-stream.Events:
 		assert.Equal(t, info.Info.Name, inspectResult.Service.Spec.Name)
-		assert.Equal(t, info.Info.Provider, "swarm")
+		assert.Equal(t, info.Info.Provider, sablier.ProviderSwarm)
 		assert.Assert(t, info.Info.Swarm != nil)
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/provider/kubernetes/deployment_events.go
+++ b/pkg/provider/kubernetes/deployment_events.go
@@ -9,11 +9,26 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
-func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier.InstanceInfo, wantStopped, wantStarted bool) cache.SharedIndexInformer {
+func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier.InstanceEvent, wantStopped, wantStarted, wantCreated, wantRemoved bool) cache.SharedIndexInformer {
 	handler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if !wantCreated {
+				return
+			}
+			d := obj.(*appsv1.Deployment)
+			parsed := DeploymentName(d, ParseOptions{Delimiter: p.delimiter})
+			info, err := p.InstanceInspect(ctx, parsed.Original)
+			if err != nil {
+				p.l.WarnContext(ctx, "inspect after add event failed, using bare info", "deployment", parsed.Original, "error", err)
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: sablier.InstanceInfo{Name: parsed.Original, Provider: sablier.ProviderKubernetes}}
+				return
+			}
+			instance <- sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: info}
+		},
 		UpdateFunc: func(old, new interface{}) {
 			newDeployment := new.(*appsv1.Deployment)
 			oldDeployment := old.(*appsv1.Deployment)
@@ -30,23 +45,26 @@ func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier
 				info, err := p.InstanceInspect(ctx, parsed.Original)
 				if err != nil {
 					p.l.WarnContext(ctx, "inspect after scale-to-0 event failed, using bare info", "deployment", parsed.Original, "error", err)
-					instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderKubernetes}
+					instance <- sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderKubernetes}}
 					return
 				}
-				instance <- info
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: info}
 			}
 			if wantStarted && oldReplicas == 0 && newReplicas != 0 {
 				parsed := DeploymentName(newDeployment, ParseOptions{Delimiter: p.delimiter})
 				info, err := p.InstanceInspect(ctx, parsed.Original)
 				if err != nil {
 					p.l.WarnContext(ctx, "inspect after scale-from-0 event failed, using bare info", "deployment", parsed.Original, "error", err)
-					instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderKubernetes}
+					instance <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderKubernetes}}
 					return
 				}
-				instance <- info
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: info}
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
+			if !wantRemoved {
+				return
+			}
 			d := obj.(*appsv1.Deployment)
 			parsed := DeploymentName(d, ParseOptions{Delimiter: p.delimiter})
 			// Deployment is gone; build InstanceInfo from the deleted object directly.
@@ -66,7 +84,7 @@ func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier
 				},
 			}
 			sablier.PopulateEnabledAndGroup(&info, d.Labels)
-			instance <- info
+			instance <- sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: info}
 		},
 	}
 	factory := informers.NewSharedInformerFactoryWithOptions(p.Client, 2*time.Second, informers.WithNamespace(corev1.NamespaceAll))

--- a/pkg/provider/kubernetes/deployment_events.go
+++ b/pkg/provider/kubernetes/deployment_events.go
@@ -62,7 +62,7 @@ func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			if !wantRemoved {
+			if !wantRemoved && !wantStopped {
 				return
 			}
 			d := obj.(*appsv1.Deployment)
@@ -84,7 +84,12 @@ func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier
 				},
 			}
 			sablier.PopulateEnabledAndGroup(&info, d.Labels)
-			instance <- sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: info}
+			if wantRemoved {
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: info}
+			}
+			if wantStopped {
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: info}
+			}
 		},
 	}
 	factory := informers.NewSharedInformerFactoryWithOptions(p.Client, 2*time.Second, informers.WithNamespace(corev1.NamespaceAll))

--- a/pkg/provider/kubernetes/instance_events.go
+++ b/pkg/provider/kubernetes/instance_events.go
@@ -11,11 +11,13 @@ import (
 func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEventsOptions) sablier.InstanceEventStream {
 	wantStopped := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStopped)
 	wantStarted := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStarted)
-	eventsC := make(chan sablier.InstanceInfo)
+	wantCreated := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventCreated)
+	wantRemoved := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventRemoved)
+	eventsC := make(chan sablier.InstanceEvent)
 	errC := make(chan error, 1)
-	informer := p.watchDeployments(ctx, eventsC, wantStopped, wantStarted)
+	informer := p.watchDeployments(ctx, eventsC, wantStopped, wantStarted, wantCreated, wantRemoved)
 	go informer.Run(ctx.Done())
-	informer = p.watchStatefulSets(ctx, eventsC, wantStopped, wantStarted)
+	informer = p.watchStatefulSets(ctx, eventsC, wantStopped, wantStarted, wantCreated, wantRemoved)
 	go informer.Run(ctx.Done())
 	return sablier.InstanceEventStream{Events: eventsC, Err: errC}
 }

--- a/pkg/provider/kubernetes/instance_events_test.go
+++ b/pkg/provider/kubernetes/instance_events_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sablierapp/sablier/pkg/config"
 	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/provider/kubernetes"
+	"github.com/sablierapp/sablier/pkg/sablier"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -48,7 +49,7 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Equal(t, info.Info.Provider, sablier.ProviderKubernetes)
 			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
@@ -69,7 +70,7 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Equal(t, info.Info.Provider, sablier.ProviderKubernetes)
 			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
@@ -94,7 +95,7 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Equal(t, info.Info.Provider, sablier.ProviderKubernetes)
 			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
@@ -116,7 +117,7 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Equal(t, info.Info.Provider, sablier.ProviderKubernetes)
 			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
@@ -173,7 +174,7 @@ func TestKubernetesProvider_InstanceEvents_Started(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Equal(t, info.Info.Provider, sablier.ProviderKubernetes)
 			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
@@ -215,7 +216,7 @@ func TestKubernetesProvider_InstanceEvents_Started(t *testing.T) {
 		select {
 		case info := <-stream.Events:
 			assert.Equal(t, info.Info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Equal(t, info.Info.Provider, sablier.ProviderKubernetes)
 			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
@@ -254,7 +255,7 @@ func TestKubernetesProvider_InstanceEvents_Created(t *testing.T) {
 				if info.Info.Name != expectedName {
 					continue
 				}
-				assert.Equal(t, info.Info.Provider, "kubernetes")
+				assert.Equal(t, info.Info.Provider, sablier.ProviderKubernetes)
 				assert.Assert(t, info.Info.Kubernetes != nil)
 				return
 			case err := <-stream.Err:
@@ -276,7 +277,7 @@ func TestKubernetesProvider_InstanceEvents_Created(t *testing.T) {
 				if info.Info.Name != expectedName {
 					continue
 				}
-				assert.Equal(t, info.Info.Provider, "kubernetes")
+				assert.Equal(t, info.Info.Provider, sablier.ProviderKubernetes)
 				assert.Assert(t, info.Info.Kubernetes != nil)
 				return
 			case err := <-stream.Err:

--- a/pkg/provider/kubernetes/instance_events_test.go
+++ b/pkg/provider/kubernetes/instance_events_test.go
@@ -224,3 +224,66 @@ func TestKubernetesProvider_InstanceEvents_Started(t *testing.T) {
 		}
 	})
 }
+
+func TestKubernetesProvider_InstanceEvents_Created(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	kind := sharedKinD
+	conf := config.NewProviderConfig().Kubernetes
+	conf.QPS = 100
+	conf.Burst = 100
+	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), conf)
+	assert.NilError(t, err)
+
+	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated},
+	})
+
+	t.Run("deployment is created", func(t *testing.T) {
+		d, err := kind.CreateMimicDeployment(ctx, MimicOptions{})
+		assert.NilError(t, err)
+
+		expectedName := kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original
+		for {
+			select {
+			case info := <-stream.Events:
+				if info.Info.Name != expectedName {
+					continue
+				}
+				assert.Equal(t, info.Info.Provider, "kubernetes")
+				assert.Assert(t, info.Info.Kubernetes != nil)
+				return
+			case err := <-stream.Err:
+				t.Fatalf("unexpected error: %v", err)
+			case <-ctx.Done():
+				t.Fatalf("timed out waiting for deployment created event: %v", ctx.Err())
+			}
+		}
+	})
+
+	t.Run("statefulSet is created", func(t *testing.T) {
+		ss, err := kind.CreateMimicStatefulSet(ctx, MimicOptions{})
+		assert.NilError(t, err)
+
+		expectedName := kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original
+		for {
+			select {
+			case info := <-stream.Events:
+				if info.Info.Name != expectedName {
+					continue
+				}
+				assert.Equal(t, info.Info.Provider, "kubernetes")
+				assert.Assert(t, info.Info.Kubernetes != nil)
+				return
+			case err := <-stream.Err:
+				t.Fatalf("unexpected error: %v", err)
+			case <-ctx.Done():
+				t.Fatalf("timed out waiting for statefulset created event: %v", ctx.Err())
+			}
+		}
+	})
+}

--- a/pkg/provider/kubernetes/instance_events_test.go
+++ b/pkg/provider/kubernetes/instance_events_test.go
@@ -47,9 +47,9 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 
 		select {
 		case info := <-stream.Events:
-			assert.Equal(t, info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Provider, "kubernetes")
-			assert.Assert(t, info.Kubernetes != nil)
+			assert.Equal(t, info.Info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -66,9 +66,9 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 
 		select {
 		case info := <-stream.Events:
-			assert.Equal(t, info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Provider, "kubernetes")
-			assert.Assert(t, info.Kubernetes != nil)
+			assert.Equal(t, info.Info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -89,9 +89,9 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 
 		select {
 		case info := <-stream.Events:
-			assert.Equal(t, info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Provider, "kubernetes")
-			assert.Assert(t, info.Kubernetes != nil)
+			assert.Equal(t, info.Info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -109,9 +109,9 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 
 		select {
 		case info := <-stream.Events:
-			assert.Equal(t, info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Provider, "kubernetes")
-			assert.Assert(t, info.Kubernetes != nil)
+			assert.Equal(t, info.Info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -164,9 +164,9 @@ func TestKubernetesProvider_InstanceEvents_Started(t *testing.T) {
 
 		select {
 		case info := <-stream.Events:
-			assert.Equal(t, info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Provider, "kubernetes")
-			assert.Assert(t, info.Kubernetes != nil)
+			assert.Equal(t, info.Info.Name, kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		case <-testCtx.Done():
@@ -206,9 +206,9 @@ func TestKubernetesProvider_InstanceEvents_Started(t *testing.T) {
 
 		select {
 		case info := <-stream.Events:
-			assert.Equal(t, info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
-			assert.Equal(t, info.Provider, "kubernetes")
-			assert.Assert(t, info.Kubernetes != nil)
+			assert.Equal(t, info.Info.Name, kubernetes.StatefulSetName(ss, kubernetes.ParseOptions{Delimiter: "_"}).Original)
+			assert.Equal(t, info.Info.Provider, "kubernetes")
+			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
 		case <-testCtx.Done():

--- a/pkg/provider/kubernetes/instance_events_test.go
+++ b/pkg/provider/kubernetes/instance_events_test.go
@@ -52,6 +52,8 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for statefulset started event: %v", ctx.Err())
 		}
 	})
 	t.Run("deployment is removed", func(t *testing.T) {
@@ -71,6 +73,8 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for statefulset started event: %v", ctx.Err())
 		}
 	})
 	t.Run("statefulSet is scaled to 0 replicas", func(t *testing.T) {
@@ -94,6 +98,8 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for statefulset started event: %v", ctx.Err())
 		}
 	})
 
@@ -114,6 +120,8 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 			assert.Assert(t, info.Info.Kubernetes != nil)
 		case err := <-stream.Err:
 			t.Fatalf("unexpected error: %v", err)
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for statefulset started event: %v", ctx.Err())
 		}
 	})
 }

--- a/pkg/provider/kubernetes/statefulset_events.go
+++ b/pkg/provider/kubernetes/statefulset_events.go
@@ -63,7 +63,7 @@ func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablie
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			if !wantRemoved {
+			if !wantRemoved && !wantStopped {
 				return
 			}
 			ss := obj.(*appsv1.StatefulSet)
@@ -85,7 +85,12 @@ func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablie
 				},
 			}
 			sablier.PopulateEnabledAndGroup(&info, ss.Labels)
-			instance <- sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: info}
+			if wantRemoved {
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: info}
+			}
+			if wantStopped {
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: info}
+			}
 		},
 	}
 	factory := informers.NewSharedInformerFactoryWithOptions(p.Client, 2*time.Second, informers.WithNamespace(core_v1.NamespaceAll))

--- a/pkg/provider/kubernetes/statefulset_events.go
+++ b/pkg/provider/kubernetes/statefulset_events.go
@@ -9,11 +9,26 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
-func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablier.InstanceInfo, wantStopped, wantStarted bool) cache.SharedIndexInformer {
+func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablier.InstanceEvent, wantStopped, wantStarted, wantCreated, wantRemoved bool) cache.SharedIndexInformer {
 	handler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if !wantCreated {
+				return
+			}
+			ss := obj.(*appsv1.StatefulSet)
+			parsed := StatefulSetName(ss, ParseOptions{Delimiter: p.delimiter})
+			info, err := p.InstanceInspect(ctx, parsed.Original)
+			if err != nil {
+				p.l.WarnContext(ctx, "inspect after add event failed, using bare info", "statefulset", parsed.Original, "error", err)
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: sablier.InstanceInfo{Name: parsed.Original, Provider: sablier.ProviderKubernetes}}
+				return
+			}
+			instance <- sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: info}
+		},
 		UpdateFunc: func(old, new interface{}) {
 			newStatefulSet := new.(*appsv1.StatefulSet)
 			oldStatefulSet := old.(*appsv1.StatefulSet)
@@ -31,23 +46,26 @@ func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablie
 				info, err := p.InstanceInspect(ctx, parsed.Original)
 				if err != nil {
 					p.l.WarnContext(ctx, "inspect after scale-to-0 event failed, using bare info", "statefulset", parsed.Original, "error", err)
-					instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderKubernetes}
+					instance <- sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderKubernetes}}
 					return
 				}
-				instance <- info
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: info}
 			}
 			if wantStarted && oldReplicas == 0 && newReplicas != 0 {
 				parsed := StatefulSetName(newStatefulSet, ParseOptions{Delimiter: p.delimiter})
 				info, err := p.InstanceInspect(ctx, parsed.Original)
 				if err != nil {
 					p.l.WarnContext(ctx, "inspect after scale-from-0 event failed, using bare info", "statefulset", parsed.Original, "error", err)
-					instance <- sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderKubernetes}
+					instance <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderKubernetes}}
 					return
 				}
-				instance <- info
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: info}
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
+			if !wantRemoved {
+				return
+			}
 			ss := obj.(*appsv1.StatefulSet)
 			parsed := StatefulSetName(ss, ParseOptions{Delimiter: p.delimiter})
 			// StatefulSet is gone; build InstanceInfo from the deleted object directly.
@@ -67,7 +85,7 @@ func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablie
 				},
 			}
 			sablier.PopulateEnabledAndGroup(&info, ss.Labels)
-			instance <- info
+			instance <- sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: info}
 		},
 	}
 	factory := informers.NewSharedInformerFactoryWithOptions(p.Client, 2*time.Second, informers.WithNamespace(core_v1.NamespaceAll))

--- a/pkg/provider/podman/events_test.go
+++ b/pkg/provider/podman/events_test.go
@@ -46,7 +46,7 @@ func TestPodmanProvider_InstanceEvents(t *testing.T) {
 	select {
 	case info := <-stream.Events:
 		// Podman may or may not prefix container names with "/" — compare without the slash.
-		assert.Equal(t, info.Name, strings.TrimPrefix(inspected.Container.Name, "/"))
+		assert.Equal(t, info.Info.Name, strings.TrimPrefix(inspected.Container.Name, "/"))
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestPodmanProvider_InstanceEvents_Started(t *testing.T) {
 
 	select {
 	case info := <-stream.Events:
-		assert.Equal(t, info.Name, strings.TrimPrefix(inspected.Container.Name, "/"))
+		assert.Equal(t, info.Info.Name, strings.TrimPrefix(inspected.Container.Name, "/"))
 	case err := <-stream.Err:
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/provider/proxmoxlxc/events.go
+++ b/pkg/provider/proxmoxlxc/events.go
@@ -18,7 +18,7 @@ const maxConsecutivePollErrors = 5
 // instances transition from running to stopped (or vice versa). Proxmox VE
 // does not provide a real-time event stream, so polling is used.
 func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEventsOptions) sablier.InstanceEventStream {
-	eventsC := make(chan sablier.InstanceInfo)
+	eventsC := make(chan sablier.InstanceEvent)
 	errC := make(chan error, 1)
 
 	wantStopped := len(opts.Types) == 0 || slices.Contains(opts.Types, provider.InstanceEventStopped)
@@ -88,11 +88,14 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 						if !currentRunning[name] {
 							p.l.DebugContext(ctx, "container stopped detected", slog.String("name", name))
 							select {
-							case eventsC <- sablier.InstanceInfo{
-								Name:            name,
-								CurrentReplicas: 0,
-								DesiredReplicas: p.desiredReplicas,
-								Status:          sablier.InstanceStatusStopped,
+							case eventsC <- sablier.InstanceEvent{
+								Type: provider.InstanceEventStopped,
+								Info: sablier.InstanceInfo{
+									Name:            name,
+									CurrentReplicas: 0,
+									DesiredReplicas: p.desiredReplicas,
+									Status:          sablier.InstanceStatusStopped,
+								},
 							}:
 							case <-ctx.Done():
 								return
@@ -107,11 +110,14 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 						if !running[name] {
 							p.l.DebugContext(ctx, "container started detected", slog.String("name", name))
 							select {
-							case eventsC <- sablier.InstanceInfo{
-								Name:            name,
-								CurrentReplicas: p.desiredReplicas,
-								DesiredReplicas: p.desiredReplicas,
-								Status:          sablier.InstanceStatusStarting,
+							case eventsC <- sablier.InstanceEvent{
+								Type: provider.InstanceEventStarted,
+								Info: sablier.InstanceInfo{
+									Name:            name,
+									CurrentReplicas: p.desiredReplicas,
+									DesiredReplicas: p.desiredReplicas,
+									Status:          sablier.InstanceStatusStarting,
+								},
 							}:
 							case <-ctx.Done():
 								return

--- a/pkg/provider/proxmoxlxc/integration_test.go
+++ b/pkg/provider/proxmoxlxc/integration_test.go
@@ -119,7 +119,7 @@ func TestProxmoxLXCProvider_Integration(t *testing.T) {
 		select {
 		case info, ok := <-stream.Events:
 			assert.Assert(t, ok, "events channel closed unexpectedly")
-			assert.Equal(t, info.Name, env.name)
+			assert.Equal(t, info.Info.Name, env.name)
 		case <-time.After(30 * time.Second):
 			t.Fatal("timed out waiting for stop notification")
 		}

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -4,7 +4,7 @@ type InstanceListOptions struct {
 	All bool
 }
 
-// InstanceEventType identifies which kind of instance state change to subscribe to.
+// InstanceEventType identifies which kind of instance lifecycle change to subscribe to.
 type InstanceEventType string
 
 const (
@@ -12,6 +12,12 @@ const (
 	InstanceEventStopped InstanceEventType = "stopped"
 	// InstanceEventStarted fires when an instance transitions to started / running / scaled-from-zero.
 	InstanceEventStarted InstanceEventType = "started"
+	// InstanceEventCreated fires when a new instance (container/service/workload) is created.
+	InstanceEventCreated InstanceEventType = "created"
+	// InstanceEventUpdated fires when an instance's configuration (e.g. labels) changes.
+	InstanceEventUpdated InstanceEventType = "updated"
+	// InstanceEventRemoved fires when an instance is permanently deleted from the provider.
+	InstanceEventRemoved InstanceEventType = "removed"
 )
 
 // InstanceEventsOptions controls which events InstanceEvents streams.

--- a/pkg/sablier/autostop.go
+++ b/pkg/sablier/autostop.go
@@ -100,18 +100,18 @@ func (s *Sablier) WatchAndStopExternallyStarted(ctx context.Context) {
 				continue
 			}
 			// Only act on Sablier-managed instances.
-			if info.Enabled != "true" {
+			if info.Info.Enabled != "true" {
 				continue
 			}
-			if s.isStartedByUs(ctx, info.Name) {
-				s.l.DebugContext(ctx, "instance started by Sablier, skipping", slog.String("instance", info.Name))
+			if s.isStartedByUs(ctx, info.Info.Name) {
+				s.l.DebugContext(ctx, "instance started by Sablier, skipping", slog.String("instance", info.Info.Name))
 				continue
 			}
-			s.l.InfoContext(ctx, "externally started instance detected, stopping", slog.String("instance", info.Name))
-			if err := s.provider.InstanceStop(ctx, info.Name); err != nil {
-				s.l.ErrorContext(ctx, "failed to stop externally-started instance", slog.String("instance", info.Name), slog.Any("error", err))
+			s.l.InfoContext(ctx, "externally started instance detected, stopping", slog.String("instance", info.Info.Name))
+			if err := s.provider.InstanceStop(ctx, info.Info.Name); err != nil {
+				s.l.ErrorContext(ctx, "failed to stop externally-started instance", slog.String("instance", info.Info.Name), slog.Any("error", err))
 			} else {
-				s.metrics.RecordInstanceStop(info.Name, "externally-started")
+				s.metrics.RecordInstanceStop(info.Info.Name, "externally-started")
 			}
 		case err, ok := <-errC:
 			if !ok {

--- a/pkg/sablier/autostop_test.go
+++ b/pkg/sablier/autostop_test.go
@@ -84,7 +84,7 @@ func TestWatchAndStopExternallyStarted_StopsExternalInstance(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	eventsC := make(chan sablier.InstanceInfo, 1)
+	eventsC := make(chan sablier.InstanceEvent, 1)
 	errC := make(chan error, 1)
 
 	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
@@ -101,7 +101,7 @@ func TestWatchAndStopExternallyStarted_StopsExternalInstance(t *testing.T) {
 	})
 
 	// Send the event before starting the goroutine so the channel is pre-filled.
-	eventsC <- sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}}
 
 	go s.WatchAndStopExternallyStarted(ctx)
 
@@ -123,7 +123,7 @@ func TestWatchAndStopExternallyStarted_SkipsSablierStartedInstance_InStore(t *te
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	eventsC := make(chan sablier.InstanceInfo, 1)
+	eventsC := make(chan sablier.InstanceEvent, 1)
 	errC := make(chan error, 1)
 
 	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
@@ -137,7 +137,7 @@ func TestWatchAndStopExternallyStarted_SkipsSablierStartedInstance_InStore(t *te
 	}, nil)
 
 	// InstanceStop must NOT be called; gomock will fail the test if it is.
-	eventsC <- sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}}
 
 	go s.WatchAndStopExternallyStarted(ctx)
 
@@ -154,7 +154,7 @@ func TestWatchAndStopExternallyStarted_SkipsNonSablierInstance(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	eventsC := make(chan sablier.InstanceInfo, 1)
+	eventsC := make(chan sablier.InstanceEvent, 1)
 	errC := make(chan error, 1)
 
 	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
@@ -162,7 +162,7 @@ func TestWatchAndStopExternallyStarted_SkipsNonSablierInstance(t *testing.T) {
 	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
 
 	// No sessions.Get or InstanceStop expected.
-	eventsC <- sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "false"}
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "false"}}
 
 	go s.WatchAndStopExternallyStarted(ctx)
 
@@ -178,7 +178,7 @@ func TestWatchAndStopExternallyStarted_ReconciliationTicker(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	eventsC := make(chan sablier.InstanceInfo) // no events sent
+	eventsC := make(chan sablier.InstanceEvent) // no events sent
 	errC := make(chan error, 1)
 
 	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
@@ -219,7 +219,7 @@ func TestWatchAndStopExternallyStarted_EventStreamClosed(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	eventsC := make(chan sablier.InstanceInfo)
+	eventsC := make(chan sablier.InstanceEvent)
 	errC := make(chan error, 1)
 
 	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{

--- a/pkg/sablier/group_watch.go
+++ b/pkg/sablier/group_watch.go
@@ -4,23 +4,201 @@ import (
 	"context"
 	"log/slog"
 	"time"
+
+	"github.com/sablierapp/sablier/pkg/provider"
 )
 
+// GroupWatch maintains group membership in sync with the provider.
+//
+// It subscribes to created, updated, and removed instance events to react
+// immediately to changes, and runs a reconciliation loop every 30 seconds
+// as a safety net in case events are missed.
+//
+// Per-instance log messages are emitted for every group assignment change:
+//   - "instance X added to group A (reason: created)"
+//   - "instance X moved from group A to group B (reason: updated)"
+//   - "instance X removed from group A (reason: removed)"
 func (s *Sablier) GroupWatch(ctx context.Context) {
-	// This should be changed to event based instead of polling.
-	ticker := time.NewTicker(2 * time.Second)
+	stream := s.provider.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{
+			provider.InstanceEventCreated,
+			provider.InstanceEventUpdated,
+			provider.InstanceEventRemoved,
+		},
+	})
+	eventsC := stream.Events
+	errC := stream.Err
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	// Initial reconciliation so current state matches provider labels.
+	s.reconcileGroups(ctx, "startup")
+
 	for {
 		select {
 		case <-ctx.Done():
 			s.l.InfoContext(ctx, "stop watching groups", slog.Any("reason", ctx.Err()))
 			return
-		case <-ticker.C:
-			groups, err := s.provider.InstanceGroups(ctx)
-			if err != nil {
-				s.l.ErrorContext(ctx, "cannot retrieve group from provider", slog.Any("reason", err))
-			} else if groups != nil {
-				s.SetGroups(groups)
+
+		case event, ok := <-eventsC:
+			if !ok {
+				s.l.WarnContext(ctx, "group event stream closed; relying on reconciliation ticker")
+				eventsC = nil // disable this case
+				continue
 			}
+			s.handleGroupEvent(ctx, event)
+
+		case err, ok := <-errC:
+			if !ok {
+				errC = nil
+				continue
+			}
+			s.l.ErrorContext(ctx, "group event stream permanently lost; relying on reconciliation ticker", slog.Any("error", err))
+			errC = nil
+			eventsC = nil
+
+		case <-ticker.C:
+			s.reconcileGroups(ctx, "reconciliation")
 		}
 	}
+}
+
+// handleGroupEvent processes a single instance lifecycle event and updates group membership.
+func (s *Sablier) handleGroupEvent(ctx context.Context, event InstanceEvent) {
+	info := event.Info
+	reason := string(event.Type)
+
+	switch event.Type {
+	case provider.InstanceEventCreated:
+		if info.Group == "" {
+			return // not group-managed
+		}
+		previous := s.AddInstanceToGroup(info.Name, info.Group)
+		if previous == "" {
+			s.l.InfoContext(ctx, "instance added to group",
+				slog.String("instance", info.Name),
+				slog.String("group", info.Group),
+				slog.String("reason", reason),
+			)
+		} else if previous != info.Group {
+			s.l.InfoContext(ctx, "instance moved to group",
+				slog.String("instance", info.Name),
+				slog.String("from_group", previous),
+				slog.String("to_group", info.Group),
+				slog.String("reason", reason),
+			)
+		}
+
+	case provider.InstanceEventUpdated:
+		currentGroup := s.GroupForInstance(info.Name)
+		newGroup := info.Group
+		if currentGroup == newGroup {
+			return // group unchanged
+		}
+		if newGroup == "" {
+			// Instance lost its group label.
+			removed := s.RemoveInstanceFromGroup(info.Name)
+			if removed != "" {
+				s.l.InfoContext(ctx, "instance removed from group",
+					slog.String("instance", info.Name),
+					slog.String("group", removed),
+					slog.String("reason", reason),
+				)
+			}
+			return
+		}
+		previous := s.AddInstanceToGroup(info.Name, newGroup)
+		if previous == "" {
+			s.l.InfoContext(ctx, "instance added to group",
+				slog.String("instance", info.Name),
+				slog.String("group", newGroup),
+				slog.String("reason", reason),
+			)
+		} else {
+			s.l.InfoContext(ctx, "instance moved to group",
+				slog.String("instance", info.Name),
+				slog.String("from_group", previous),
+				slog.String("to_group", newGroup),
+				slog.String("reason", reason),
+			)
+		}
+
+	case provider.InstanceEventRemoved:
+		group := s.RemoveInstanceFromGroup(info.Name)
+		if group != "" {
+			s.l.InfoContext(ctx, "instance removed from group",
+				slog.String("instance", info.Name),
+				slog.String("group", group),
+				slog.String("reason", reason),
+			)
+		}
+	}
+}
+
+// reconcileGroups performs a full group resync against the provider.
+func (s *Sablier) reconcileGroups(ctx context.Context, reason string) {
+	groups, err := s.provider.InstanceGroups(ctx)
+	if err != nil {
+		s.l.ErrorContext(ctx, "cannot retrieve groups from provider", slog.String("reason", reason), slog.Any("error", err))
+		return
+	}
+	if groups == nil {
+		return
+	}
+
+	// Build a new instanceToGroup from the provider's authoritative state and
+	// emit per-instance log messages for any changes.
+	newInstanceToGroup := make(map[string]string)
+	for group, instances := range groups {
+		for _, inst := range instances {
+			newInstanceToGroup[inst] = group
+		}
+	}
+
+	// Detect additions and moves.
+	for inst, newGroup := range newInstanceToGroup {
+		oldGroup := s.GroupForInstance(inst)
+		if oldGroup == newGroup {
+			continue
+		}
+		s.AddInstanceToGroup(inst, newGroup)
+		if oldGroup == "" {
+			s.l.InfoContext(ctx, "instance added to group",
+				slog.String("instance", inst),
+				slog.String("group", newGroup),
+				slog.String("reason", reason),
+			)
+		} else {
+			s.l.InfoContext(ctx, "instance moved to group",
+				slog.String("instance", inst),
+				slog.String("from_group", oldGroup),
+				slog.String("to_group", newGroup),
+				slog.String("reason", reason),
+			)
+		}
+	}
+
+	// Detect removals.
+	for inst, oldGroup := range s.instanceToGroupSnapshot() {
+		if _, stillManaged := newInstanceToGroup[inst]; !stillManaged {
+			s.RemoveInstanceFromGroup(inst)
+			s.l.InfoContext(ctx, "instance removed from group",
+				slog.String("instance", inst),
+				slog.String("group", oldGroup),
+				slog.String("reason", reason),
+			)
+		}
+	}
+}
+
+// instanceToGroupSnapshot returns a defensive copy of the reverse map. Safe for concurrent use.
+func (s *Sablier) instanceToGroupSnapshot() map[string]string {
+	s.groupsMu.RLock()
+	defer s.groupsMu.RUnlock()
+	out := make(map[string]string, len(s.instanceToGroup))
+	for k, v := range s.instanceToGroup {
+		out[k] = v
+	}
+	return out
 }

--- a/pkg/sablier/group_watch.go
+++ b/pkg/sablier/group_watch.go
@@ -192,13 +192,16 @@ func (s *Sablier) reconcileGroups(ctx context.Context, reason string) {
 	}
 }
 
-// instanceToGroupSnapshot returns a defensive copy of the reverse map. Safe for concurrent use.
+// instanceToGroupSnapshot returns a snapshot of the current instance→group mapping,
+// derived from s.groups. Safe for concurrent use.
 func (s *Sablier) instanceToGroupSnapshot() map[string]string {
 	s.groupsMu.RLock()
 	defer s.groupsMu.RUnlock()
-	out := make(map[string]string, len(s.instanceToGroup))
-	for k, v := range s.instanceToGroup {
-		out[k] = v
+	out := make(map[string]string)
+	for group, instances := range s.groups {
+		for _, inst := range instances {
+			out[inst] = group
+		}
 	}
 	return out
 }

--- a/pkg/sablier/group_watch_test.go
+++ b/pkg/sablier/group_watch_test.go
@@ -6,14 +6,24 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sablierapp/sablier/pkg/provider"
+	"github.com/sablierapp/sablier/pkg/sablier"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 )
 
 func TestGroupWatch_ContextDone(t *testing.T) {
-	s, _, _ := setupSablier(t)
+	s, _, p := setupSablier(t)
 
 	ctx, cancel := context.WithCancel(t.Context())
+
+	eventsC := make(chan sablier.InstanceEvent)
+	errC := make(chan error, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+
 	cancel()
 
 	done := make(chan struct{})
@@ -29,13 +39,95 @@ func TestGroupWatch_ContextDone(t *testing.T) {
 	}
 }
 
-func TestGroupWatch_UpdatesGroupsOnTick(t *testing.T) {
+func TestGroupWatch_CreatedEvent_AddsToGroup(t *testing.T) {
+	s, _, p := setupSablier(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	eventsC <- sablier.InstanceEvent{
+		Type: provider.InstanceEventCreated,
+		Info: sablier.InstanceInfo{Name: "nginx", Group: "web"},
+	}
+
+	assert.Assert(t, pollFor(t, func() bool {
+		return containsInstance(s.Groups(), "web", "nginx")
+	}, 2*time.Second), "nginx should be in group web after created event")
+}
+
+func TestGroupWatch_RemovedEvent_RemovesFromGroup(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.SetGroups(map[string][]string{"web": {"nginx"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	eventsC <- sablier.InstanceEvent{
+		Type: provider.InstanceEventRemoved,
+		Info: sablier.InstanceInfo{Name: "nginx"},
+	}
+
+	assert.Assert(t, pollFor(t, func() bool {
+		return !containsInstance(s.Groups(), "web", "nginx")
+	}, 2*time.Second), "nginx should no longer be in group web after removed event")
+}
+
+func TestGroupWatch_UpdatedEvent_MovesGroup(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.SetGroups(map[string][]string{"web": {"nginx"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	eventsC <- sablier.InstanceEvent{
+		Type: provider.InstanceEventUpdated,
+		Info: sablier.InstanceInfo{Name: "nginx", Group: "api"},
+	}
+
+	assert.Assert(t, pollFor(t, func() bool {
+		groups := s.Groups()
+		return !containsInstance(groups, "web", "nginx") && containsInstance(groups, "api", "nginx")
+	}, 2*time.Second), "nginx should have moved from group web to group api after updated event")
+}
+
+func TestGroupWatch_ReconciliationUpdatesGroups(t *testing.T) {
 	s, _, p := setupSablier(t)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	called := make(chan struct{}, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
+
 	p.EXPECT().InstanceGroups(gomock.Any()).DoAndReturn(func(context.Context) (map[string][]string, error) {
 		select {
 		case called <- struct{}{}:
@@ -48,12 +140,46 @@ func TestGroupWatch_UpdatesGroupsOnTick(t *testing.T) {
 
 	select {
 	case <-called:
-		cancel()
+		// at least one reconciliation happened (startup call)
 	case <-time.After(3 * time.Second):
-		t.Fatal("group watch did not poll provider")
+		t.Fatal("group watch did not call InstanceGroups")
 	}
 
-	assert.DeepEqual(t, s.Groups(), map[string][]string{"g": {"a", "b"}})
+	assert.Assert(t, pollFor(t, func() bool {
+		return containsInstance(s.Groups(), "g", "a") && containsInstance(s.Groups(), "g", "b")
+	}, 2*time.Second), "expected groups to be populated via reconciliation")
+}
+
+func TestGroupWatch_EventStreamClosed_FallsBackToReconciliation(t *testing.T) {
+	s, _, p := setupSablier(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceEvent)
+	errC := make(chan error, 1)
+	close(eventsC) // simulate immediate stream closure
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	called := make(chan struct{}, 1)
+	p.EXPECT().InstanceGroups(gomock.Any()).DoAndReturn(func(context.Context) (map[string][]string, error) {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+		return map[string][]string{"g": {"x"}}, nil
+	}).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	select {
+	case <-called:
+	case <-time.After(3 * time.Second):
+		t.Fatal("group watch did not call InstanceGroups after stream closure")
+	}
 }
 
 func TestGroupWatch_ProviderErrorDoesNotUpdateGroups(t *testing.T) {
@@ -64,6 +190,10 @@ func TestGroupWatch_ProviderErrorDoesNotUpdateGroups(t *testing.T) {
 	defer cancel()
 
 	called := make(chan struct{}, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
+
 	p.EXPECT().InstanceGroups(gomock.Any()).DoAndReturn(func(context.Context) (map[string][]string, error) {
 		select {
 		case called <- struct{}{}:
@@ -81,5 +211,29 @@ func TestGroupWatch_ProviderErrorDoesNotUpdateGroups(t *testing.T) {
 		t.Fatal("group watch did not poll provider")
 	}
 
+	time.Sleep(50 * time.Millisecond)
 	assert.DeepEqual(t, s.Groups(), map[string][]string{"existing": {"x"}})
+}
+
+// pollFor repeatedly calls check until it returns true or the deadline passes.
+func pollFor(t *testing.T, check func() bool, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if check() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// containsInstance reports whether group contains instance.
+func containsInstance(groups map[string][]string, group, instance string) bool {
+	for _, m := range groups[group] {
+		if m == instance {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/sablier/group_watch_test.go
+++ b/pkg/sablier/group_watch_test.go
@@ -215,6 +215,127 @@ func TestGroupWatch_ProviderErrorDoesNotUpdateGroups(t *testing.T) {
 	assert.DeepEqual(t, s.Groups(), map[string][]string{"existing": {"x"}})
 }
 
+func TestGroupWatch_UpdatedEvent_LostLabel(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.SetGroups(map[string][]string{"web": {"nginx"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	eventsC <- sablier.InstanceEvent{
+		Type: provider.InstanceEventUpdated,
+		Info: sablier.InstanceInfo{Name: "nginx", Group: ""},
+	}
+
+	assert.Assert(t, pollFor(t, func() bool {
+		return !containsInstance(s.Groups(), "web", "nginx")
+	}, 2*time.Second), "nginx should no longer be in group web after losing its label")
+}
+
+func TestGroupWatch_CreatedEvent_MovesToGroup(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.SetGroups(map[string][]string{"web": {"nginx"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	eventsC <- sablier.InstanceEvent{
+		Type: provider.InstanceEventCreated,
+		Info: sablier.InstanceInfo{Name: "nginx", Group: "api"},
+	}
+
+	assert.Assert(t, pollFor(t, func() bool {
+		groups := s.Groups()
+		return !containsInstance(groups, "web", "nginx") && containsInstance(groups, "api", "nginx")
+	}, 2*time.Second), "nginx should have moved from group web to group api after created event")
+}
+
+func TestGroupWatch_UpdatedEvent_GroupUnchanged(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.SetGroups(map[string][]string{"web": {"nginx"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	eventsC <- sablier.InstanceEvent{
+		Type: provider.InstanceEventUpdated,
+		Info: sablier.InstanceInfo{Name: "nginx", Group: "web"},
+	}
+
+	// Give the event time to be processed then assert state is unchanged.
+	time.Sleep(100 * time.Millisecond)
+	groups := s.Groups()
+	assert.Assert(t, containsInstance(groups, "web", "nginx"), "nginx should still be in group web")
+	assert.Equal(t, len(groups["web"]), 1, "nginx should appear exactly once in group web")
+}
+
+func TestGroupWatch_ReconciliationMovesGroup(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.SetGroups(map[string][]string{"web": {"nginx"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{"api": {"nginx"}}, nil).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	assert.Assert(t, pollFor(t, func() bool {
+		groups := s.Groups()
+		return !containsInstance(groups, "web", "nginx") && containsInstance(groups, "api", "nginx")
+	}, 3*time.Second), "nginx should have moved from group web to group api via reconciliation")
+}
+
+func TestGroupWatch_ReconciliationRemovesFromGroup(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.SetGroups(map[string][]string{"web": {"nginx"}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
+	// Provider no longer reports nginx in any group.
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+
+	go s.GroupWatch(ctx)
+
+	assert.Assert(t, pollFor(t, func() bool {
+		return !containsInstance(s.Groups(), "web", "nginx")
+	}, 3*time.Second), "nginx should have been removed from group web via reconciliation")
+}
+
 // pollFor repeatedly calls check until it returns true or the deadline passes.
 func pollFor(t *testing.T, check func() bool, timeout time.Duration) bool {
 	t.Helper()

--- a/pkg/sablier/provider.go
+++ b/pkg/sablier/provider.go
@@ -8,12 +8,18 @@ import (
 
 //go:generate go tool -modfile=../../tools.mod mockgen -package providertest -source=provider.go -destination=../provider/providertest/mock_provider.go *
 
+// InstanceEvent wraps an instance state change with the event type that triggered it.
+type InstanceEvent struct {
+	Type provider.InstanceEventType
+	Info InstanceInfo
+}
+
 // InstanceEventStream is returned by InstanceEvents.
-// Events carries instance state change notifications.
+// Events carries typed instance lifecycle notifications.
 // Err carries a terminal error when the stream cannot be recovered;
 // after an error is sent both channels are closed.
 type InstanceEventStream struct {
-	Events <-chan InstanceInfo
+	Events <-chan InstanceEvent
 	Err    <-chan error
 }
 

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -14,8 +14,9 @@ type Sablier struct {
 	provider Provider
 	sessions Store
 
-	groupsMu sync.RWMutex
-	groups   map[string][]string
+	groupsMu        sync.RWMutex
+	groups          map[string][]string
+	instanceToGroup map[string]string // reverse map: instance → group
 
 	pendingMu     sync.Mutex
 	pendingStarts map[string]*pendingStart
@@ -47,6 +48,7 @@ func New(logger *slog.Logger, store Store, provider Provider) *Sablier {
 		sessions:                      store,
 		groupsMu:                      sync.RWMutex{},
 		groups:                        map[string][]string{},
+		instanceToGroup:               map[string]string{},
 		pendingStarts:                 map[string]*pendingStart{},
 		l:                             logger,
 		metrics:                       metrics.Noop{},
@@ -86,9 +88,71 @@ func (s *Sablier) SetGroups(groups map[string][]string) {
 		groups = map[string][]string{}
 	}
 	if diff := cmp.Diff(s.groups, groups); diff != "" {
-		// TODO: Change this log for a friendly logging, groups rarely change, so we can put some effort on displaying what changed
 		s.l.Info("set groups", slog.Any("old", s.groups), slog.Any("new", groups), slog.Any("diff", diff))
 		s.groups = groups
+		// Rebuild reverse map.
+		s.instanceToGroup = make(map[string]string, len(groups))
+		for group, instances := range groups {
+			for _, inst := range instances {
+				s.instanceToGroup[inst] = group
+			}
+		}
+	}
+}
+
+// GroupForInstance returns the group the instance currently belongs to, or empty string.
+func (s *Sablier) GroupForInstance(name string) string {
+	s.groupsMu.RLock()
+	defer s.groupsMu.RUnlock()
+	return s.instanceToGroup[name]
+}
+
+// AddInstanceToGroup adds instance to the given group, removing it from any previous group.
+// Returns the previous group (empty if none) so the caller can log the transition.
+func (s *Sablier) AddInstanceToGroup(instance, group string) (previous string) {
+	s.groupsMu.Lock()
+	defer s.groupsMu.Unlock()
+	previous = s.instanceToGroup[instance]
+	if previous == group {
+		return previous
+	}
+	// Remove from previous group.
+	if previous != "" {
+		s.removeFromGroup(instance, previous)
+	}
+	// Add to new group.
+	s.instanceToGroup[instance] = group
+	s.groups[group] = append(s.groups[group], instance)
+	return previous
+}
+
+// RemoveInstanceFromGroup removes instance from whichever group it belongs to.
+// Returns the group it was removed from (empty if it wasn't in any group).
+func (s *Sablier) RemoveInstanceFromGroup(instance string) (group string) {
+	s.groupsMu.Lock()
+	defer s.groupsMu.Unlock()
+	group = s.instanceToGroup[instance]
+	if group == "" {
+		return ""
+	}
+	s.removeFromGroup(instance, group)
+	delete(s.instanceToGroup, instance)
+	return group
+}
+
+// removeFromGroup removes instance from the groups slice. Must be called with groupsMu held.
+func (s *Sablier) removeFromGroup(instance, group string) {
+	members := s.groups[group]
+	filtered := members[:0]
+	for _, m := range members {
+		if m != instance {
+			filtered = append(filtered, m)
+		}
+	}
+	if len(filtered) == 0 {
+		delete(s.groups, group)
+	} else {
+		s.groups[group] = filtered
 	}
 }
 

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -14,9 +14,8 @@ type Sablier struct {
 	provider Provider
 	sessions Store
 
-	groupsMu        sync.RWMutex
-	groups          map[string][]string
-	instanceToGroup map[string]string // reverse map: instance → group
+	groupsMu sync.RWMutex
+	groups   map[string][]string
 
 	pendingMu     sync.Mutex
 	pendingStarts map[string]*pendingStart
@@ -46,9 +45,8 @@ func New(logger *slog.Logger, store Store, provider Provider) *Sablier {
 	return &Sablier{
 		provider:                      provider,
 		sessions:                      store,
-		groupsMu:                      sync.RWMutex{},
-		groups:                        map[string][]string{},
-		instanceToGroup:               map[string]string{},
+		groupsMu: sync.RWMutex{},
+		groups:   map[string][]string{},
 		pendingStarts:                 map[string]*pendingStart{},
 		l:                             logger,
 		metrics:                       metrics.Noop{},
@@ -90,13 +88,6 @@ func (s *Sablier) SetGroups(groups map[string][]string) {
 	if diff := cmp.Diff(s.groups, groups); diff != "" {
 		s.l.Info("set groups", slog.Any("old", s.groups), slog.Any("new", groups), slog.Any("diff", diff))
 		s.groups = groups
-		// Rebuild reverse map.
-		s.instanceToGroup = make(map[string]string, len(groups))
-		for group, instances := range groups {
-			for _, inst := range instances {
-				s.instanceToGroup[inst] = group
-			}
-		}
 	}
 }
 
@@ -104,7 +95,20 @@ func (s *Sablier) SetGroups(groups map[string][]string) {
 func (s *Sablier) GroupForInstance(name string) string {
 	s.groupsMu.RLock()
 	defer s.groupsMu.RUnlock()
-	return s.instanceToGroup[name]
+	return s.groupForInstanceLocked(name)
+}
+
+// groupForInstanceLocked scans s.groups to find which group instance belongs to.
+// Must be called with groupsMu held.
+func (s *Sablier) groupForInstanceLocked(name string) string {
+	for group, instances := range s.groups {
+		for _, inst := range instances {
+			if inst == name {
+				return group
+			}
+		}
+	}
+	return ""
 }
 
 // AddInstanceToGroup adds instance to the given group, removing it from any previous group.
@@ -112,16 +116,13 @@ func (s *Sablier) GroupForInstance(name string) string {
 func (s *Sablier) AddInstanceToGroup(instance, group string) (previous string) {
 	s.groupsMu.Lock()
 	defer s.groupsMu.Unlock()
-	previous = s.instanceToGroup[instance]
+	previous = s.groupForInstanceLocked(instance)
 	if previous == group {
 		return previous
 	}
-	// Remove from previous group.
 	if previous != "" {
 		s.removeFromGroup(instance, previous)
 	}
-	// Add to new group.
-	s.instanceToGroup[instance] = group
 	s.groups[group] = append(s.groups[group], instance)
 	return previous
 }
@@ -131,12 +132,11 @@ func (s *Sablier) AddInstanceToGroup(instance, group string) (previous string) {
 func (s *Sablier) RemoveInstanceFromGroup(instance string) (group string) {
 	s.groupsMu.Lock()
 	defer s.groupsMu.Unlock()
-	group = s.instanceToGroup[instance]
+	group = s.groupForInstanceLocked(instance)
 	if group == "" {
 		return ""
 	}
 	s.removeFromGroup(instance, group)
-	delete(s.instanceToGroup, instance)
 	return group
 }
 

--- a/pkg/sabliercmd/start.go
+++ b/pkg/sabliercmd/start.go
@@ -78,11 +78,11 @@ func Start(ctx context.Context, conf config.Config) error {
 	go func() {
 		for {
 			select {
-			case info, ok := <-stream.Events:
+			case event, ok := <-stream.Events:
 				if !ok {
 					return
 				}
-				err := s.RemoveInstance(ctx, info.Name)
+				err := s.RemoveInstance(ctx, event.Info.Name)
 				if err != nil {
 					logger.Warn("could not remove instance", slog.Any("error", err))
 				}


### PR DESCRIPTION
And do a reconciliation loop every 30s.

Previously, we aggressively fetched all groups every two seconds.