### PR TITLE
feat: add poke api endpoint

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -18,6 +18,8 @@ type Sablier interface {
 	RequestSessionGroup(ctx context.Context, group string, duration time.Duration) (*sablier.SessionState, error)
 	RequestReadySession(ctx context.Context, names []string, duration time.Duration, timeout time.Duration) (*sablier.SessionState, error)
 	RequestReadySessionGroup(ctx context.Context, group string, duration time.Duration, timeout time.Duration) (*sablier.SessionState, error)
+	ExtendSession(ctx context.Context, names []string, duration time.Duration) (*sablier.SessionState, error)
+	ExtendSessionGroup(ctx context.Context, group string, duration time.Duration) (*sablier.SessionState, error)
 	InstanceEvents(ctx context.Context, opts provider.InstanceEventsOptions) sablier.InstanceEventStream
 }
 

--- a/internal/api/apitest/mocks_sablier.go
+++ b/internal/api/apitest/mocks_sablier.go
@@ -57,6 +57,36 @@ func (mr *MockSablierMockRecorder) InstanceEvents(ctx, opts any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceEvents", reflect.TypeOf((*MockSablier)(nil).InstanceEvents), ctx, opts)
 }
 
+// ExtendSession mocks base method.
+func (m *MockSablier) ExtendSession(ctx context.Context, names []string, duration time.Duration) (*sablier.SessionState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExtendSession", ctx, names, duration)
+	ret0, _ := ret[0].(*sablier.SessionState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExtendSession indicates an expected call of ExtendSession.
+func (mr *MockSablierMockRecorder) ExtendSession(ctx, names, duration any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtendSession", reflect.TypeOf((*MockSablier)(nil).ExtendSession), ctx, names, duration)
+}
+
+// ExtendSessionGroup mocks base method.
+func (m *MockSablier) ExtendSessionGroup(ctx context.Context, group string, duration time.Duration) (*sablier.SessionState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExtendSessionGroup", ctx, group, duration)
+	ret0, _ := ret[0].(*sablier.SessionState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExtendSessionGroup indicates an expected call of ExtendSessionGroup.
+func (mr *MockSablierMockRecorder) ExtendSessionGroup(ctx, group, duration any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtendSessionGroup", reflect.TypeOf((*MockSablier)(nil).ExtendSessionGroup), ctx, group, duration)
+}
+
 // RequestReadySession mocks base method.
 func (m *MockSablier) RequestReadySession(ctx context.Context, names []string, duration, timeout time.Duration) (*sablier.SessionState, error) {
 	m.ctrl.T.Helper()

--- a/internal/api/poke.go
+++ b/internal/api/poke.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
+
+type PokeRequest struct {
+	Names           []string      `form:"names"`
+	Group           string        `form:"group"`
+	SessionDuration time.Duration `form:"session_duration"`
+}
+
+// Poke registers GET /api/poke. It extends the TTL of an existing session
+// without applying any start strategy. Instances that are not currently
+// tracked by Sablier are reported in the response body but do not cause a
+// non-2xx status code.
+func Poke(router *gin.RouterGroup, s *ServeStrategy) {
+	router.GET("/poke", func(c *gin.Context) {
+		request := PokeRequest{
+			SessionDuration: s.SessionsConfig.DefaultDuration,
+		}
+
+		if err := c.ShouldBind(&request); err != nil {
+			AbortWithProblemDetail(c, ProblemValidation(err))
+			return
+		}
+
+		if len(request.Names) == 0 && request.Group == "" {
+			AbortWithProblemDetail(c, ProblemValidation(errors.New("'names' or 'group' query parameter must be set")))
+			return
+		}
+
+		if len(request.Names) > 0 && request.Group != "" {
+			AbortWithProblemDetail(c, ProblemValidation(errors.New("'names' and 'group' query parameters are both set, only one must be set")))
+			return
+		}
+
+		recordSessionRequest(s.Metrics, "poke", request.Group)
+
+		var sessionState *sablier.SessionState
+		var err error
+		if len(request.Names) > 0 {
+			sessionState, err = s.Sablier.ExtendSession(c.Request.Context(), request.Names, request.SessionDuration)
+		} else {
+			sessionState, err = s.Sablier.ExtendSessionGroup(c.Request.Context(), request.Group, request.SessionDuration)
+			var groupNotFoundError sablier.ErrGroupNotFound
+			if errors.As(err, &groupNotFoundError) {
+				AbortWithProblemDetail(c, ProblemGroupNotFound(groupNotFoundError))
+				return
+			}
+		}
+
+		if err != nil {
+			AbortWithProblemDetail(c, ProblemError(err))
+			return
+		}
+
+		AddSablierHeader(c, sessionState)
+		c.JSON(http.StatusOK, map[string]interface{}{"session": sessionState})
+	})
+}

--- a/internal/api/poke_test.go
+++ b/internal/api/poke_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"github.com/tniswong/go.rfcx/rfc7807"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+)
+
+func TestPoke(t *testing.T) {
+	t.Run("PokeInvalidBind", func(t *testing.T) {
+		app, router, strategy, _ := NewApiTest(t)
+		Poke(router, strategy)
+		r := PerformRequest(app, "GET", "/api/poke?session_duration=invalid")
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+
+	t.Run("PokeWithoutNamesOrGroup", func(t *testing.T) {
+		app, router, strategy, _ := NewApiTest(t)
+		Poke(router, strategy)
+		r := PerformRequest(app, "GET", "/api/poke")
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+
+	t.Run("PokeWithNamesAndGroup", func(t *testing.T) {
+		app, router, strategy, _ := NewApiTest(t)
+		Poke(router, strategy)
+		r := PerformRequest(app, "GET", "/api/poke?names=test&group=test")
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+
+	t.Run("PokeByNames", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		Poke(router, strategy)
+		m.EXPECT().ExtendSession(gomock.Any(), []string{"nginx"}, gomock.Any()).
+			Return(&sablier.SessionState{
+				Instances: map[string]sablier.InstanceInfoWithError{
+					"nginx": {Instance: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusReady}},
+				},
+			}, nil)
+		r := PerformRequest(app, "GET", "/api/poke?names=nginx")
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, SablierStatusReady, r.Header().Get(SablierStatusHeader))
+	})
+
+	t.Run("PokeByGroup", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		Poke(router, strategy)
+		m.EXPECT().ExtendSessionGroup(gomock.Any(), "mygroup", gomock.Any()).
+			Return(&sablier.SessionState{}, nil)
+		r := PerformRequest(app, "GET", "/api/poke?group=mygroup")
+		assert.Equal(t, http.StatusOK, r.Code)
+	})
+
+	t.Run("PokeErrGroupNotFound", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		Poke(router, strategy)
+		m.EXPECT().ExtendSessionGroup(gomock.Any(), "missing", gomock.Any()).
+			Return(nil, sablier.ErrGroupNotFound{
+				Group:           "missing",
+				AvailableGroups: []string{"mygroup"},
+			})
+		r := PerformRequest(app, "GET", "/api/poke?group=missing")
+		assert.Equal(t, http.StatusNotFound, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+
+	t.Run("PokeError", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		Poke(router, strategy)
+		m.EXPECT().ExtendSession(gomock.Any(), []string{"nginx"}, gomock.Any()).
+			Return(nil, errors.New("store unavailable"))
+		r := PerformRequest(app, "GET", "/api/poke?names=nginx")
+		assert.Equal(t, http.StatusInternalServerError, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -24,6 +24,7 @@ func registerRoutes(ctx context.Context, router *gin.Engine, serverConf config.S
 	APIv1 := base.Group("/api")
 	api.StartDynamic(APIv1, s)
 	api.StartBlocking(APIv1, s)
+	api.Poke(APIv1, s)
 	api.ListThemes(APIv1, s)
 	api.InstanceEvents(APIv1, s)
 }

--- a/pkg/sablier/session_extend.go
+++ b/pkg/sablier/session_extend.go
@@ -1,0 +1,83 @@
+package sablier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/store"
+)
+
+// ExtendSession extends the TTL of already-tracked instances in the session
+// store. It does NOT start any instance; if a named instance is not currently
+// tracked, it is reported with a store.ErrKeyNotFound error in the result.
+func (s *Sablier) ExtendSession(ctx context.Context, names []string, duration time.Duration) (*SessionState, error) {
+	s.l.DebugContext(ctx, "extending session", slog.Any("names", names), slog.Duration("duration", duration))
+	if len(names) == 0 {
+		return nil, fmt.Errorf("names cannot be empty")
+	}
+
+	var (
+		wg           sync.WaitGroup
+		mx           sync.Mutex
+		sessionState = &SessionState{Instances: make(map[string]InstanceInfoWithError, len(names))}
+	)
+
+	wg.Add(len(names))
+	for _, name := range names {
+		go func(n string) {
+			defer wg.Done()
+			result := s.extendOne(ctx, n, duration)
+			mx.Lock()
+			sessionState.Instances[n] = result
+			mx.Unlock()
+		}(name)
+	}
+	wg.Wait()
+
+	return sessionState, nil
+}
+
+// ExtendSessionGroup extends the TTL of all instances belonging to a named
+// group. Returns ErrGroupNotFound when the group is unknown.
+func (s *Sablier) ExtendSessionGroup(ctx context.Context, group string, duration time.Duration) (*SessionState, error) {
+	s.l.DebugContext(ctx, "extending session for group", slog.String("group", group), slog.Duration("duration", duration))
+	if group == "" {
+		return nil, fmt.Errorf("group is mandatory")
+	}
+
+	names, ok := s.groups.Get(group)
+	if !ok {
+		return nil, ErrGroupNotFound{
+			Group:           group,
+			AvailableGroups: s.groups.Keys(),
+		}
+	}
+
+	if len(names) == 0 {
+		return nil, fmt.Errorf("group has no members")
+	}
+
+	return s.ExtendSession(ctx, names, duration)
+}
+
+// extendOne refreshes the TTL for a single instance. If the instance is not
+// in the store the error field contains store.ErrKeyNotFound.
+func (s *Sablier) extendOne(ctx context.Context, name string, duration time.Duration) InstanceInfoWithError {
+	info, err := s.sessions.Get(ctx, name)
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return InstanceInfoWithError{Error: fmt.Errorf("instance %q is not tracked by Sablier: %w", name, store.ErrKeyNotFound)}
+		}
+		return InstanceInfoWithError{Error: err}
+	}
+
+	if err := s.sessions.Put(ctx, info, duration); err != nil {
+		return InstanceInfoWithError{Error: fmt.Errorf("could not extend session for %q: %w", name, err)}
+	}
+
+	return InstanceInfoWithError{Instance: info}
+}


### PR DESCRIPTION
This can be used to extended the life duration of a session without themes and blocking behaviors.