### PR TITLE
fix(api): handle multiple error types

### DIFF
--- a/internal/api/problemdetail.go
+++ b/internal/api/problemdetail.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/sablierapp/sablier/pkg/sablier"
 	"github.com/sablierapp/sablier/pkg/theme"
 	"github.com/tniswong/go.rfcx/rfc7807"
-	"net/http"
 )
 
 func ProblemError(e error) rfc7807.Problem {
@@ -49,4 +51,34 @@ func ProblemThemeNotFound(e theme.ErrThemeNotFound) rfc7807.Problem {
 	_ = pb.Extend("requestTheme", e.Theme)
 	_ = pb.Extend("error", e.Error())
 	return pb
+}
+
+func ProblemTimeout(e sablier.ErrTimeout) rfc7807.Problem {
+	return rfc7807.Problem{
+		Type:   "https://sablierapp.dev/#/errors?id=timeout",
+		Title:  http.StatusText(http.StatusGatewayTimeout),
+		Status: http.StatusGatewayTimeout,
+		Detail: fmt.Sprintf("session was not ready after %s", e.Duration),
+	}
+}
+
+func ProblemInstanceNotManaged(e sablier.ErrInstanceNotManaged) rfc7807.Problem {
+	pb := rfc7807.Problem{
+		Type:   "https://sablierapp.dev/#/errors?id=instance-not-managed",
+		Title:  "Instance not managed",
+		Status: http.StatusNotFound,
+		Detail: fmt.Sprintf("instance %q is not managed by Sablier; add the sablier.enable label to the instance", e.Name),
+	}
+	_ = pb.Extend("instance", e.Name)
+	_ = pb.Extend("error", e.Error())
+	return pb
+}
+
+func ProblemRequestCancelled() rfc7807.Problem {
+	return rfc7807.Problem{
+		Type:   "https://sablierapp.dev/#/errors?id=request-cancelled",
+		Title:  "Request Cancelled",
+		Status: http.StatusServiceUnavailable,
+		Detail: "the request was cancelled before the session became ready",
+	}
 }

--- a/internal/api/start_blocking.go
+++ b/internal/api/start_blocking.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
 	"errors"
-	"github.com/gin-gonic/gin"
-	"github.com/sablierapp/sablier/pkg/sablier"
 	"net/http"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
 type BlockingRequest struct {
@@ -45,13 +47,24 @@ func StartBlocking(router *gin.RouterGroup, s *ServeStrategy) {
 			sessionState, err = s.Sablier.RequestReadySession(c.Request.Context(), request.Names, request.SessionDuration, request.Timeout)
 		} else {
 			sessionState, err = s.Sablier.RequestReadySessionGroup(c.Request.Context(), request.Group, request.SessionDuration, request.Timeout)
-			var groupNotFoundError sablier.ErrGroupNotFound
-			if errors.As(err, &groupNotFoundError) {
+			if groupNotFoundError, ok := errors.AsType[sablier.ErrGroupNotFound](err); ok {
 				AbortWithProblemDetail(c, ProblemGroupNotFound(groupNotFoundError))
 				return
 			}
 		}
 		if err != nil {
+			if timeoutErr, ok := errors.AsType[sablier.ErrTimeout](err); ok {
+				AbortWithProblemDetail(c, ProblemTimeout(timeoutErr))
+				return
+			}
+			if notManagedErr, ok := errors.AsType[sablier.ErrInstanceNotManaged](err); ok {
+				AbortWithProblemDetail(c, ProblemInstanceNotManaged(notManagedErr))
+				return
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				AbortWithProblemDetail(c, ProblemRequestCancelled())
+				return
+			}
 			AbortWithProblemDetail(c, ProblemError(err))
 			return
 		}

--- a/internal/api/start_blocking_test.go
+++ b/internal/api/start_blocking_test.go
@@ -1,13 +1,16 @@
 package api
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/sablierapp/sablier/pkg/sablier"
 	"github.com/tniswong/go.rfcx/rfc7807"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
-	"net/http"
-	"testing"
 )
 
 func TestStartBlocking(t *testing.T) {
@@ -73,6 +76,30 @@ func TestStartBlocking(t *testing.T) {
 		m.EXPECT().RequestReadySessionGroup(gomock.Any(), "test", gomock.Any(), gomock.Any()).Return(nil, nil)
 		r := PerformRequest(app, "GET", "/api/strategies/blocking?group=test")
 		assert.Equal(t, http.StatusInternalServerError, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+	t.Run("StartBlockingErrTimeout", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		StartBlocking(router, strategy)
+		m.EXPECT().RequestReadySession(gomock.Any(), []string{"test"}, gomock.Any(), gomock.Any()).Return(nil, sablier.ErrTimeout{Duration: 30 * time.Second})
+		r := PerformRequest(app, "GET", "/api/strategies/blocking?names=test")
+		assert.Equal(t, http.StatusGatewayTimeout, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+	t.Run("StartBlockingErrInstanceNotManaged", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		StartBlocking(router, strategy)
+		m.EXPECT().RequestReadySession(gomock.Any(), []string{"test"}, gomock.Any(), gomock.Any()).Return(nil, sablier.ErrInstanceNotManaged{Name: "test"})
+		r := PerformRequest(app, "GET", "/api/strategies/blocking?names=test")
+		assert.Equal(t, http.StatusNotFound, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+	t.Run("StartBlockingErrRequestCancelled", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		StartBlocking(router, strategy)
+		m.EXPECT().RequestReadySession(gomock.Any(), []string{"test"}, gomock.Any(), gomock.Any()).Return(nil, context.Canceled)
+		r := PerformRequest(app, "GET", "/api/strategies/blocking?names=test")
+		assert.Equal(t, http.StatusServiceUnavailable, r.Code)
 		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
 	})
 }

--- a/internal/api/start_dynamic.go
+++ b/internal/api/start_dynamic.go
@@ -57,8 +57,7 @@ func StartDynamic(router *gin.RouterGroup, s *ServeStrategy) {
 			sessionState, err = s.Sablier.RequestSession(c, request.Names, request.SessionDuration)
 		} else {
 			sessionState, err = s.Sablier.RequestSessionGroup(c, request.Group, request.SessionDuration)
-			var groupNotFoundError sablier.ErrGroupNotFound
-			if errors.As(err, &groupNotFoundError) {
+			if groupNotFoundError, ok := errors.AsType[sablier.ErrGroupNotFound](err); ok {
 				AbortWithProblemDetail(c, ProblemGroupNotFound(groupNotFoundError))
 				return
 			}
@@ -87,8 +86,7 @@ func StartDynamic(router *gin.RouterGroup, s *ServeStrategy) {
 		buf := new(bytes.Buffer)
 		writer := bufio.NewWriter(buf)
 		err = s.Theme.Render(request.Theme, renderOptions, writer)
-		var themeNotFound theme.ErrThemeNotFound
-		if errors.As(err, &themeNotFound) {
+		if themeNotFound, ok := errors.AsType[theme.ErrThemeNotFound](err); ok {
 			AbortWithProblemDetail(c, ProblemThemeNotFound(themeNotFound))
 			return
 		}

--- a/pkg/sablier/instance_request_test.go
+++ b/pkg/sablier/instance_request_test.go
@@ -91,8 +91,8 @@ func TestRequestSession_NewUnlabeledRejectedWhenRejectUnlabeledRequestsEnabled(t
 			session, err := manager.RequestSession(ctx, []string{"nginx"}, time.Minute)
 			assert.NilError(t, err)
 
-			var notManaged sablier.ErrInstanceNotManaged
-			assert.Assert(t, errors.As(session.Instances["nginx"].Error, &notManaged))
+			notManaged, ok := errors.AsType[sablier.ErrInstanceNotManaged](session.Instances["nginx"].Error)
+			assert.Assert(t, ok)
 			assert.Equal(t, notManaged.Name, "nginx")
 		})
 	}

--- a/pkg/sablier/session_request.go
+++ b/pkg/sablier/session_request.go
@@ -135,7 +135,7 @@ func (s *Sablier) requestReadySession(ctx context.Context, names []string, durat
 		return nil, err
 	case <-time.After(timeout):
 		close(quit)
-		return nil, fmt.Errorf("session was not ready after %s", timeout.String())
+		return nil, ErrTimeout{Duration: timeout}
 	}
 }
 

--- a/pkg/sablier/session_request_test.go
+++ b/pkg/sablier/session_request_test.go
@@ -147,8 +147,8 @@ func TestRequestSession_RejectsUnlabeledInstances(t *testing.T) {
 	session, err := manager.RequestSession(ctx, []string{"nginx"}, time.Minute)
 	assert.NilError(t, err)
 
-	var notManaged sablier.ErrInstanceNotManaged
-	assert.Assert(t, errors.As(session.Instances["nginx"].Error, &notManaged))
+	notManaged, ok := errors.AsType[sablier.ErrInstanceNotManaged](session.Instances["nginx"].Error)
+	assert.Assert(t, ok)
 	assert.Equal(t, notManaged.Name, "nginx")
 }
 
@@ -280,7 +280,10 @@ func TestSessionsManager_RequestReadySessionCancelledByTimeout(t *testing.T) {
 			errchan <- err
 		}()
 
-		assert.Error(t, <-errchan, "session was not ready after 1s")
+		err := <-errchan
+		timeoutErr, ok := errors.AsType[sablier.ErrTimeout](err)
+		assert.Assert(t, ok)
+		assert.Equal(t, time.Second, timeoutErr.Duration)
 	})
 }
 

--- a/pkg/sabliercmd/root.go
+++ b/pkg/sabliercmd/root.go
@@ -131,8 +131,7 @@ func initializeConfig(cmd *cobra.Command) error {
 	// if we cannot parse the config file.
 	if err := v.ReadInConfig(); err != nil {
 		// It's okay if there isn't a config file
-		var configFileNotFoundError viper.ConfigFileNotFoundError
-		if !errors.As(err, &configFileNotFoundError) {
+		if _, ok := errors.AsType[viper.ConfigFileNotFoundError](err); !ok {
 			return err
 		}
 	}


### PR DESCRIPTION
This will return the appropriate HTTP Status code based on the error instead of always 500.