### PR TITLE
feat(provider): support CloudNativePG Cluster hibernation in the Kubernetes provider

### DIFF
--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -59,7 +59,19 @@ rules:
       - get     # Retrieve info about specific dep
       - list    # Events
       - watch   # Events
+  # Only required if you manage CloudNativePG Clusters (see below).
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters
+    verbs:
+      - get     # Retrieve info about a specific cluster
+      - list    # Discovery and events
+      - watch   # Events
+      - patch   # Toggle the hibernation annotation
 ```
+
+?> The `postgresql.cnpg.io` rule is optional. When the CloudNativePG CRD is absent, Sablier simply skips CloudNativePG discovery.
 
 ## Register Deployments
 
@@ -96,3 +108,38 @@ spec:
 Sablier checks for the deployment replicas. As soon as the current replicas matches the wanted replicas, then the deployment is considered `ready`.
 
 ?> Kubernetes uses the Pod healthcheck to check if the Pod is up and running. So the provider has a native healthcheck support.
+
+## Register CloudNativePG Clusters
+
+Sablier can also start and stop [CloudNativePG](https://cloudnative-pg.io/) `Cluster` resources. Instead of scaling a replica count, Sablier toggles CloudNativePG's [declarative hibernation](https://cloudnative-pg.io/documentation/current/declarative_hibernation/) annotation:
+
+- **Stop** sets `cnpg.io/hibernation: "on"` — the operator scales the cluster down and removes its workload while keeping the PVCs.
+- **Start** sets `cnpg.io/hibernation: "off"` — the operator resumes the cluster.
+
+Opt-in with the same labels used for deployments and statefulsets:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: opencell-db
+  labels:
+    sablier.enable: "true"
+    sablier.group: opencell
+spec:
+  instances: 3
+  storage:
+    size: 1Gi
+```
+
+This makes it possible to put an application, its Keycloak and its database in a single `sablier.group`, so that a single request wakes up the whole stack and inactivity hibernates all of it.
+
+### Cluster readiness
+
+A CloudNativePG Cluster is considered:
+
+- `stopped` when the `cnpg.io/hibernation` annotation is `"on"`;
+- `ready` when `status.readyInstances` is greater than or equal to `spec.instances`;
+- `starting` otherwise.
+
+?> Resuming a hibernated cluster takes longer than a simple scale-up (PVC reattachment and PostgreSQL recovery). Make sure your reverse-proxy timeouts allow for it.

--- a/pkg/provider/kubernetes/cnpgcluster.go
+++ b/pkg/provider/kubernetes/cnpgcluster.go
@@ -1,0 +1,44 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// KindCNPGCluster is the workload kind used in instance names to identify a
+// CloudNativePG Cluster custom resource (e.g. "cnpgcluster_namespace_name_1").
+const KindCNPGCluster = "cnpgcluster"
+
+// cnpgClusterGVR is the GroupVersionResource of CloudNativePG Cluster resources.
+// See https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-Cluster
+var cnpgClusterGVR = schema.GroupVersionResource{
+	Group:    "postgresql.cnpg.io",
+	Version:  "v1",
+	Resource: "clusters",
+}
+
+// cnpgHibernationAnnotation is the annotation CloudNativePG watches to declaratively
+// hibernate ("on") or resume ("off") a Cluster. Hibernation scales the cluster down
+// and deletes the underlying resources while keeping the PVCs intact.
+// See https://cloudnative-pg.io/documentation/current/declarative_hibernation/
+const cnpgHibernationAnnotation = "cnpg.io/hibernation"
+
+const (
+	cnpgHibernationOn  = "on"
+	cnpgHibernationOff = "off"
+)
+
+// ClusterName builds the ParsedName identifier for a CloudNativePG Cluster,
+// mirroring DeploymentName and StatefulSetName.
+func ClusterName(namespace, name string, opts ParseOptions) ParsedName {
+	original := fmt.Sprintf("%s%s%s%s%s%s%d", KindCNPGCluster, opts.Delimiter, namespace, opts.Delimiter, name, opts.Delimiter, 1)
+
+	return ParsedName{
+		Original:  original,
+		Kind:      KindCNPGCluster,
+		Namespace: namespace,
+		Name:      name,
+		Replicas:  1,
+	}
+}

--- a/pkg/provider/kubernetes/cnpgcluster_events.go
+++ b/pkg/provider/kubernetes/cnpgcluster_events.go
@@ -1,0 +1,144 @@
+package kubernetes
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/sablierapp/sablier/pkg/provider"
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
+
+// clusterCRDInstalled reports whether the CloudNativePG Cluster CRD is served by the
+// API server. It lets InstanceEvents avoid starting a dynamic informer (which would
+// otherwise log continuous list/watch errors) on clusters that don't run CloudNativePG.
+func (p *Provider) clusterCRDInstalled(ctx context.Context) bool {
+	if p.dynamic == nil {
+		return false
+	}
+	_, err := p.dynamic.Resource(cnpgClusterGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		// Transient or permission errors: assume the CRD exists and let the informer surface them.
+		p.l.WarnContext(ctx, "could not verify cloudnativepg CRD presence, enabling cnpg watcher anyway", "error", err)
+		return true
+	}
+	return true
+}
+
+// clusterFromObject extracts the *unstructured.Unstructured from an informer event,
+// unwrapping a tombstone when the final state was missed.
+func clusterFromObject(obj any) (*unstructured.Unstructured, bool) {
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return u, true
+	}
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		return nil, false
+	}
+	u, ok := tombstone.Obj.(*unstructured.Unstructured)
+	return u, ok
+}
+
+func (p *Provider) watchClusters(ctx context.Context, instance chan<- sablier.InstanceEvent, wantStopped, wantStarted, wantCreated, wantRemoved bool) cache.SharedIndexInformer {
+	handler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			if !wantCreated {
+				return
+			}
+			u, ok := clusterFromObject(obj)
+			if !ok {
+				return
+			}
+			parsed := ClusterName(u.GetNamespace(), u.GetName(), ParseOptions{Delimiter: p.delimiter})
+			info, err := p.InstanceInspect(ctx, parsed.Original)
+			if err != nil {
+				p.l.WarnContext(ctx, "inspect after add event failed, using bare info", "cnpgcluster", parsed.Original, "error", err)
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: sablier.InstanceInfo{Name: parsed.Original, Provider: sablier.ProviderKubernetes}}
+				return
+			}
+			instance <- sablier.InstanceEvent{Type: provider.InstanceEventCreated, Info: info}
+		},
+		UpdateFunc: func(old, new any) {
+			newCluster, ok := clusterFromObject(new)
+			if !ok {
+				return
+			}
+			oldCluster, ok := clusterFromObject(old)
+			if !ok {
+				return
+			}
+			if newCluster.GetResourceVersion() == oldCluster.GetResourceVersion() {
+				return
+			}
+
+			oldHibernating := oldCluster.GetAnnotations()[cnpgHibernationAnnotation] == cnpgHibernationOn
+			newHibernating := newCluster.GetAnnotations()[cnpgHibernationAnnotation] == cnpgHibernationOn
+
+			if wantStopped && !oldHibernating && newHibernating {
+				parsed := ClusterName(newCluster.GetNamespace(), newCluster.GetName(), ParseOptions{Delimiter: p.delimiter})
+				info, err := p.InstanceInspect(ctx, parsed.Original)
+				if err != nil {
+					p.l.WarnContext(ctx, "inspect after hibernate event failed, using bare info", "cnpgcluster", parsed.Original, "error", err)
+					instance <- sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStopped, Provider: sablier.ProviderKubernetes}}
+					return
+				}
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: info}
+			}
+			if wantStarted && oldHibernating && !newHibernating {
+				parsed := ClusterName(newCluster.GetNamespace(), newCluster.GetName(), ParseOptions{Delimiter: p.delimiter})
+				info, err := p.InstanceInspect(ctx, parsed.Original)
+				if err != nil {
+					p.l.WarnContext(ctx, "inspect after resume event failed, using bare info", "cnpgcluster", parsed.Original, "error", err)
+					instance <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: parsed.Original, Status: sablier.InstanceStatusStarting, Provider: sablier.ProviderKubernetes}}
+					return
+				}
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: info}
+			}
+		},
+		DeleteFunc: func(obj any) {
+			if !wantRemoved && !wantStopped {
+				return
+			}
+			u, ok := clusterFromObject(obj)
+			if !ok {
+				return
+			}
+			parsed := ClusterName(u.GetNamespace(), u.GetName(), ParseOptions{Delimiter: p.delimiter})
+			// Cluster is gone; build InstanceInfo from the deleted object directly.
+			image, _, _ := unstructured.NestedString(u.Object, "spec", "imageName")
+			labels := u.GetLabels()
+			info := sablier.InstanceInfo{
+				Name:     parsed.Original,
+				Status:   sablier.InstanceStatusStopped,
+				Provider: sablier.ProviderKubernetes,
+				Kubernetes: &sablier.KubernetesWorkloadInfo{
+					Namespace: u.GetNamespace(),
+					Kind:      KindCNPGCluster,
+					Image:     image,
+					Labels:    labels,
+				},
+			}
+			sablier.PopulateEnabledAndGroup(&info, labels)
+			if wantRemoved {
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: info}
+			}
+			if wantStopped {
+				instance <- sablier.InstanceEvent{Type: provider.InstanceEventStopped, Info: info}
+			}
+		},
+	}
+
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(p.dynamic, 2*time.Second, metav1.NamespaceAll, nil)
+	informer := factory.ForResource(cnpgClusterGVR).Informer()
+
+	_, _ = informer.AddEventHandler(handler)
+	return informer
+}

--- a/pkg/provider/kubernetes/cnpgcluster_hibernate.go
+++ b/pkg/provider/kubernetes/cnpgcluster_hibernate.go
@@ -1,0 +1,37 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// clusterHibernate toggles the CloudNativePG declarative hibernation annotation on a
+// Cluster. When hibernate is true the cluster is scaled down and its workload removed
+// (PVCs are kept); when false the operator resumes the cluster. This is the
+// CloudNativePG equivalent of scaling a Deployment/StatefulSet to or from zero.
+func (p *Provider) clusterHibernate(ctx context.Context, config ParsedName, hibernate bool) error {
+	if p.dynamic == nil {
+		return fmt.Errorf("cnpgcluster support requires a dynamic client, none configured")
+	}
+
+	value := cnpgHibernationOff
+	if hibernate {
+		value = cnpgHibernationOn
+	}
+
+	// A merge patch on metadata.annotations adds or overwrites only the hibernation
+	// key, leaving any other annotations on the Cluster untouched.
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, cnpgHibernationAnnotation, value))
+
+	_, err := p.dynamic.Resource(cnpgClusterGVR).Namespace(config.Namespace).Patch(
+		ctx, config.Name, types.MergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot set hibernation=%s on cnpg cluster %s/%s: %w", value, config.Namespace, config.Name, err)
+	}
+
+	return nil
+}

--- a/pkg/provider/kubernetes/cnpgcluster_inspect.go
+++ b/pkg/provider/kubernetes/cnpgcluster_inspect.go
@@ -1,0 +1,73 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
+
+// ClusterInspect reports the state of a CloudNativePG Cluster. The status is derived
+// from the hibernation annotation and the cluster's ready/desired instance counts:
+//   - hibernation "on"                        -> Stopped
+//   - readyInstances >= spec.instances (>0)   -> Ready
+//   - otherwise                               -> Starting
+func (p *Provider) ClusterInspect(ctx context.Context, config ParsedName) (sablier.InstanceInfo, error) {
+	if p.dynamic == nil {
+		return sablier.InstanceInfo{}, fmt.Errorf("cnpgcluster support requires a dynamic client, none configured")
+	}
+
+	u, err := p.dynamic.Resource(cnpgClusterGVR).Namespace(config.Namespace).Get(ctx, config.Name, metav1.GetOptions{})
+	if err != nil {
+		return sablier.InstanceInfo{}, fmt.Errorf("error getting cnpg cluster: %w", err)
+	}
+
+	instances, _, _ := unstructured.NestedInt64(u.Object, "spec", "instances")
+	if instances == 0 {
+		instances = 1 // CloudNativePG defaults spec.instances to 1 when unset
+	}
+	readyInstances, _, _ := unstructured.NestedInt64(u.Object, "status", "readyInstances")
+	image, _, _ := unstructured.NestedString(u.Object, "spec", "imageName")
+
+	hibernation := u.GetAnnotations()[cnpgHibernationAnnotation]
+
+	var status sablier.InstanceStatus
+	switch {
+	case hibernation == cnpgHibernationOn:
+		status = sablier.InstanceStatusStopped
+	case readyInstances >= instances:
+		status = sablier.InstanceStatusReady
+	default:
+		status = sablier.InstanceStatusStarting
+	}
+
+	p.l.DebugContext(ctx, "cnpg cluster inspected",
+		"cluster", config.Name, "namespace", config.Namespace,
+		"instances", instances, "readyInstances", readyInstances, "hibernation", hibernation,
+	)
+
+	info := sablier.InstanceInfo{
+		Name:            config.Original,
+		CurrentReplicas: int32(readyInstances),
+		DesiredReplicas: config.Replicas,
+		Status:          status,
+		Provider:        sablier.ProviderKubernetes,
+	}
+
+	labels := u.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	sablier.PopulateEnabledAndGroup(&info, labels)
+	info.Kubernetes = &sablier.KubernetesWorkloadInfo{
+		Namespace: config.Namespace,
+		Kind:      KindCNPGCluster,
+		Image:     image,
+		Labels:    labels,
+	}
+
+	return info, nil
+}

--- a/pkg/provider/kubernetes/cnpgcluster_integration_test.go
+++ b/pkg/provider/kubernetes/cnpgcluster_integration_test.go
@@ -1,0 +1,184 @@
+package kubernetes_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/neilotoole/slogt"
+	"github.com/sablierapp/sablier/pkg/config"
+	"github.com/sablierapp/sablier/pkg/provider/kubernetes"
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	crdGVR = schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}
+	cnpgGVR = schema.GroupVersionResource{
+		Group:    "postgresql.cnpg.io",
+		Version:  "v1",
+		Resource: "clusters",
+	}
+	cnpgCRDOnce sync.Once
+)
+
+// ensureCNPGClusterCRD installs a minimal CloudNativePG Cluster CRD into the shared
+// cluster (once) so the real API server accepts Cluster resources. It intentionally
+// does not run the CloudNativePG operator: these tests verify Sablier's interactions
+// with the Cluster API (hibernation annotation, listing, inspection), not Postgres.
+func ensureCNPGClusterCRD(ctx context.Context, t *testing.T, kind *kindContainer) {
+	t.Helper()
+	cnpgCRDOnce.Do(func() {
+		crd := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata":   map[string]any{"name": "clusters.postgresql.cnpg.io"},
+			"spec": map[string]any{
+				"group": "postgresql.cnpg.io",
+				"scope": "Namespaced",
+				"names": map[string]any{
+					"plural":   "clusters",
+					"singular": "cluster",
+					"kind":     "Cluster",
+					"listKind": "ClusterList",
+				},
+				"versions": []any{
+					map[string]any{
+						"name":    "v1",
+						"served":  true,
+						"storage": true,
+						"schema": map[string]any{
+							"openAPIV3Schema": map[string]any{
+								"type":                                 "object",
+								"x-kubernetes-preserve-unknown-fields": true,
+							},
+						},
+					},
+				},
+			},
+		}}
+
+		_, err := kind.dynamic.Resource(crdGVR).Create(ctx, crd, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create cnpg cluster CRD: %v", err)
+		}
+
+		// Wait until the API server serves the new resource type.
+		deadline := time.Now().Add(30 * time.Second)
+		for {
+			_, err := kind.dynamic.Resource(cnpgGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{Limit: 1})
+			if err == nil {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("cnpg cluster CRD not established in time: %v", err)
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	})
+}
+
+func createCNPGCluster(ctx context.Context, t *testing.T, kind *kindContainer, name string, labels map[string]string, instances, readyInstances int64) {
+	t.Helper()
+	cluster := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "postgresql.cnpg.io/v1",
+		"kind":       "Cluster",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+			"labels":    toStringMap(labels),
+		},
+		"spec": map[string]any{
+			"instances": instances,
+			"imageName": "ghcr.io/cloudnative-pg/postgresql:16",
+		},
+		"status": map[string]any{
+			"readyInstances": readyInstances,
+		},
+	}}
+
+	_, err := kind.dynamic.Resource(cnpgGVR).Namespace("default").Create(ctx, cluster, metav1.CreateOptions{})
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = kind.dynamic.Resource(cnpgGVR).Namespace("default").Delete(context.Background(), name, metav1.DeleteOptions{})
+	})
+}
+
+func toStringMap(m map[string]string) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func clusterHibernationAnnotation(ctx context.Context, t *testing.T, kind *kindContainer, name string) string {
+	t.Helper()
+	u, err := kind.dynamic.Resource(cnpgGVR).Namespace("default").Get(ctx, name, metav1.GetOptions{})
+	assert.NilError(t, err)
+	return u.GetAnnotations()["cnpg.io/hibernation"]
+}
+
+func TestKubernetesProvider_CNPGCluster(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx := t.Context()
+	kind := sharedKinD
+	ensureCNPGClusterCRD(ctx, t, kind)
+
+	p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
+	assert.NilError(t, err)
+
+	name := "pg-" + generateRandomName()
+	createCNPGCluster(ctx, t, kind, name, map[string]string{
+		"sablier.enable": "true",
+		"sablier.group":  "opencell",
+	}, 1, 1)
+
+	instanceName := kubernetes.ClusterName("default", name, kubernetes.ParseOptions{Delimiter: "_"}).Original
+
+	t.Run("inspect reports ready", func(t *testing.T) {
+		info, err := p.InstanceInspect(ctx, instanceName)
+		assert.NilError(t, err)
+		assert.Equal(t, info.Status, sablier.InstanceStatusReady)
+		assert.Equal(t, info.Kubernetes.Kind, kubernetes.KindCNPGCluster)
+	})
+
+	t.Run("stop hibernates the cluster", func(t *testing.T) {
+		assert.NilError(t, p.InstanceStop(ctx, instanceName))
+		assert.Equal(t, clusterHibernationAnnotation(ctx, t, kind, name), "on")
+
+		info, err := p.InstanceInspect(ctx, instanceName)
+		assert.NilError(t, err)
+		assert.Equal(t, info.Status, sablier.InstanceStatusStopped)
+	})
+
+	t.Run("start resumes the cluster", func(t *testing.T) {
+		assert.NilError(t, p.InstanceStart(ctx, instanceName))
+		assert.Equal(t, clusterHibernationAnnotation(ctx, t, kind, name), "off")
+	})
+
+	t.Run("list discovers the cluster", func(t *testing.T) {
+		instances, err := p.ClusterList(ctx)
+		assert.NilError(t, err)
+		found := false
+		for _, i := range instances {
+			if i.Name == instanceName {
+				found = true
+				assert.DeepEqual(t, i.Groups, []string{"opencell"})
+			}
+		}
+		assert.Assert(t, found, fmt.Sprintf("expected to find %s in cluster list", instanceName))
+	})
+}

--- a/pkg/provider/kubernetes/cnpgcluster_list.go
+++ b/pkg/provider/kubernetes/cnpgcluster_list.go
@@ -1,0 +1,83 @@
+package kubernetes
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
+
+// listClusters returns the CloudNativePG Clusters labelled sablier.enable=true across
+// all namespaces. When the dynamic client is unset or the CloudNativePG CRD is not
+// installed, it returns no clusters rather than an error, so the provider keeps working
+// on clusters that don't run CloudNativePG.
+func (p *Provider) listClusters(ctx context.Context) ([]unstructured.Unstructured, error) {
+	if p.dynamic == nil {
+		return nil, nil
+	}
+
+	list, err := p.dynamic.Resource(cnpgClusterGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		LabelSelector: "sablier.enable=true",
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			p.l.DebugContext(ctx, "cloudnativepg CRD not installed, skipping cnpg cluster discovery")
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return list.Items, nil
+}
+
+func (p *Provider) ClusterList(ctx context.Context) ([]sablier.InstanceConfiguration, error) {
+	items, err := p.listClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	instances := make([]sablier.InstanceConfiguration, 0, len(items))
+	for i := range items {
+		instances = append(instances, p.clusterToInstance(&items[i]))
+	}
+
+	return instances, nil
+}
+
+func (p *Provider) clusterToInstance(u *unstructured.Unstructured) sablier.InstanceConfiguration {
+	labels := u.GetLabels()
+	enabled := labels["sablier.enable"]
+	var groups []string
+	if enabled == "true" {
+		groups = sablier.ParseGroups(labels["sablier.group"])
+	}
+
+	parsed := ClusterName(u.GetNamespace(), u.GetName(), ParseOptions{Delimiter: p.delimiter})
+
+	return sablier.InstanceConfiguration{
+		Name:    parsed.Original,
+		Groups:  groups,
+		Enabled: enabled,
+	}
+}
+
+func (p *Provider) ClusterGroups(ctx context.Context) (map[string][]string, error) {
+	items, err := p.listClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	groups := make(map[string][]string)
+	for i := range items {
+		u := &items[i]
+		parsed := ClusterName(u.GetNamespace(), u.GetName(), ParseOptions{Delimiter: p.delimiter})
+		for _, groupName := range sablier.ParseGroups(u.GetLabels()["sablier.group"]) {
+			groups[groupName] = append(groups[groupName], parsed.Original)
+		}
+	}
+
+	return groups, nil
+}

--- a/pkg/provider/kubernetes/cnpgcluster_test.go
+++ b/pkg/provider/kubernetes/cnpgcluster_test.go
@@ -1,0 +1,177 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/neilotoole/slogt"
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"go.opentelemetry.io/otel"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+// newClusterObj builds an unstructured CloudNativePG Cluster for tests.
+func newClusterObj(namespace, name string, labels, annotations map[string]string, instances, readyInstances int64) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("postgresql.cnpg.io/v1")
+	u.SetKind("Cluster")
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	if labels != nil {
+		u.SetLabels(labels)
+	}
+	if annotations != nil {
+		u.SetAnnotations(annotations)
+	}
+	_ = unstructured.SetNestedField(u.Object, instances, "spec", "instances")
+	_ = unstructured.SetNestedField(u.Object, "ghcr.io/cloudnative-pg/postgresql:16", "spec", "imageName")
+	_ = unstructured.SetNestedField(u.Object, readyInstances, "status", "readyInstances")
+	return u
+}
+
+func newFakeCNPGProvider(t *testing.T, objs ...runtime.Object) *Provider {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{cnpgClusterGVR: "ClusterList"},
+		objs...,
+	)
+	return &Provider{
+		dynamic:   dyn,
+		delimiter: "_",
+		l:         slogt.New(t),
+		tracer:    otel.Tracer("test"),
+	}
+}
+
+func TestProvider_ClusterInspect(t *testing.T) {
+	t.Parallel()
+
+	enabled := map[string]string{"sablier.enable": "true", "sablier.group": "opencell"}
+
+	tests := []struct {
+		name           string
+		labels         map[string]string
+		annotations    map[string]string
+		instances      int64
+		readyInstances int64
+		wantStatus     sablier.InstanceStatus
+	}{
+		{
+			name:           "ready when all instances are ready",
+			labels:         enabled,
+			instances:      3,
+			readyInstances: 3,
+			wantStatus:     sablier.InstanceStatusReady,
+		},
+		{
+			name:           "starting when not all instances are ready",
+			labels:         enabled,
+			instances:      3,
+			readyInstances: 1,
+			wantStatus:     sablier.InstanceStatusStarting,
+		},
+		{
+			name:           "stopped when hibernation annotation is on",
+			labels:         enabled,
+			annotations:    map[string]string{cnpgHibernationAnnotation: cnpgHibernationOn},
+			instances:      3,
+			readyInstances: 0,
+			wantStatus:     sablier.InstanceStatusStopped,
+		},
+		{
+			name:           "hibernation on takes precedence over ready instances",
+			labels:         enabled,
+			annotations:    map[string]string{cnpgHibernationAnnotation: cnpgHibernationOn},
+			instances:      1,
+			readyInstances: 1,
+			wantStatus:     sablier.InstanceStatusStopped,
+		},
+		{
+			name:           "ready with defaulted single instance",
+			labels:         enabled,
+			instances:      0, // unset -> defaults to 1
+			readyInstances: 1,
+			wantStatus:     sablier.InstanceStatusReady,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			obj := newClusterObj("default", "pg", tc.labels, tc.annotations, tc.instances, tc.readyInstances)
+			p := newFakeCNPGProvider(t, obj)
+
+			parsed := ClusterName("default", "pg", ParseOptions{Delimiter: "_"})
+			info, err := p.ClusterInspect(context.Background(), parsed)
+			assert.NilError(t, err)
+			assert.Equal(t, info.Status, tc.wantStatus)
+			assert.Equal(t, info.Provider, sablier.ProviderKubernetes)
+			assert.Assert(t, info.Kubernetes != nil)
+			assert.Equal(t, info.Kubernetes.Kind, KindCNPGCluster)
+			assert.Equal(t, info.Kubernetes.Image, "ghcr.io/cloudnative-pg/postgresql:16")
+		})
+	}
+}
+
+func TestProvider_ClusterHibernate(t *testing.T) {
+	t.Parallel()
+
+	getAnnotation := func(t *testing.T, p *Provider) string {
+		t.Helper()
+		u, err := p.dynamic.Resource(cnpgClusterGVR).Namespace("default").Get(context.Background(), "pg", metav1.GetOptions{})
+		assert.NilError(t, err)
+		return u.GetAnnotations()[cnpgHibernationAnnotation]
+	}
+
+	t.Run("stop sets hibernation on", func(t *testing.T) {
+		t.Parallel()
+		obj := newClusterObj("default", "pg", nil, nil, 1, 1)
+		p := newFakeCNPGProvider(t, obj)
+
+		parsed := ClusterName("default", "pg", ParseOptions{Delimiter: "_"})
+		assert.NilError(t, p.InstanceStop(context.Background(), parsed.Original))
+		assert.Equal(t, getAnnotation(t, p), cnpgHibernationOn)
+	})
+
+	t.Run("start sets hibernation off", func(t *testing.T) {
+		t.Parallel()
+		obj := newClusterObj("default", "pg", nil, map[string]string{cnpgHibernationAnnotation: cnpgHibernationOn}, 1, 0)
+		p := newFakeCNPGProvider(t, obj)
+
+		parsed := ClusterName("default", "pg", ParseOptions{Delimiter: "_"})
+		assert.NilError(t, p.InstanceStart(context.Background(), parsed.Original))
+		assert.Equal(t, getAnnotation(t, p), cnpgHibernationOff)
+	})
+}
+
+func TestProvider_ClusterListAndGroups(t *testing.T) {
+	t.Parallel()
+
+	enabled := newClusterObj("default", "pg-opencell",
+		map[string]string{"sablier.enable": "true", "sablier.group": "opencell"}, nil, 1, 1)
+	enabledDefaultGroup := newClusterObj("default", "pg-solo",
+		map[string]string{"sablier.enable": "true"}, nil, 1, 1)
+	disabled := newClusterObj("default", "pg-ignored", nil, nil, 1, 1)
+
+	p := newFakeCNPGProvider(t, enabled, enabledDefaultGroup, disabled)
+
+	instances, err := p.ClusterList(context.Background())
+	assert.NilError(t, err)
+	// Only the two sablier.enable=true clusters are listed.
+	assert.Equal(t, len(instances), 2)
+
+	groups, err := p.ClusterGroups(context.Background())
+	assert.NilError(t, err)
+
+	opencell := ClusterName("default", "pg-opencell", ParseOptions{Delimiter: "_"}).Original
+	solo := ClusterName("default", "pg-solo", ParseOptions{Delimiter: "_"}).Original
+	assert.DeepEqual(t, groups["opencell"], []string{opencell})
+	assert.DeepEqual(t, groups["default"], []string{solo})
+}

--- a/pkg/provider/kubernetes/deployment_inspect_test.go
+++ b/pkg/provider/kubernetes/deployment_inspect_test.go
@@ -156,7 +156,7 @@ func TestKubernetesProvider_DeploymentInspect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			p, err := kubernetes.New(ctx, c.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+			p, err := kubernetes.New(ctx, c.client, c.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
 			assert.NilError(t, err)
 
 			name, err := tt.args.do(c)

--- a/pkg/provider/kubernetes/instance_events.go
+++ b/pkg/provider/kubernetes/instance_events.go
@@ -19,5 +19,11 @@ func (p *Provider) InstanceEvents(ctx context.Context, opts provider.InstanceEve
 	go informer.Run(ctx.Done())
 	informer = p.watchStatefulSets(ctx, eventsC, wantStopped, wantStarted, wantCreated, wantRemoved)
 	go informer.Run(ctx.Done())
+	// Only watch CloudNativePG Clusters when the CRD is present, to avoid noisy
+	// list/watch errors on clusters that don't run CloudNativePG.
+	if p.clusterCRDInstalled(ctx) {
+		informer = p.watchClusters(ctx, eventsC, wantStopped, wantStarted, wantCreated, wantRemoved)
+		go informer.Run(ctx.Done())
+	}
 	return sablier.InstanceEventStream{Events: eventsC, Err: errC}
 }

--- a/pkg/provider/kubernetes/instance_events_test.go
+++ b/pkg/provider/kubernetes/instance_events_test.go
@@ -25,7 +25,7 @@ func TestKubernetesProvider_InstanceEvents(t *testing.T) {
 	conf := config.NewProviderConfig().Kubernetes
 	conf.QPS = 100
 	conf.Burst = 100
-	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), conf)
+	p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), conf)
 	assert.NilError(t, err)
 
 	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{
@@ -138,7 +138,7 @@ func TestKubernetesProvider_InstanceEvents_Started(t *testing.T) {
 	conf := config.NewProviderConfig().Kubernetes
 	conf.QPS = 100
 	conf.Burst = 100
-	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), conf)
+	p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), conf)
 	assert.NilError(t, err)
 
 	t.Run("deployment is scaled from 0 replicas", func(t *testing.T) {
@@ -237,7 +237,7 @@ func TestKubernetesProvider_InstanceEvents_Created(t *testing.T) {
 	conf := config.NewProviderConfig().Kubernetes
 	conf.QPS = 100
 	conf.Burst = 100
-	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), conf)
+	p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), conf)
 	assert.NilError(t, err)
 
 	stream := p.InstanceEvents(ctx, provider.InstanceEventsOptions{

--- a/pkg/provider/kubernetes/instance_inspect.go
+++ b/pkg/provider/kubernetes/instance_inspect.go
@@ -17,7 +17,9 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 		return p.DeploymentInspect(ctx, parsed)
 	case "statefulset":
 		return p.StatefulSetInspect(ctx, parsed)
+	case KindCNPGCluster:
+		return p.ClusterInspect(ctx, parsed)
 	default:
-		return sablier.InstanceInfo{}, fmt.Errorf("unsupported kind \"%s\" must be one of \"deployment\", \"statefulset\"", parsed.Kind)
+		return sablier.InstanceInfo{}, fmt.Errorf("unsupported kind \"%s\" must be one of \"deployment\", \"statefulset\", \"cnpgcluster\"", parsed.Kind)
 	}
 }

--- a/pkg/provider/kubernetes/instance_inspect_test.go
+++ b/pkg/provider/kubernetes/instance_inspect_test.go
@@ -38,14 +38,14 @@ func TestKubernetesProvider_InstanceInspect(t *testing.T) {
 			args: args{
 				name: "service_default_my-service_1",
 			},
-			want: fmt.Errorf("unsupported kind \"service\" must be one of \"deployment\", \"statefulset\""),
+			want: fmt.Errorf("unsupported kind \"service\" must be one of \"deployment\", \"statefulset\", \"cnpgcluster\""),
 		},
 	}
 	c := sharedKinD
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			p, err := kubernetes.New(ctx, c.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+			p, err := kubernetes.New(ctx, c.client, c.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
 			assert.NilError(t, err)
 
 			_, err = p.InstanceInspect(ctx, tt.args.name)

--- a/pkg/provider/kubernetes/instance_list.go
+++ b/pkg/provider/kubernetes/instance_list.go
@@ -18,7 +18,14 @@ func (p *Provider) InstanceList(ctx context.Context, options provider.InstanceLi
 		return nil, err
 	}
 
-	return append(deployments, statefulSets...), nil
+	clusters, err := p.ClusterList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	instances := append(deployments, statefulSets...)
+	instances = append(instances, clusters...)
+	return instances, nil
 }
 
 func (p *Provider) InstanceGroups(ctx context.Context) (map[string][]string, error) {
@@ -32,10 +39,19 @@ func (p *Provider) InstanceGroups(ctx context.Context) (map[string][]string, err
 		return nil, err
 	}
 
+	clusters, err := p.ClusterGroups(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	groups := make(map[string][]string)
 	maps.Copy(groups, deployments)
 
 	for group, instances := range statefulSets {
+		groups[group] = append(groups[group], instances...)
+	}
+
+	for group, instances := range clusters {
 		groups[group] = append(groups[group], instances...)
 	}
 

--- a/pkg/provider/kubernetes/instance_list_test.go
+++ b/pkg/provider/kubernetes/instance_list_test.go
@@ -22,7 +22,7 @@ func TestKubernetesProvider_InstanceList(t *testing.T) {
 
 	ctx := t.Context()
 	kind := sharedKinD
-	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+	p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
 	assert.NilError(t, err)
 
 	d1, err := kind.CreateMimicDeployment(ctx, MimicOptions{
@@ -112,7 +112,7 @@ func TestKubernetesProvider_InstanceGroups(t *testing.T) {
 
 	ctx := t.Context()
 	kind := sharedKinD
-	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+	p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
 	assert.NilError(t, err)
 
 	d1, err := kind.CreateMimicDeployment(ctx, MimicOptions{

--- a/pkg/provider/kubernetes/instance_start.go
+++ b/pkg/provider/kubernetes/instance_start.go
@@ -27,6 +27,13 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) (err error) {
 		return err
 	}
 
+	// CloudNativePG Clusters are resumed by clearing the hibernation annotation
+	// rather than scaling a replica count, so they bypass the scale-mode logic.
+	if parsed.Kind == KindCNPGCluster {
+		span.SetAttributes(attribute.String("operation", "cnpg_resume"))
+		return p.clusterHibernate(ctx, parsed, false)
+	}
+
 	labels, err := p.getWorkloadLabels(ctx, parsed)
 	if err != nil {
 		return err

--- a/pkg/provider/kubernetes/instance_start_test.go
+++ b/pkg/provider/kubernetes/instance_start_test.go
@@ -22,7 +22,7 @@ func TestKubernetesProvider_InstanceStart_ScaleMode(t *testing.T) {
 
 	ctx := context.Background()
 	kind := sharedKinD
-	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+	p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
 	assert.NilError(t, err)
 
 	t.Run("deployment scale mode active resources applied", func(t *testing.T) {
@@ -257,7 +257,7 @@ func TestKubernetesProvider_InstanceStart(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			p, err := kubernetes.New(ctx, kind.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+			p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
 			assert.NilError(t, err)
 
 			name, err := tt.args.do(kind)

--- a/pkg/provider/kubernetes/instance_stop.go
+++ b/pkg/provider/kubernetes/instance_stop.go
@@ -27,6 +27,13 @@ func (p *Provider) InstanceStop(ctx context.Context, name string) (err error) {
 		return err
 	}
 
+	// CloudNativePG Clusters are stopped via the hibernation annotation rather than
+	// scaling a replica count, so they bypass the scale-mode logic.
+	if parsed.Kind == KindCNPGCluster {
+		span.SetAttributes(attribute.String("operation", "cnpg_hibernate"))
+		return p.clusterHibernate(ctx, parsed, true)
+	}
+
 	labels, err := p.getWorkloadLabels(ctx, parsed)
 	if err != nil {
 		return err

--- a/pkg/provider/kubernetes/instance_stop_test.go
+++ b/pkg/provider/kubernetes/instance_stop_test.go
@@ -22,7 +22,7 @@ func TestKubernetesProvider_InstanceStop_ScaleMode(t *testing.T) {
 
 	ctx := context.Background()
 	kind := sharedKinD
-	p, err := kubernetes.New(ctx, kind.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+	p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
 	assert.NilError(t, err)
 
 	t.Run("deployment scale mode idle resources applied", func(t *testing.T) {
@@ -257,7 +257,7 @@ func TestKubernetesProvider_InstanceStop(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			p, err := kubernetes.New(ctx, kind.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+			p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
 			assert.NilError(t, err)
 
 			name, err := tt.args.do(kind)

--- a/pkg/provider/kubernetes/kubernetes.go
+++ b/pkg/provider/kubernetes/kubernetes.go
@@ -6,6 +6,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
 
 	providerConfig "github.com/sablierapp/sablier/pkg/config"
@@ -16,13 +17,17 @@ import (
 var _ sablier.Provider = (*Provider)(nil)
 
 type Provider struct {
-	Client    k8s.Interface
+	Client k8s.Interface
+	// dynamic drives Custom Resources (e.g. CloudNativePG Clusters) that are not
+	// part of the typed clientset. It may be nil when the provider is constructed
+	// without CRD support; CRD-backed operations guard against that.
+	dynamic   dynamic.Interface
 	delimiter string
 	l         *slog.Logger
 	tracer    trace.Tracer
 }
 
-func New(ctx context.Context, client *k8s.Clientset, logger *slog.Logger, config providerConfig.Kubernetes) (*Provider, error) {
+func New(ctx context.Context, client *k8s.Clientset, dynamicClient dynamic.Interface, logger *slog.Logger, config providerConfig.Kubernetes) (*Provider, error) {
 	logger = logger.With(slog.String("provider", "kubernetes"))
 
 	info, err := client.ServerVersion()
@@ -38,6 +43,7 @@ func New(ctx context.Context, client *k8s.Clientset, logger *slog.Logger, config
 
 	return &Provider{
 		Client:    client,
+		dynamic:   dynamicClient,
 		delimiter: config.Delimiter,
 		l:         logger,
 		tracer:    otel.Tracer("github.com/sablierapp/sablier/pkg/provider/kubernetes"),

--- a/pkg/provider/kubernetes/statefulset_inspect_test.go
+++ b/pkg/provider/kubernetes/statefulset_inspect_test.go
@@ -156,7 +156,7 @@ func TestKubernetesProvider_InspectStatefulSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			p, err := kubernetes.New(ctx, c.client, slogt.New(t), config.NewProviderConfig().Kubernetes)
+			p, err := kubernetes.New(ctx, c.client, c.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
 			assert.NilError(t, err)
 
 			name, err := tt.args.do(c)

--- a/pkg/provider/kubernetes/testcontainers_test.go
+++ b/pkg/provider/kubernetes/testcontainers_test.go
@@ -16,7 +16,9 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -29,7 +31,9 @@ var sharedKinD *kindContainer
 
 type kindContainer struct {
 	testcontainers.Container
-	client *kubernetes.Clientset
+	client  *kubernetes.Clientset
+	dynamic dynamic.Interface
+	restcfg *rest.Config
 }
 
 type MimicOptions struct {
@@ -175,9 +179,17 @@ func TestMain(m *testing.M) {
 		log.Fatalf("failed to create kubernetes client: %v", err)
 	}
 
+	dyn, err := dynamic.NewForConfig(restcfg)
+	if err != nil {
+		_ = kind.Terminate(ctx)
+		log.Fatalf("failed to create dynamic client: %v", err)
+	}
+
 	sharedKinD = &kindContainer{
 		Container: kind,
 		client:    k8s,
+		dynamic:   dyn,
+		restcfg:   restcfg,
 	}
 
 	code := m.Run()

--- a/pkg/sabliercmd/provider.go
+++ b/pkg/sabliercmd/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sablierapp/sablier/pkg/provider/podman"
 	"github.com/sablierapp/sablier/pkg/provider/proxmoxlxc"
 	"github.com/sablierapp/sablier/pkg/sablier"
+	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -60,7 +61,13 @@ func setupProvider(ctx context.Context, logger *slog.Logger, config config.Provi
 		if err != nil {
 			return nil, err
 		}
-		return kubernetes.New(ctx, cli, logger, config.Kubernetes)
+		// dynamicCli manages Custom Resources (e.g. CloudNativePG Clusters) that
+		// the typed clientset cannot reach. It shares the same instrumented config.
+		dynamicCli, err := dynamic.NewForConfig(kubeclientConfig)
+		if err != nil {
+			return nil, err
+		}
+		return kubernetes.New(ctx, cli, dynamicCli, logger, config.Kubernetes)
 	case "podman":
 		opts := []client.Opt{client.FromEnv}
 		if config.Podman.Uri != "" {


### PR DESCRIPTION
Closes #943

## What this does

Following up on the discussion in #943, this adds a new `cnpgcluster` workload kind to the Kubernetes provider so Sablier can start and stop [CloudNativePG](https://cloudnative-pg.io/) `Cluster` resources, right next to Deployments and StatefulSets.

Instead of scaling a replica count, Sablier toggles CloudNativePG's declarative hibernation annotation:

- **stop** → `cnpg.io/hibernation: "on"` (operator scales the cluster down and removes its workload, **keeps the PVCs**)
- **start** → `cnpg.io/hibernation: "off"` (operator resumes the cluster)

My use case: I run Opencell as a StatefulSet + a Keycloak + a CloudNativePG database. With this, I can put all three in the same `sablier.group`, so a single request on the Traefik ingress wakes the whole stack and inactivity hibernates all of it — database included.

## Design choices

- **Dynamic client, no new dependency.** I went with `k8s.io/client-go/dynamic` (already pulled by client-go) rather than the typed CloudNativePG client, to keep the dependency footprint minimal — no `controller-runtime`. The dynamic client is wired into the provider next to the typed clientset.
- **Purely additive.** No change to the `sablier.Provider` interface, no new CLI flag. The new kind is routed inside the existing `instance_{start,stop,inspect,list,events}.go`.
- **Safe when CloudNativePG is absent.** If the CRD isn't installed, listing no-ops (returns no clusters instead of erroring) and the events informer isn't started, so non-CNPG clusters are completely unaffected.
- **Readiness mapping:** hibernation `on` → stopped; `status.readyInstances >= spec.instances` → ready; otherwise starting.

New files live alongside the existing per-kind files: `cnpgcluster.go`, `cnpgcluster_hibernate.go`, `cnpgcluster_inspect.go`, `cnpgcluster_list.go`, `cnpgcluster_events.go`, plus tests. Docs updated in `docs/providers/kubernetes.md` (new section + the optional RBAC rule).

## Testing done

I went a bit further than usual on testing because it touches a database:

- **Unit tests** (`cnpgcluster_test.go`) using `client-go/dynamic/fake`: status mapping (ready/starting/stopped), hibernate patching via `InstanceStart`/`InstanceStop`, and list/groups label filtering.
- **Testcontainers integration test** (`cnpgcluster_integration_test.go`), in the same spirit as the existing k3s tests: it installs a minimal Cluster CRD into the shared k3s cluster and verifies inspect / stop / start / list against the real API server. As you mentioned in #943, the CNPG install is done in the test itself (CRD only — no operator needed to validate Sablier's interactions).
- **Real cluster, provider level:** drove the provider against a real CloudNativePG cluster and watched the actual operator hibernate (pods → 0, PVC kept) and resume.
- **Real cluster, full end-to-end:** deployed this build in-cluster behind a Traefik instance with the Sablier plugin, with a CloudNativePG `Cluster` and a `whoami` app sharing one `sablier.group`. First request wakes the whole group (app scaled up + database resumed), then after the session expires both are stopped together (deployment → 0, cluster → hibernated), and a later request blocks ~25s while the database recovers, then serves. Exactly the behaviour I was after.
- `make fmt`, `golangci-lint run`, and the full `pkg/provider/kubernetes` test suite are green.

Happy to adjust anything — naming of the kind, readiness semantics for multi-instance clusters, etc.
