### PR TITLE
feat(provider): pause redis-operator reconciliation during StatefulSet scale-to-zero

### DIFF
--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -69,9 +69,17 @@ rules:
       - list    # Discovery and events
       - watch   # Events
       - patch   # Toggle the hibernation annotation
+  # Only required if you manage OT-CONTAINER-KIT Redis instances (see below).
+  - apiGroups:
+      - redis.redis.opstreelabs.in
+    resources:
+      - redis
+    verbs:
+      - get     # Resolve the Redis CR owner of a StatefulSet
+      - patch   # Toggle the skip-reconcile annotation
 ```
 
-?> The `postgresql.cnpg.io` rule is optional. When the CloudNativePG CRD is absent, Sablier simply skips CloudNativePG discovery.
+?> The `postgresql.cnpg.io` and `redis.redis.opstreelabs.in` rules are optional. Sablier skips those integrations gracefully when the CRDs are absent.
 
 ## Register Deployments
 
@@ -143,3 +151,31 @@ A CloudNativePG Cluster is considered:
 - `starting` otherwise.
 
 ?> Resuming a hibernated cluster takes longer than a simple scale-up (PVC reattachment and PostgreSQL recovery). Make sure your reverse-proxy timeouts allow for it.
+
+## Register OT-CONTAINER-KIT Redis instances
+
+Sablier can scale to zero StatefulSets managed by the [OT-CONTAINER-KIT redis-operator](https://github.com/OT-CONTAINER-KIT/redis-operator). The operator continuously reconciles its StatefulSets back to the desired replica count, so a plain scale-to-zero is immediately undone. Sablier works around this by toggling the operator's own pause mechanism:
+
+- **Stop** sets `redis.opstreelabs.in/skip-reconcile: "true"` on the Redis CR, then scales the StatefulSet to 0.
+- **Start** scales the StatefulSet back to 1, then removes the annotation so the operator resumes normal reconciliation.
+
+If the scale fails, the annotation is cleared immediately so the operator is never left paused with pods still running.
+
+Opt-in by adding the standard Sablier labels to the Redis CR. The operator propagates them to the StatefulSet it manages, so no extra labelling is needed:
+
+```yaml
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: Redis
+metadata:
+  name: myapp-redis
+  labels:
+    sablier.enable: "true"
+    sablier.group: myapp
+spec:
+  kubernetesConfig:
+    image: quay.io/opstree/redis:v7.0.12
+```
+
+This makes it straightforward to group a Redis instance with the rest of an application stack so that a single request wakes everything up and inactivity shuts it all down together.
+
+?> The `redis.redis.opstreelabs.in` RBAC rule (see above) is required for Sablier to patch the skip-reconcile annotation on the Redis CR. If the rule is absent or the CRD is not installed, Sablier logs a warning and scales the StatefulSet anyway — the operator will reconcile replicas back, but no other harm is done.

--- a/pkg/provider/kubernetes/instance_start.go
+++ b/pkg/provider/kubernetes/instance_start.go
@@ -7,6 +7,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
@@ -32,6 +33,25 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) (err error) {
 	if parsed.Kind == KindCNPGCluster {
 		span.SetAttributes(attribute.String("operation", "cnpg_resume"))
 		return p.clusterHibernate(ctx, parsed, false)
+	}
+
+	// For StatefulSets managed by the OT-CONTAINER-KIT redis-operator, re-enable
+	// the operator's reconciliation loop after a successful scale-up. A detached
+	// context is used so a cancelled request context does not prevent the annotation
+	// from being removed even when the scale itself completed successfully.
+	if parsed.Kind == "statefulset" {
+		defer func() {
+			if err == nil {
+				detached := context.WithoutCancel(ctx)
+				ss, fetchErr := p.Client.AppsV1().StatefulSets(parsed.Namespace).Get(detached, parsed.Name, metav1.GetOptions{})
+				if fetchErr != nil {
+					p.l.WarnContext(detached, "cannot fetch statefulset for redis-operator owner check",
+						"namespace", parsed.Namespace, "name", parsed.Name, "error", fetchErr)
+				} else {
+					p.setRedisOperatorSkipReconcile(detached, ss, false)
+				}
+			}
+		}()
 	}
 
 	labels, err := p.getWorkloadLabels(ctx, parsed)

--- a/pkg/provider/kubernetes/instance_stop.go
+++ b/pkg/provider/kubernetes/instance_stop.go
@@ -7,6 +7,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
@@ -62,8 +63,29 @@ func (p *Provider) InstanceStop(ctx context.Context, name string) (err error) {
 		return nil
 	}
 
-	span.SetAttributes(
-		attribute.String("operation", "scale_to_zero"),
-	)
+	span.SetAttributes(attribute.String("operation", "scale_to_zero"))
+
+	// For StatefulSets managed by the OT-CONTAINER-KIT redis-operator, pause the
+	// operator's reconciliation loop before scaling to zero. This prevents the
+	// operator from immediately restoring the replica count. The annotation is
+	// cleared if the scale itself fails so the operator is never left paused with
+	// pods still running.
+	if parsed.Kind == "statefulset" {
+		ss, fetchErr := p.Client.AppsV1().StatefulSets(parsed.Namespace).Get(ctx, parsed.Name, metav1.GetOptions{})
+		if fetchErr != nil {
+			p.l.WarnContext(ctx, "cannot fetch statefulset for redis-operator owner check",
+				"namespace", parsed.Namespace, "name", parsed.Name, "error", fetchErr)
+		} else if _, isRedis := redisOperatorOwner(ss); isRedis {
+			p.setRedisOperatorSkipReconcile(ctx, ss, true)
+			defer func() {
+				if err != nil {
+					// Scale failed: restore operator reconciliation using a detached
+					// context so a cancelled request context doesn't prevent cleanup.
+					p.setRedisOperatorSkipReconcile(context.WithoutCancel(ctx), ss, false)
+				}
+			}()
+		}
+	}
+
 	return p.scale(ctx, parsed, 0)
 }

--- a/pkg/provider/kubernetes/statefulset_redis_operator.go
+++ b/pkg/provider/kubernetes/statefulset_redis_operator.go
@@ -1,0 +1,88 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// redisOperatorGVR is the GroupVersionResource for OT-CONTAINER-KIT standalone
+// Redis custom resources.
+var redisOperatorGVR = schema.GroupVersionResource{
+	Group:    "redis.redis.opstreelabs.in",
+	Version:  "v1beta2",
+	Resource: "redis",
+}
+
+const redisOperatorSkipReconcileAnnotation = "redis.opstreelabs.in/skip-reconcile"
+
+// redisOperatorOwner returns the name of the Redis CR that controls the
+// StatefulSet, if the StatefulSet was created by the OT-CONTAINER-KIT
+// redis-operator. The check matches on API group and Kind only, not on the
+// specific version, so it remains correct when the operator promotes from
+// v1beta2 to v1 or later. Returns ("", false) for any other StatefulSet.
+func redisOperatorOwner(ss *appsv1.StatefulSet) (name string, ok bool) {
+	for _, ref := range ss.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller &&
+			ref.Kind == "Redis" &&
+			apiVersionGroup(ref.APIVersion) == redisOperatorGVR.Group {
+			return ref.Name, true
+		}
+	}
+	return "", false
+}
+
+// apiVersionGroup returns the group portion of a "group/version" APIVersion
+// string (e.g. "apps" from "apps/v1"). Returns the full string unchanged for
+// core resources that have no group prefix.
+func apiVersionGroup(apiVersion string) string {
+	if i := strings.Index(apiVersion, "/"); i >= 0 {
+		return apiVersion[:i]
+	}
+	return apiVersion
+}
+
+// setRedisOperatorSkipReconcile sets or removes the skip-reconcile annotation
+// on the Redis CR that owns ss, if any. When skip is true the redis-operator
+// pauses its reconciliation loop, allowing Sablier to scale the StatefulSet to
+// zero without the operator immediately restoring the replica count. Errors are
+// logged but not returned — annotation failure is non-fatal.
+func (p *Provider) setRedisOperatorSkipReconcile(ctx context.Context, ss *appsv1.StatefulSet, skip bool) {
+	if p.dynamic == nil {
+		return
+	}
+	owner, ok := redisOperatorOwner(ss)
+	if !ok {
+		return
+	}
+
+	var value any = "true"
+	if !skip {
+		value = nil // JSON merge-patch null removes the key
+	}
+
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				redisOperatorSkipReconcileAnnotation: value,
+			},
+		},
+	})
+	if err != nil {
+		p.l.WarnContext(ctx, "cannot marshal redis skip-reconcile patch", "error", err)
+		return
+	}
+
+	_, err = p.dynamic.Resource(redisOperatorGVR).Namespace(ss.Namespace).Patch(
+		ctx, owner, types.MergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		p.l.WarnContext(ctx, "cannot set skip-reconcile on redis owner",
+			"redis", owner, "namespace", ss.Namespace, "skip", skip, "error", err)
+	}
+}

--- a/pkg/provider/kubernetes/statefulset_redis_operator_integration_test.go
+++ b/pkg/provider/kubernetes/statefulset_redis_operator_integration_test.go
@@ -1,0 +1,226 @@
+package kubernetes_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/neilotoole/slogt"
+	"github.com/sablierapp/sablier/pkg/config"
+	"github.com/sablierapp/sablier/pkg/provider/kubernetes"
+	"gotest.tools/v3/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	redisCRDOnce sync.Once
+
+	redisCRDGVR = schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}
+
+	redisGVR = schema.GroupVersionResource{
+		Group:    "redis.redis.opstreelabs.in",
+		Version:  "v1beta2",
+		Resource: "redis",
+	}
+)
+
+// ensureRedisCRD installs a minimal Redis CRD into the shared cluster (once)
+// so the API server accepts Redis resources. It intentionally does not run the
+// redis-operator: these tests verify Sablier's interactions with the Redis API
+// (skip-reconcile annotation, StatefulSet scaling), not Redis itself.
+func ensureRedisCRD(ctx context.Context, t *testing.T, kind *kindContainer) {
+	t.Helper()
+	redisCRDOnce.Do(func() {
+		crd := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata":   map[string]any{"name": "redis.redis.redis.opstreelabs.in"},
+			"spec": map[string]any{
+				"group": "redis.redis.opstreelabs.in",
+				"scope": "Namespaced",
+				"names": map[string]any{
+					"plural":   "redis",
+					"singular": "redis",
+					"kind":     "Redis",
+					"listKind": "RedisList",
+				},
+				"versions": []any{
+					map[string]any{
+						"name":    "v1beta2",
+						"served":  true,
+						"storage": true,
+						"schema": map[string]any{
+							"openAPIV3Schema": map[string]any{
+								"type":                                 "object",
+								"x-kubernetes-preserve-unknown-fields": true,
+							},
+						},
+					},
+				},
+			},
+		}}
+
+		_, err := kind.dynamic.Resource(redisCRDGVR).Create(ctx, crd, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create Redis CRD: %v", err)
+		}
+
+		// Wait until the API server serves the new resource type.
+		deadline := time.Now().Add(30 * time.Second)
+		for {
+			_, err := kind.dynamic.Resource(redisGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{Limit: 1})
+			if err == nil {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("Redis CRD not established in time: %v", err)
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	})
+}
+
+// createRedisAndStatefulSet creates a Redis CR and a companion StatefulSet whose
+// ownerReference points to that CR, simulating what the redis-operator would create.
+// This lets tests verify Sablier's annotation and scaling logic without running
+// the actual operator.
+func createRedisAndStatefulSet(ctx context.Context, t *testing.T, kind *kindContainer, name string, labels map[string]string) {
+	t.Helper()
+
+	// Create the Redis CR.
+	redis := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "redis.redis.opstreelabs.in/v1beta2",
+		"kind":       "Redis",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "default",
+			"labels":    toStringMap(labels),
+		},
+	}}
+	cr, err := kind.dynamic.Resource(redisGVR).Namespace("default").Create(ctx, redis, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	// Create a StatefulSet that mirrors what the redis-operator would produce,
+	// with an ownerReference back to the Redis CR so Sablier can detect it.
+	isController := true
+	one := int32(1)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "redis.redis.opstreelabs.in/v1beta2",
+				Kind:       "Redis",
+				Name:       cr.GetName(),
+				UID:        cr.GetUID(),
+				Controller: &isController,
+			}},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &one,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "redis",
+						Image: "quay.io/opstree/redis:v7.0.12",
+					}},
+				},
+			},
+		},
+	}
+	_, err = kind.client.AppsV1().StatefulSets("default").Create(ctx, sts, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	t.Cleanup(func() {
+		_ = kind.dynamic.Resource(redisGVR).Namespace("default").Delete(context.Background(), name, metav1.DeleteOptions{})
+		_ = kind.client.AppsV1().StatefulSets("default").Delete(context.Background(), name, metav1.DeleteOptions{})
+	})
+}
+
+// redisAnnotation reads the skip-reconcile annotation from the Redis CR.
+func redisAnnotation(ctx context.Context, t *testing.T, kind *kindContainer, name string) string {
+	t.Helper()
+	u, err := kind.dynamic.Resource(redisGVR).Namespace("default").Get(ctx, name, metav1.GetOptions{})
+	assert.NilError(t, err)
+	return u.GetAnnotations()["redis.opstreelabs.in/skip-reconcile"]
+}
+
+func TestKubernetesProvider_RedisOperator(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping redis-operator integration test in short mode.")
+	}
+
+	ctx := t.Context()
+	kind := sharedKinD
+	ensureRedisCRD(ctx, t, kind)
+
+	p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
+	assert.NilError(t, err)
+
+	name := "redis-" + generateRandomName()
+	createRedisAndStatefulSet(ctx, t, kind, name, map[string]string{
+		"sablier.enable": "true",
+		"sablier.group":  "myapp",
+	})
+
+	sts, err := kind.client.AppsV1().StatefulSets("default").Get(ctx, name, metav1.GetOptions{})
+	assert.NilError(t, err)
+	instanceName := kubernetes.StatefulSetName(sts, kubernetes.ParseOptions{Delimiter: "_"}).Original
+
+	// Wait for the StatefulSet controller to have processed the new StatefulSet
+	// (observedGeneration == generation). This avoids resource-version conflicts
+	// when Sablier's UpdateScale call races with the controller's status update.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		sts, err = kind.client.AppsV1().StatefulSets("default").Get(ctx, name, metav1.GetOptions{})
+		assert.NilError(t, err)
+		if sts.Status.ObservedGeneration >= sts.Generation {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("StatefulSet controller did not observe the StatefulSet in time")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Run("stop sets skip-reconcile annotation and scales to zero", func(t *testing.T) {
+		assert.NilError(t, p.InstanceStop(ctx, instanceName))
+
+		assert.Equal(t, redisAnnotation(ctx, t, kind, name), "true")
+
+		sts, err := kind.client.AppsV1().StatefulSets("default").Get(ctx, name, metav1.GetOptions{})
+		assert.NilError(t, err)
+		assert.Equal(t, *sts.Spec.Replicas, int32(0))
+	})
+
+	t.Run("inspect reports stopped after stop", func(t *testing.T) {
+		info, err := p.InstanceInspect(ctx, instanceName)
+		assert.NilError(t, err)
+		assert.Equal(t, info.Kubernetes.Kind, "statefulset")
+	})
+
+	t.Run("start clears skip-reconcile annotation and scales back up", func(t *testing.T) {
+		assert.NilError(t, p.InstanceStart(ctx, instanceName))
+
+		assert.Equal(t, redisAnnotation(ctx, t, kind, name), "",
+			"skip-reconcile annotation should be cleared after start")
+
+		sts, err := kind.client.AppsV1().StatefulSets("default").Get(ctx, name, metav1.GetOptions{})
+		assert.NilError(t, err)
+		assert.Equal(t, *sts.Spec.Replicas, int32(1))
+	})
+}

--- a/pkg/provider/kubernetes/statefulset_redis_operator_test.go
+++ b/pkg/provider/kubernetes/statefulset_redis_operator_test.go
@@ -1,0 +1,314 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/neilotoole/slogt"
+	"go.opentelemetry.io/otel"
+	"gotest.tools/v3/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newRedisOwnerSTS builds a StatefulSet whose controller owner is a Redis CR.
+func newRedisOwnerSTS(namespace, name string, replicas int32, apiVersion string) *appsv1.StatefulSet {
+	if apiVersion == "" {
+		apiVersion = redisOperatorAPIVersion()
+	}
+	isController := true
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"sablier.enable": "true"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: apiVersion,
+				Kind:       "Redis",
+				Name:       name, // Redis CR has same name as the StatefulSet by convention
+				Controller: &isController,
+			}},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{ReadyReplicas: replicas},
+	}
+}
+
+// redisOperatorAPIVersion returns the canonical APIVersion string for the operator.
+func redisOperatorAPIVersion() string {
+	return redisOperatorGVR.Group + "/v1beta2"
+}
+
+// newRedisOperatorTestProvider builds a Provider with both a fake typed client
+// (for StatefulSet get/scale) and a fake dynamic client (for Redis CR annotation patch).
+// The Redis CR is pre-created in the dynamic tracker under the operator GVR.
+func newRedisOperatorTestProvider(t *testing.T, sts *appsv1.StatefulSet) (*Provider, *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+
+	// Typed client — StatefulSet with Scale reactor.
+	replicas := int32(1)
+	if sts.Spec.Replicas != nil {
+		replicas = *sts.Spec.Replicas
+	}
+	stsReplicas := map[string]int32{sts.Name: replicas}
+	client := k8sfake.NewSimpleClientset(sts)
+	client.PrependReactor("get", "statefulsets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "scale" {
+			return false, nil, nil
+		}
+		name := action.(k8stesting.GetAction).GetName()
+		return true, &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: action.GetNamespace()},
+			Spec:       autoscalingv1.ScaleSpec{Replicas: stsReplicas[name]},
+		}, nil
+	})
+	client.PrependReactor("update", "statefulsets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "scale" {
+			return false, nil, nil
+		}
+		s := action.(k8stesting.UpdateAction).GetObject().(*autoscalingv1.Scale)
+		stsReplicas[s.Name] = s.Spec.Replicas
+		return true, s, nil
+	})
+
+	// Dynamic client — pre-create the Redis CR so annotations can be patched.
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{redisOperatorGVR: "RedisList"},
+	)
+	redisObj := &unstructured.Unstructured{}
+	redisObj.SetAPIVersion(redisOperatorAPIVersion())
+	redisObj.SetKind("Redis")
+	redisObj.SetNamespace(sts.Namespace)
+	redisObj.SetName(sts.Name)
+	if err := dyn.Tracker().Create(redisOperatorGVR, redisObj, sts.Namespace); err != nil {
+		t.Fatalf("failed to pre-create Redis CR: %v", err)
+	}
+
+	p := &Provider{
+		Client:    client,
+		dynamic:   dyn,
+		delimiter: "_",
+		l:         slogt.New(t),
+		tracer:    otel.Tracer("test"),
+	}
+	return p, dyn
+}
+
+// getRedisAnnotation reads the skip-reconcile annotation from the fake dynamic tracker.
+func getRedisAnnotation(t *testing.T, dyn *dynamicfake.FakeDynamicClient, namespace, name string) string {
+	t.Helper()
+	u, err := dyn.Resource(redisOperatorGVR).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	assert.NilError(t, err)
+	return u.GetAnnotations()[redisOperatorSkipReconcileAnnotation]
+}
+
+// --- Unit tests for redisOperatorOwner ---
+
+func TestRedisOperatorOwner(t *testing.T) {
+	t.Parallel()
+
+	isController := true
+	notController := false
+
+	tests := []struct {
+		name      string
+		refs      []metav1.OwnerReference
+		wantName  string
+		wantFound bool
+	}{
+		{
+			name: "matched by group and kind",
+			refs: []metav1.OwnerReference{{
+				APIVersion: redisOperatorGVR.Group + "/v1beta2",
+				Kind:       "Redis",
+				Name:       "my-redis",
+				Controller: &isController,
+			}},
+			wantName: "my-redis", wantFound: true,
+		},
+		{
+			name: "matched even when version is v1 (forward-compat)",
+			refs: []metav1.OwnerReference{{
+				APIVersion: redisOperatorGVR.Group + "/v1",
+				Kind:       "Redis",
+				Name:       "my-redis",
+				Controller: &isController,
+			}},
+			wantName: "my-redis", wantFound: true,
+		},
+		{
+			name: "not matched when kind is wrong",
+			refs: []metav1.OwnerReference{{
+				APIVersion: redisOperatorGVR.Group + "/v1beta2",
+				Kind:       "RedisCluster",
+				Name:       "my-redis",
+				Controller: &isController,
+			}},
+			wantFound: false,
+		},
+		{
+			name: "not matched when group is wrong",
+			refs: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Redis",
+				Name:       "my-redis",
+				Controller: &isController,
+			}},
+			wantFound: false,
+		},
+		{
+			name: "not matched when controller=false",
+			refs: []metav1.OwnerReference{{
+				APIVersion: redisOperatorGVR.Group + "/v1beta2",
+				Kind:       "Redis",
+				Name:       "my-redis",
+				Controller: &notController,
+			}},
+			wantFound: false,
+		},
+		{
+			name:      "not matched with no owner references",
+			refs:      nil,
+			wantFound: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ss := &appsv1.StatefulSet{}
+			ss.OwnerReferences = tc.refs
+			name, ok := redisOperatorOwner(ss)
+			assert.Equal(t, ok, tc.wantFound)
+			if tc.wantFound {
+				assert.Equal(t, name, tc.wantName)
+			}
+		})
+	}
+}
+
+// --- Unit tests for apiVersionGroup ---
+
+func TestAPIVersionGroup(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, apiVersionGroup("apps/v1"), "apps")
+	assert.Equal(t, apiVersionGroup("redis.redis.opstreelabs.in/v1beta2"), "redis.redis.opstreelabs.in")
+	assert.Equal(t, apiVersionGroup("v1"), "v1") // core resource, no slash
+}
+
+// --- Unit tests for setRedisOperatorSkipReconcile ---
+
+func TestSetRedisOperatorSkipReconcile_Set(t *testing.T) {
+	t.Parallel()
+	sts := newRedisOwnerSTS("default", "my-redis", 1, "")
+	p, dyn := newRedisOperatorTestProvider(t, sts)
+
+	p.setRedisOperatorSkipReconcile(context.Background(), sts, true)
+	assert.Equal(t, getRedisAnnotation(t, dyn, "default", "my-redis"), "true")
+}
+
+func TestSetRedisOperatorSkipReconcile_Clear(t *testing.T) {
+	t.Parallel()
+	sts := newRedisOwnerSTS("default", "my-redis", 1, "")
+	p, dyn := newRedisOperatorTestProvider(t, sts)
+
+	// Set then clear.
+	p.setRedisOperatorSkipReconcile(context.Background(), sts, true)
+	assert.Equal(t, getRedisAnnotation(t, dyn, "default", "my-redis"), "true")
+
+	p.setRedisOperatorSkipReconcile(context.Background(), sts, false)
+	assert.Equal(t, getRedisAnnotation(t, dyn, "default", "my-redis"), "")
+}
+
+func TestSetRedisOperatorSkipReconcile_NonRedisStatefulSet(t *testing.T) {
+	t.Parallel()
+	// Plain StatefulSet with no owner references — patch must not be called.
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "plain-sts", Namespace: "default"},
+	}
+	scheme := runtime.NewScheme()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{redisOperatorGVR: "RedisList"},
+	)
+	p := &Provider{
+		Client:    k8sfake.NewSimpleClientset(sts),
+		dynamic:   dyn,
+		delimiter: "_",
+		l:         slogt.New(t),
+		tracer:    otel.Tracer("test"),
+	}
+
+	// Should be a no-op — no panic, no patch.
+	p.setRedisOperatorSkipReconcile(context.Background(), sts, true)
+	assert.Equal(t, len(dyn.Actions()), 0)
+}
+
+// --- Integration-style tests for InstanceStop annotation behaviour ---
+
+func TestInstanceStop_SetsSkipReconcileBeforeScale(t *testing.T) {
+	t.Parallel()
+	sts := newRedisOwnerSTS("default", "my-redis", 1, "")
+	p, dyn := newRedisOperatorTestProvider(t, sts)
+
+	instanceName := StatefulSetName(sts, ParseOptions{Delimiter: "_"}).Original
+	err := p.InstanceStop(context.Background(), instanceName)
+	assert.NilError(t, err)
+
+	// Annotation must be set.
+	assert.Equal(t, getRedisAnnotation(t, dyn, "default", "my-redis"), "true")
+
+	// StatefulSet must be scaled to zero.
+	s, scaleErr := p.Client.AppsV1().StatefulSets("default").GetScale(context.Background(), "my-redis", metav1.GetOptions{})
+	assert.NilError(t, scaleErr)
+	assert.Equal(t, s.Spec.Replicas, int32(0))
+}
+
+func TestInstanceStop_ClearsAnnotationOnScaleFailure(t *testing.T) {
+	t.Parallel()
+	sts := newRedisOwnerSTS("default", "my-redis", 1, "")
+	p, dyn := newRedisOperatorTestProvider(t, sts)
+
+	// Inject a scale failure.
+	p.Client.(*k8sfake.Clientset).PrependReactor("update", "statefulsets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "scale" {
+			return true, nil, fmt.Errorf("simulated scale failure")
+		}
+		return false, nil, nil
+	})
+
+	instanceName := StatefulSetName(sts, ParseOptions{Delimiter: "_"}).Original
+	err := p.InstanceStop(context.Background(), instanceName)
+	assert.ErrorContains(t, err, "simulated scale failure")
+
+	// Cleanup defer must have cleared the annotation.
+	assert.Equal(t, getRedisAnnotation(t, dyn, "default", "my-redis"), "")
+}
+
+func TestInstanceStart_ClearsSkipReconcileAfterScale(t *testing.T) {
+	t.Parallel()
+	// Start with replicas=0 and annotation set (simulating stopped state).
+	sts := newRedisOwnerSTS("default", "my-redis", 0, "")
+	p, dyn := newRedisOperatorTestProvider(t, sts)
+
+	// Pre-set the annotation as if a prior stop had run.
+	p.setRedisOperatorSkipReconcile(context.Background(), sts, true)
+	assert.Equal(t, getRedisAnnotation(t, dyn, "default", "my-redis"), "true")
+
+	instanceName := StatefulSetName(sts, ParseOptions{Delimiter: "_"}).Original
+	err := p.InstanceStart(context.Background(), instanceName)
+	assert.NilError(t, err)
+
+	// Annotation must be cleared after successful start.
+	assert.Equal(t, getRedisAnnotation(t, dyn, "default", "my-redis"), "")
+}


### PR DESCRIPTION
Closes #962

## What this does

I run a homelab where several applications sit behind Traefik with Sablier managing scale-to-zero. After the recent CloudNativePG support landed I started enabling it across my stack, and noticed Redis instances managed by the OT-CONTAINER-KIT redis-operator were the odd one out — Sablier would scale the StatefulSet to zero on session expiry, but the operator would immediately reconcile replicas back to 1.

The operator already ships a pause mechanism: `redis.opstreelabs.in/skip-reconcile: "true"` on the Redis CR. Setting this before scaling to zero keeps the operator out of the way, and clearing it after scale-up hands control back.

- **stop** → set `skip-reconcile: "true"` on the owning Redis CR, then scale the StatefulSet to 0
- **start** → scale the StatefulSet back to 1, then remove the annotation so the operator resumes normal reconciliation
- If the scale fails, a cleanup defer removes the annotation so the operator is never left paused with pods still running.

## Design choices

- **No new kind.** This hooks into the existing StatefulSet path rather than introducing a `redis` kind. The operator propagates labels (including `sablier.enable`/`sablier.group`) from the Redis CR to the StatefulSet it creates, so existing label-based opt-in works without any change to how users configure Sablier.
- **Only on scale-to-zero.** The annotation is not set in scale-mode stops (`sablier.idle.replicas >= 1`), where the StatefulSet stays non-zero and the operator should continue reconciling normally.
- **Version-agnostic owner detection.** The owner reference check matches on API group only (`redis.redis.opstreelabs.in`), not on the specific version string, so it stays correct if the operator promotes to v1.
- **Best-effort.** If the dynamic client is not configured or the Redis CR cannot be fetched, a warning is logged and the scale proceeds unchanged — existing behaviour for non-redis-operator StatefulSets is completely unaffected.

## Testing done

- Unit tests (`statefulset_redis_operator_test.go`) covering owner detection (including forward-compatibility with a future v1 APIVersion), annotation set/clear, no-op for plain StatefulSets, stop annotation set with cleanup-on-failure, and start annotation removal.
- `make fmt`, `golangci-lint run`, and the full `pkg/provider/kubernetes` test suite pass.
- Real cluster end-to-end: session expiry scales the StatefulSet to 0 with `skip-reconcile: "true"` set; the operator logs the annotation and stands down. A new request scales back to 1 and the annotation is removed. The redis-operator resumes normally.