### PR TITLE
Start session on group discovery

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,6 +251,8 @@ storage:
 sessions:
   # The default session duration (default 5m)
   default-duration: 5m
+  # Create a default-duration session when a group-managed instance is discovered (default false)
+  create-on-group-discovery: false
   # The expiration checking interval. 
   # Higher duration gives less stress on CPU. 
   # If you only use sessions of 1h, setting this to 5m is a good trade-off.
@@ -358,6 +360,7 @@ sablier start --strategy.dynamic.custom-themes-path /my/path
       --server.base-path string                               The base path for the API (default "/")
       --server.metrics.enabled                                Enable the Prometheus /metrics endpoint (default false)
       --server.port int                                       The server port to use (default 10000)
+      --sessions.create-on-group-discovery                    Create a default-duration session when a group-managed instance is discovered
       --sessions.default-duration duration                    The default session duration (default 5m0s)
       --sessions.expiration-interval duration                 The expiration checking interval. Higher duration gives less stress on CPU. If you only use sessions of 1h, setting this to 5m is a good trade-off. (default 20s)
       --storage.file string                                   File path to save the state

--- a/examples/group-discovery-session/Makefile
+++ b/examples/group-discovery-session/Makefile
@@ -1,0 +1,29 @@
+SABLIER_URL ?= http://localhost:10000
+WHOAMI_NAME := sablier-group-discovery-whoami
+
+.PHONY: up down logs wait-sablier test
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f sablier
+
+wait-sablier:
+	@for i in $$(seq 1 30); do \
+		if curl -fsS "$(SABLIER_URL)/health" >/dev/null; then exit 0; fi; \
+		sleep 1; \
+	done; \
+	echo "sablier did not become healthy"; \
+	docker compose logs sablier; \
+	exit 1
+
+test: up wait-sablier
+	@echo "==> Waiting for the discovery-created session to expire"
+	sleep 12
+	@status=$$(docker inspect -f '{{.State.Status}}' "$(WHOAMI_NAME)"); \
+	test "$$status" != "running"; \
+	echo "OK: discovered group session expired and stopped $(WHOAMI_NAME)"

--- a/examples/group-discovery-session/README.md
+++ b/examples/group-discovery-session/README.md
@@ -1,0 +1,25 @@
+# `group-discovery-session` Example
+
+This example demonstrates `--sessions.create-on-group-discovery=true`.
+
+The stack starts one labelled Docker container and Sablier. Sablier discovers
+the `whoami` group and creates a default-duration session immediately, without
+waiting for a first request.
+
+## Run
+
+```bash
+make test
+```
+
+Expected result:
+
+```text
+OK: discovered group session expired and stopped sablier-group-discovery-whoami
+```
+
+## Tear down
+
+```bash
+make down
+```

--- a/examples/group-discovery-session/compose.yml
+++ b/examples/group-discovery-session/compose.yml
@@ -1,0 +1,24 @@
+services:
+  whoami:
+    image: acouvreur/whoami:v1.10.2
+    container_name: sablier-group-discovery-whoami
+    labels:
+      - sablier.enable=true
+      - sablier.group=whoami
+
+  sablier:
+    image: ${SABLIER_IMAGE:-sablier:local}
+    depends_on:
+      - whoami
+    command:
+      - start
+      - --provider.name=docker
+      - --logging.level=debug
+      - --sessions.default-duration=10s
+      - --sessions.expiration-interval=1s
+      - --sessions.create-on-group-discovery=true
+      - --provider.auto-stop-on-startup=false
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "10000:10000"

--- a/pkg/config/sessions.go
+++ b/pkg/config/sessions.go
@@ -10,6 +10,12 @@ type Sessions struct {
 	// Default: 5m
 	DefaultDuration time.Duration
 
+	// CreateOnGroupDiscovery creates a default-duration session when a group-managed instance is discovered.
+	// Env: SABLIER_SESSIONS_CREATE_ON_GROUP_DISCOVERY
+	// CLI: --sessions.create-on-group-discovery
+	// Default: false
+	CreateOnGroupDiscovery bool
+
 	// ExpirationInterval is how often Sablier checks for and stops expired sessions.
 	// A longer interval reduces CPU overhead; align it with your shortest session duration
 	// (e.g. if all sessions are ≥1 h, 5 m is a reasonable trade-off).

--- a/pkg/sablier/group_watch.go
+++ b/pkg/sablier/group_watch.go
@@ -2,10 +2,12 @@ package sablier
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
 	"github.com/sablierapp/sablier/pkg/provider"
+	"github.com/sablierapp/sablier/pkg/store"
 )
 
 // GroupWatch maintains group membership in sync with the provider.
@@ -82,6 +84,9 @@ func (s *Sablier) handleGroupEvent(ctx context.Context, event InstanceEvent) {
 				slog.String("reason", reason),
 			)
 		}
+		if len(added) > 0 {
+			s.seedGroupSession(ctx, info.Name)
+		}
 
 	case provider.InstanceEventUpdated:
 		currentGroups := s.GroupsForInstance(info.Name)
@@ -115,6 +120,9 @@ func (s *Sablier) handleGroupEvent(ctx context.Context, event InstanceEvent) {
 				slog.String("group", g),
 				slog.String("reason", reason),
 			)
+		}
+		if len(added) > 0 {
+			s.seedGroupSession(ctx, info.Name)
 		}
 
 	case provider.InstanceEventRemoved:
@@ -158,6 +166,9 @@ func (s *Sablier) reconcileGroups(ctx context.Context, reason string) {
 				slog.String("reason", reason),
 			)
 		}
+		if len(added) > 0 {
+			s.seedGroupSession(ctx, inst)
+		}
 		for _, g := range removed {
 			s.l.InfoContext(ctx, "instance removed from group",
 				slog.String("instance", inst),
@@ -179,6 +190,48 @@ func (s *Sablier) reconcileGroups(ctx context.Context, reason string) {
 				)
 			}
 		}
+	}
+}
+
+// SeedGroupSessions creates default-duration sessions for discovered group members.
+func (s *Sablier) SeedGroupSessions(ctx context.Context, groups map[string][]string) {
+	seen := map[string]bool{}
+	for _, instances := range groups {
+		for _, name := range instances {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			s.seedGroupSession(ctx, name)
+		}
+	}
+}
+
+func (s *Sablier) seedGroupSession(ctx context.Context, name string) {
+	if s.GroupDiscoverySessionDuration <= 0 {
+		return
+	}
+
+	_, err := s.sessions.Get(ctx, name)
+	switch {
+	case err == nil:
+		return
+	case !errors.Is(err, store.ErrKeyNotFound):
+		s.l.WarnContext(ctx, "group discovery session lookup failed", slog.String("instance", name), slog.Any("error", err))
+		return
+	}
+
+	info, err := s.provider.InstanceInspect(ctx, name)
+	if err != nil {
+		s.l.WarnContext(ctx, "group discovery instance inspect failed", slog.String("instance", name), slog.Any("error", err))
+		return
+	}
+	if info.Status != InstanceStatusReady {
+		return
+	}
+
+	if err := s.sessions.Put(ctx, info, s.GroupDiscoverySessionDuration); err != nil {
+		s.l.WarnContext(ctx, "group discovery session seed failed", slog.String("instance", name), slog.Any("error", err))
 	}
 }
 

--- a/pkg/sablier/group_watch_test.go
+++ b/pkg/sablier/group_watch_test.go
@@ -7,8 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/neilotoole/slogt"
 	"github.com/sablierapp/sablier/pkg/provider"
+	"github.com/sablierapp/sablier/pkg/provider/providertest"
 	"github.com/sablierapp/sablier/pkg/sablier"
+	"github.com/sablierapp/sablier/pkg/store"
+	"github.com/sablierapp/sablier/pkg/store/inmemory"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 )
@@ -62,6 +66,77 @@ func TestGroupWatch_CreatedEvent_AddsToGroup(t *testing.T) {
 	assert.Assert(t, pollFor(t, func() bool {
 		return containsInstance(s.Groups(), "web", "nginx")
 	}, 2*time.Second), "nginx should be in group web after created event")
+}
+
+func TestGroupWatch_GroupDiscoverySessionExpiresAndStopsInstanceWhenEnabled(t *testing.T) {
+	s, sessions, p := setupGroupWatchWithInMemoryStore(t)
+	s.GroupDiscoverySessionDuration = 200 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	assert.NilError(t, sessions.OnExpire(ctx, s.OnInstanceExpired(ctx)))
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+	ready := sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusReady}
+	p.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(ready, nil)
+	stopped := make(chan struct{}, 1)
+	p.EXPECT().InstanceStop(gomock.Any(), "nginx").DoAndReturn(func(context.Context, string) error {
+		stopped <- struct{}{}
+		return nil
+	})
+
+	startGroupWatch(t, s, ctx, cancel)
+
+	eventsC <- sablier.InstanceEvent{
+		Type: provider.InstanceEventCreated,
+		Info: sablier.InstanceInfo{Name: "nginx", Groups: []string{"web"}},
+	}
+
+	assert.Assert(t, pollFor(t, func() bool {
+		_, err := sessions.Get(ctx, "nginx")
+		return err == nil
+	}, time.Second), "discovered instance should get a session")
+
+	time.Sleep(250 * time.Millisecond)
+	_, _ = sessions.Get(ctx, "nginx") // trigger immediate expiry instead of waiting for the store ticker
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("expired discovery session did not stop the instance")
+	}
+}
+
+func TestGroupWatch_GroupDiscoveryDoesNotCreateSessionWhenDisabled(t *testing.T) {
+	s, sessions, p := setupGroupWatchWithInMemoryStore(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	assert.NilError(t, sessions.OnExpire(ctx, s.OnInstanceExpired(ctx)))
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+
+	startGroupWatch(t, s, ctx, cancel)
+
+	eventsC <- sablier.InstanceEvent{
+		Type: provider.InstanceEventCreated,
+		Info: sablier.InstanceInfo{Name: "nginx", Groups: []string{"web"}},
+	}
+
+	assert.Assert(t, pollFor(t, func() bool {
+		return containsInstance(s.Groups(), "web", "nginx")
+	}, 2*time.Second), "nginx should be tracked in the group")
+
+	_, err := sessions.Get(ctx, "nginx")
+	assert.Equal(t, err, store.ErrKeyNotFound)
 }
 
 func TestGroupWatch_RemovedEvent_RemovesFromGroup(t *testing.T) {
@@ -452,6 +527,14 @@ func TestGroupWatch_ReconciliationMultipleGroups(t *testing.T) {
 			containsInstance(groups, "team-a", "frontend") &&
 			containsInstance(groups, "team-b", "backend")
 	}, 3*time.Second), "reconciliation should populate all instances across multiple groups")
+}
+
+func setupGroupWatchWithInMemoryStore(t *testing.T) (*sablier.Sablier, sablier.Store, *providertest.MockProvider) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	p := providertest.NewMockProvider(ctrl)
+	sessions := inmemory.NewInMemory()
+	return sablier.New(slogt.New(t), sessions, p), sessions, p
 }
 
 // startGroupWatch launches s.GroupWatch in a goroutine and registers a

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -38,6 +38,10 @@ type Sablier struct {
 	// reconciled. Defaults to 30 seconds.
 	RunningHoursRefreshFrequency time.Duration
 
+	// GroupDiscoverySessionDuration creates sessions for discovered group members.
+	// Zero disables it.
+	GroupDiscoverySessionDuration time.Duration
+
 	// rejectUnlabeledRequests blocks direct named requests unless sablier.enable=true.
 	rejectUnlabeledRequests bool
 

--- a/pkg/sabliercmd/root.go
+++ b/pkg/sabliercmd/root.go
@@ -91,6 +91,8 @@ It provides integrations with multiple reverse proxies and different loading str
 	// Sessions flags
 	startCmd.Flags().DurationVar(&conf.Sessions.DefaultDuration, "sessions.default-duration", time.Duration(5)*time.Minute, "The default session duration")
 	_ = viper.BindPFlag("sessions.default-duration", startCmd.Flags().Lookup("sessions.default-duration"))
+	startCmd.Flags().BoolVar(&conf.Sessions.CreateOnGroupDiscovery, "sessions.create-on-group-discovery", false, "Create a default-duration session when a group-managed instance is discovered")
+	_ = viper.BindPFlag("sessions.create-on-group-discovery", startCmd.Flags().Lookup("sessions.create-on-group-discovery"))
 	startCmd.Flags().DurationVar(&conf.Sessions.ExpirationInterval, "sessions.expiration-interval", time.Duration(20)*time.Second, "The expiration checking interval. Higher duration gives less stress on CPU. If you only use sessions of 1h, setting this to 5m is a good trade-off.")
 	_ = viper.BindPFlag("sessions.expiration-interval", startCmd.Flags().Lookup("sessions.expiration-interval"))
 

--- a/pkg/sabliercmd/start.go
+++ b/pkg/sabliercmd/start.go
@@ -78,6 +78,9 @@ func Start(ctx context.Context, conf config.Config) error {
 	s.WithMetrics(rec)
 	s.WithRejectUnlabeledRequests(conf.Provider.RejectUnlabeledRequests)
 	s.WithVerifyEnabledOnExpiration(conf.Provider.VerifyEnabledOnExpiration)
+	if conf.Sessions.CreateOnGroupDiscovery {
+		s.GroupDiscoverySessionDuration = conf.Sessions.DefaultDuration
+	}
 	err = store.OnExpire(ctx, s.OnInstanceExpired(ctx))
 	if err != nil {
 		return err
@@ -94,6 +97,7 @@ func Start(ctx context.Context, conf config.Config) error {
 		logger.WarnContext(ctx, "initial group scan failed", slog.Any("reason", err))
 	} else {
 		s.SetGroups(groups)
+		s.SeedGroupSessions(ctx, groups)
 	}
 
 	go s.GroupWatch(ctx)

--- a/pkg/sabliercmd/testdata/config_cli_wanted.json
+++ b/pkg/sabliercmd/testdata/config_cli_wanted.json
@@ -35,6 +35,7 @@
   },
   "Sessions": {
     "DefaultDuration": 10800000000000,
+    "CreateOnGroupDiscovery": false,
     "ExpirationInterval": 10800000000000
   },
   "Logging": {

--- a/pkg/sabliercmd/testdata/config_default.json
+++ b/pkg/sabliercmd/testdata/config_default.json
@@ -35,6 +35,7 @@
   },
   "Sessions": {
     "DefaultDuration": 300000000000,
+    "CreateOnGroupDiscovery": false,
     "ExpirationInterval": 20000000000
   },
   "Logging": {

--- a/pkg/sabliercmd/testdata/config_env_wanted.json
+++ b/pkg/sabliercmd/testdata/config_env_wanted.json
@@ -35,6 +35,7 @@
   },
   "Sessions": {
     "DefaultDuration": 7200000000000,
+    "CreateOnGroupDiscovery": false,
     "ExpirationInterval": 7200000000000
   },
   "Logging": {

--- a/pkg/sabliercmd/testdata/config_yaml_wanted.json
+++ b/pkg/sabliercmd/testdata/config_yaml_wanted.json
@@ -35,6 +35,7 @@
   },
   "Sessions": {
     "DefaultDuration": 3600000000000,
+    "CreateOnGroupDiscovery": false,
     "ExpirationInterval": 3600000000000
   },
   "Logging": {

--- a/sablier.sample.yaml
+++ b/sablier.sample.yaml
@@ -13,6 +13,7 @@ storage:
   file:
 sessions:
   default-duration: 5m
+  create-on-group-discovery: false
   expiration-interval: 20s
 logging:
   level: info


### PR DESCRIPTION
Adds optional session seeding with flag `--sessions.create-on-group-discovery`.

When `--sessions.create-on-group-discovery=true` is set, Sablier creates a `sessions.default-duration` session for newly discovered instances. 

This makes sure that a session is attached to a group and workloads expire and downscale without waiting for a first request to start the session.