### PR TITLE
feat(sablier): add ready on start support via sablier.ready-on-start label

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ Instance labels are applied directly to your containers or workloads. They contr
 | `sablier.enable` | Yes | `"true"` | Opt the instance into Sablier management. Any value other than `"true"` is ignored. |
 | `sablier.group` | No | `"myapp"` | Assign the instance to one or more named groups (comma-separated, e.g. `"team-a,team-b"`). Defaults to `"default"` when `sablier.enable=true` and no group is set. |
 | `sablier.ready-after` | No | `"30s"` | Minimum duration to wait after the instance first reports ready before Sablier considers it truly ready. Accepts any Go duration string (`"500ms"`, `"1m30s"`, …). Useful for services that are started or pass their health check before they can actually serve traffic. |
+| `sablier.ready-on-start` | No | `"true"` | Treat the instance as ready as soon as the start is dispatched. Useful for background services where the main app doesn't need them healthy to function. |
 | `sablier.running-hours` | No | `"09:00-18:00"` | Daily keep-warm window in local time (`HH:MM-HH:MM`). Sablier starts the instance at window start and keeps it running until window end. Overnight windows like `"22:00-06:00"` are supported. |
 | `sablier.idle.cpu` | No | `"0.1"` | CPU limit applied when the session expires (scale mode). Requires `sablier.idle.replicas >= 1`. |
 | `sablier.idle.memory` | No | `"128m"` | Memory limit applied when the session expires (scale mode). Requires `sablier.idle.replicas >= 1`. |
@@ -78,6 +79,32 @@ The value is a Go duration string. Valid examples:
 If the label is absent or set to an unparseable value, no extra wait is applied.
 
 !> The `sablier.ready-after` grace period counts from when the instance **first** becomes ready in a given session. It does not reset on subsequent requests.
+
+### `sablier.ready-on-start`
+
+Some services only run in the background — NVR recorders, cache sidecars,
+build agents, etc. The main application works without them being healthy, but
+you still want Sablier to start them when a request arrives.
+
+Setting `sablier.ready-on-start=true` tells Sablier to dispatch the start but
+immediately treat the instance as ready, skipping the health check. The reverse
+proxy passes the request through without waiting.
+
+```yaml
+services:
+  frigate:
+    image: frigate:latest
+    labels:
+      - "sablier.enable=true"
+      - "sablier.group=home"
+      - "sablier.ready-on-start=true"   # start frigate, don't wait for health
+```
+
+- Only the instance with `sablier.ready-on-start=true` is affected. Other
+  instances in the same session still wait for their health checks normally.
+- Accepts a Go boolean value (`"true"`, `"1"`, …). Invalid values are ignored with a warning.
+  An empty or absent value means no special treatment.
+- Works with both dynamic and blocking strategies — no plugin-side changes needed.
 
 ### `sablier.running-hours`
 

--- a/examples/ready-on-start/Makefile
+++ b/examples/ready-on-start/Makefile
@@ -1,0 +1,19 @@
+.PHONY: up down logs start
+
+# Start all services (both containers are stopped initially)
+up:
+	docker compose up -d
+	docker compose stop web nvr
+
+# Stop and remove all services
+down:
+	docker compose down
+
+# Follow sablier logs
+logs:
+	docker compose logs -f sablier
+
+# Ask Sablier to start the home group (blocking — nvr passes through, web waits for health)
+start:
+	@echo ">>> Requesting home group (blocking)..."
+	time curl -sf "http://localhost:10000/api/strategies/blocking?group=home&session_duration=2m" | jq .

--- a/examples/ready-on-start/README.md
+++ b/examples/ready-on-start/README.md
@@ -1,0 +1,80 @@
+# `sablier.ready-on-start` Example
+
+This example demonstrates the `sablier.ready-on-start` per-instance label using
+[sablierapp/mimic](https://github.com/sablierapp/mimic), a configurable
+web-server built for testing purposes.
+
+Some services don't need to be healthy for the application to function —
+background processes, cache sidecars, video recorders, etc. With
+`sablier.ready-on-start=true`, Sablier dispatches the start but immediately
+reports the instance as ready, so the reverse proxy passes the request through
+without waiting.
+
+```
+Timeline:
+
+  t=0s   Request arrives, Sablier dispatches container start
+  t=0s   Sablier returns X-Sablier-Session-Status: ready   ← no wait
+  t=0s   Proxy passes user request through to backend
+  t=5s   Container becomes healthy (in the background)
+```
+
+## Services
+
+| Service | Role |
+|---|---|
+| `sablier` | Manages containers; exposes REST API on `:10000` |
+| `web` | `sablierapp/mimic` configured to become healthy after 5 s |
+| `nvr` | `sablierapp/mimic` with `sablier.ready-on-start=true` — background recorder that doesn't block responses |
+
+## Labels on `nvr`
+
+```yaml
+labels:
+  - "sablier.enable=true"
+  - "sablier.group=home"
+  - "sablier.ready-on-start=true"   # don't wait for health
+```
+
+## Prerequisites
+
+- Docker with Compose plugin (`docker compose version`)
+- `curl` and `jq` for the walkthrough
+
+## Walkthrough
+
+### 1. Start the stack (containers are stopped initially)
+
+```bash
+make up
+```
+
+### 2. Send a blocking request for the group
+
+```bash
+make start
+```
+
+Sablier will:
+1. Dispatch the start for both `web` and `nvr`
+2. `nvr` has `ready-on-start=true` → immediately considered ready, no wait added
+3. `web` blocks until its health check passes (~10 s)
+4. The session returns after all instances are ready (~10 s instead of ~20 s without `ready-on-start`)
+
+The `nvr` instance never delays the session even though it starts from cold.
+
+### 3. Tear down
+
+```bash
+make down
+```
+
+## What to look for in the logs
+
+```
+level=DEBUG msg="request to start instance dispatched" instance=nvr status=starting
+# nvr is immediately reported as ready despite status=starting
+level=DEBUG msg="set expiration for instance" instance=nvr expiration=1m0s
+# web still needs its health check
+level=INFO msg="instance is ready" instance=web
+```

--- a/examples/ready-on-start/compose.yml
+++ b/examples/ready-on-start/compose.yml
@@ -1,0 +1,52 @@
+services:
+  sablier:
+    image: ${SABLIER_IMAGE:-sablierapp/sablier:latest}
+    command:
+      - start
+      - --provider.name=docker
+      - --logging.level=debug
+      - --sessions.default-duration=2m
+      - --sessions.expiration-interval=10s
+      - --strategy.blocking.default-timeout=2m
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "10000:10000"
+    depends_on:
+      - web
+      - nvr
+
+  web:
+    image: sablierapp/mimic:v0.3.3
+    command:
+      - -running-after=5s
+      - -healthy=true
+      - -healthy-after=5s
+    labels:
+      - "sablier.enable=true"
+      - "sablier.group=home"
+    healthcheck:
+      test: ["CMD", "/mimic", "healthcheck"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    ports:
+      - "8080:80"
+
+  nvr:
+    image: sablierapp/mimic:v0.3.3
+    command:
+      - -running-after=5s
+      - -healthy=true
+      - -healthy-after=5s
+    labels:
+      - "sablier.enable=true"
+      - "sablier.group=home"
+      - "sablier.ready-on-start=true"
+    healthcheck:
+      test: ["CMD", "/mimic", "healthcheck"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    ports:
+      - "8081:80"

--- a/pkg/provider/docker/container_inspect_test.go
+++ b/pkg/provider/docker/container_inspect_test.go
@@ -285,8 +285,9 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 					c, err := dind.CreateMimic(ctx, MimicOptions{
 						Cmd: []string{"/mimic", "-running", "-running-after=1ms"},
 						Labels: map[string]string{
-							"sablier.enable": "true",
-							"sablier.group":  "myapp",
+							"sablier.enable":          "true",
+							"sablier.group":           "myapp",
+							"sablier.ready-on-start":  "true",
 						},
 					})
 					if err != nil {
@@ -305,10 +306,12 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 				Status:          sablier.InstanceStatusReady,
 				Enabled:         "true",
 				Groups:          []string{"myapp"},
+				ReadyOnStart:    true,
 			},
 			wantLabels: map[string]string{
-				"sablier.enable": "true",
-				"sablier.group":  "myapp",
+				"sablier.enable":         "true",
+				"sablier.group":          "myapp",
+				"sablier.ready-on-start": "true",
 			},
 			wantErr: nil,
 		},

--- a/pkg/provider/dockerswarm/service_inspect_test.go
+++ b/pkg/provider/dockerswarm/service_inspect_test.go
@@ -139,8 +139,9 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 					s, err := dind.CreateMimic(ctx, MimicOptions{
 						Cmd: []string{"/mimic"},
 						Labels: map[string]string{
-							"sablier.enable": "true",
-							"sablier.group":  "myapp",
+							"sablier.enable":         "true",
+							"sablier.group":          "myapp",
+							"sablier.ready-on-start": "true",
 						},
 					})
 					if err != nil {
@@ -166,10 +167,12 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 				Status:          sablier.InstanceStatusReady,
 				Enabled:         "true",
 				Groups:          []string{"myapp"},
+				ReadyOnStart:    true,
 			},
 			wantLabels: map[string]string{
-				"sablier.enable": "true",
-				"sablier.group":  "myapp",
+				"sablier.enable":         "true",
+				"sablier.group":          "myapp",
+				"sablier.ready-on-start": "true",
 			},
 			wantErr: nil,
 		},

--- a/pkg/provider/kubernetes/deployment_inspect_test.go
+++ b/pkg/provider/kubernetes/deployment_inspect_test.go
@@ -123,8 +123,9 @@ func TestKubernetesProvider_DeploymentInspect(t *testing.T) {
 					d, err := dind.CreateMimicDeployment(ctx, MimicOptions{
 						Cmd: []string{"/mimic"},
 						Labels: map[string]string{
-							"sablier.enable": "true",
-							"sablier.group":  "myapp",
+							"sablier.enable":         "true",
+							"sablier.group":          "myapp",
+							"sablier.ready-on-start": "true",
 						},
 					})
 					if err != nil {
@@ -144,10 +145,12 @@ func TestKubernetesProvider_DeploymentInspect(t *testing.T) {
 				Status:          sablier.InstanceStatusReady,
 				Enabled:         "true",
 				Groups:          []string{"myapp"},
+				ReadyOnStart:    true,
 			},
 			wantLabels: map[string]string{
-				"sablier.enable": "true",
-				"sablier.group":  "myapp",
+				"sablier.enable":         "true",
+				"sablier.group":          "myapp",
+				"sablier.ready-on-start": "true",
 			},
 			wantErr: nil,
 		},

--- a/pkg/provider/podman/container_inspect_test.go
+++ b/pkg/provider/podman/container_inspect_test.go
@@ -255,8 +255,9 @@ func TestPodmanProvider_GetState(t *testing.T) {
 					c, err := pind.CreateMimic(ctx, MimicOptions{
 						Cmd: []string{"/mimic", "-running", "-running-after=1ms"},
 						Labels: map[string]string{
-							"sablier.enable": "true",
-							"sablier.group":  "myapp",
+							"sablier.enable":         "true",
+							"sablier.group":          "myapp",
+							"sablier.ready-on-start": "true",
 						},
 					})
 					if err != nil {
@@ -272,10 +273,12 @@ func TestPodmanProvider_GetState(t *testing.T) {
 				Status:          sablier.InstanceStatusReady,
 				Enabled:         "true",
 				Groups:          []string{"myapp"},
+				ReadyOnStart:    true,
 			},
 			wantLabels: map[string]string{
-				"sablier.enable": "true",
-				"sablier.group":  "myapp",
+				"sablier.enable":         "true",
+				"sablier.group":          "myapp",
+				"sablier.ready-on-start": "true",
 			},
 			wantErr: nil,
 		},

--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -52,6 +52,11 @@ type InstanceInfo struct {
 	// the sablier.running-hours label (format: HH:MM-HH:MM).
 	RunningHours string `json:"runningHours,omitempty"`
 
+	// ReadyOnStart indicates the instance should be considered ready as soon as
+	// the start is dispatched, without waiting for health.
+	// Controlled by the sablier.ready-on-start label.
+	ReadyOnStart bool `json:"readyOnStart,omitempty"`
+
 	// ScaleConfig configures resource-based scale mode for this instance.
 	// When present, Sablier throttles CPU/memory instead of stopping the container.
 	ScaleConfig *ScaleConfig `json:"scaleConfig,omitempty"`
@@ -86,6 +91,9 @@ type InstanceConfiguration struct {
 }
 
 func (instance InstanceInfo) IsReady() bool {
+	if instance.ReadyOnStart {
+		return true
+	}
 	if instance.Status != InstanceStatusReady {
 		return false
 	}
@@ -192,6 +200,18 @@ func PopulateEnabledAndGroup(info *InstanceInfo, labels map[string]string) {
 				slog.String("value", v),
 				slog.Any("error", err),
 			)
+		}
+	}
+	if v := labels["sablier.ready-on-start"]; v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			slog.Warn("invalid sablier.ready-on-start label value, ignoring",
+				slog.String("instance", info.Name),
+				slog.String("value", v),
+				slog.Any("error", err),
+			)
+		} else {
+			info.ReadyOnStart = b
 		}
 	}
 	// Only expose ScaleConfig in the response when at least one non-default

--- a/pkg/sablier/instance_test.go
+++ b/pkg/sablier/instance_test.go
@@ -56,6 +56,14 @@ func TestInstanceInfo_IsReady_ReadyAfter_NilReadyAt(t *testing.T) {
 	assert.Assert(t, info.IsReady())
 }
 
+func TestInstanceInfo_IsReady_ReadyOnStart(t *testing.T) {
+	info := sablier.InstanceInfo{
+		Status:      sablier.InstanceStatusStarting,
+		ReadyOnStart: true,
+	}
+	assert.Assert(t, info.IsReady())
+}
+
 func TestPopulateEnabledAndGroup_ReadyAfter(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## What

Label `sablier.pass-through=true` makes Sablier treat an instance as ready immediately after dispatching the start. The proxy passes the request straight through — no waiting page, no blocking #975

## Changes

`pkg/sablier/instance.go` — added `PassThrough` field, label parsing, and `IsReady()` check (~10 lines).

## Usage examples

- **Home Assistant + Frigate:** Frigate (NVR) runs in background for Home Assistant. When HA starts, you don't need Frigate healthy to use HA — but you do want it started.
- CI runner with a sidecar cache: Start Redis cache alongside your app — requests proceed while Redis warms up.
- VPN gateway + apps behind it: The VPN container needs starting, but user requests to dependent apps shouldn't be held until VPN connection establishes.