### PR TITLE
feat(metrics): expose per-session expiry as a Prometheus gauge

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -286,6 +286,7 @@ When set to `true`, Sablier registers a `GET <base-path>/metrics` route on the s
 |------|------|--------|-------------|
 | `sablier_group_locked` | gauge | `group` | `1` if any instance in the group has an active session, else `0`. One series per known group, including groups with no active sessions. |
 | `sablier_group_active_instances` | gauge | `group` | Number of instances in the group that currently have an active session. |
+| `sablier_session_expires_at_timestamp_seconds` | gauge | `instance`, `group` | Unix timestamp (seconds) at which the instance's session expires and the instance is stopped. One series per active session. The value tracks the latest access, so it is pushed back on every session renewal. Derive the remaining time in Grafana with `sablier_session_expires_at_timestamp_seconds - time()`. |
 | `sablier_instance_start_duration_seconds` | histogram | `instance` | Duration of `provider.InstanceStart` calls (seconds). Observed only on success. |
 | `sablier_instance_ready_duration_seconds` | histogram | `instance` | End-to-end wall time from first not-ready observation to ready (seconds). |
 | `sablier_session_requests_total` | counter | `strategy` (`dynamic`\|`blocking`), `target` (`names`\|`group`) | Total number of session requests received. |

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -1,6 +1,10 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // GroupsProvider exposes the current configured groups (group name -> instance names).
 type GroupsProvider interface {
@@ -62,5 +66,57 @@ func (c *GroupLockCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- prometheus.MustNewConstMetric(c.lockedDesc, prometheus.GaugeValue, locked, group)
 		ch <- prometheus.MustNewConstMetric(c.countDesc, prometheus.GaugeValue, float64(count), group)
+	}
+}
+
+// SessionEntry is the minimal view of a single active session that the
+// SessionExpiryCollector needs to emit its gauge.
+type SessionEntry struct {
+	Instance  string
+	Group     string
+	ExpiresAt time.Time
+}
+
+// sessionSource enumerates the currently active sessions. Implementations must
+// be non-destructive: producing the snapshot must never renew a session.
+type sessionSource interface {
+	SessionsSnapshot() []SessionEntry
+}
+
+// SessionExpiryCollector emits one gauge per active session carrying the unix
+// timestamp (seconds) at which the session expires. It reads the session source
+// lazily at scrape time and never writes back, so scraping /metrics does not
+// renew any session.
+type SessionExpiryCollector struct {
+	sessions sessionSource
+
+	expiresAtDesc *prometheus.Desc
+}
+
+// NewSessionExpiryCollector wires a sessionSource into a Collector that can be
+// registered on the same registry as the rest of the metrics.
+func NewSessionExpiryCollector(sessions sessionSource) *SessionExpiryCollector {
+	return &SessionExpiryCollector{
+		sessions: sessions,
+		expiresAtDesc: prometheus.NewDesc(
+			"sablier_session_expires_at_timestamp_seconds",
+			"Unix timestamp (seconds) at which the instance's session expires and the instance is stopped. One series per active session. The value tracks the latest access and is pushed back on every session renewal. Derive the remaining time in Grafana with the expression: value - time().",
+			[]string{"instance", "group"}, nil,
+		),
+	}
+}
+
+func (c *SessionExpiryCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.expiresAtDesc
+}
+
+func (c *SessionExpiryCollector) Collect(ch chan<- prometheus.Metric) {
+	for _, s := range c.sessions.SessionsSnapshot() {
+		ch <- prometheus.MustNewConstMetric(
+			c.expiresAtDesc,
+			prometheus.GaugeValue,
+			float64(s.ExpiresAt.Unix()),
+			s.Instance, s.Group,
+		)
 	}
 }

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -77,9 +77,9 @@ type SessionEntry struct {
 	ExpiresAt time.Time
 }
 
-// sessionSource enumerates the currently active sessions. Implementations must
+// SessionSource enumerates the currently active sessions. Implementations must
 // be non-destructive: producing the snapshot must never renew a session.
-type sessionSource interface {
+type SessionSource interface {
 	SessionsSnapshot() []SessionEntry
 }
 
@@ -88,14 +88,14 @@ type sessionSource interface {
 // lazily at scrape time and never writes back, so scraping /metrics does not
 // renew any session.
 type SessionExpiryCollector struct {
-	sessions sessionSource
+	sessions SessionSource
 
 	expiresAtDesc *prometheus.Desc
 }
 
-// NewSessionExpiryCollector wires a sessionSource into a Collector that can be
+// NewSessionExpiryCollector wires a SessionSource into a Collector that can be
 // registered on the same registry as the rest of the metrics.
-func NewSessionExpiryCollector(sessions sessionSource) *SessionExpiryCollector {
+func NewSessionExpiryCollector(sessions SessionSource) *SessionExpiryCollector {
 	return &SessionExpiryCollector{
 		sessions: sessions,
 		expiresAtDesc: prometheus.NewDesc(

--- a/pkg/metrics/collector_test.go
+++ b/pkg/metrics/collector_test.go
@@ -1,12 +1,18 @@
 package metrics_test
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sablierapp/sablier/pkg/metrics"
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"github.com/sablierapp/sablier/pkg/store/inmemory"
 )
 
 type fakeGroupsProvider struct {
@@ -61,5 +67,76 @@ func TestGroupLockCollector_NoGroupsEmitsNothing(t *testing.T) {
 	got := testutil.CollectAndCount(c, "sablier_group_locked", "sablier_group_active_instances")
 	if got != 0 {
 		t.Errorf("expected 0 series with no groups, got %d", got)
+	}
+}
+
+type fakeSessionSource struct {
+	entries []metrics.SessionEntry
+}
+
+func (f fakeSessionSource) SessionsSnapshot() []metrics.SessionEntry {
+	return f.entries
+}
+
+func TestSessionExpiryCollector_ExposesGauge(t *testing.T) {
+	src := fakeSessionSource{entries: []metrics.SessionEntry{
+		{Instance: "whoami", Group: "demo", ExpiresAt: time.Unix(1000000000, 0)},
+		{Instance: "nginx", Group: "", ExpiresAt: time.Unix(1000000060, 0)},
+	}}
+
+	c := metrics.NewSessionExpiryCollector(src)
+
+	want := `
+# HELP sablier_session_expires_at_timestamp_seconds Unix timestamp (seconds) at which the instance's session expires and the instance is stopped. One series per active session. The value tracks the latest access and is pushed back on every session renewal. Derive the remaining time in Grafana with the expression: value - time().
+# TYPE sablier_session_expires_at_timestamp_seconds gauge
+sablier_session_expires_at_timestamp_seconds{group="",instance="nginx"} 1000000060
+sablier_session_expires_at_timestamp_seconds{group="demo",instance="whoami"} 1000000000
+`
+
+	if err := testutil.CollectAndCompare(c, strings.NewReader(want),
+		"sablier_session_expires_at_timestamp_seconds"); err != nil {
+		t.Fatalf("CollectAndCompare: %v", err)
+	}
+
+	lints, err := testutil.CollectAndLint(c, "sablier_session_expires_at_timestamp_seconds")
+	if err != nil {
+		t.Fatalf("CollectAndLint: %v", err)
+	}
+	if len(lints) > 0 {
+		t.Errorf("lint problems: %+v", lints)
+	}
+}
+
+func TestSessionExpiryCollector_NoSessionsEmitsNothing(t *testing.T) {
+	c := metrics.NewSessionExpiryCollector(fakeSessionSource{})
+	got := testutil.CollectAndCount(c, "sablier_session_expires_at_timestamp_seconds")
+	if got != 0 {
+		t.Errorf("expected 0 series with no sessions, got %d", got)
+	}
+}
+
+// TestSessionExpiryCollector_NonDestructive exercises the full production path
+// (store -> Sablier.SessionsSnapshot -> collector) and proves that scraping the
+// metric never renews the session: the exposed expiry must stay constant across
+// repeated scrapes.
+func TestSessionExpiryCollector_NonDestructive(t *testing.T) {
+	ctx := context.Background()
+	st := inmemory.NewInMemory()
+	if err := st.Put(ctx, sablier.InstanceInfo{Name: "whoami", Groups: []string{"demo"}}, 5*time.Minute); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	s := sablier.New(slog.New(slog.NewTextHandler(io.Discard, nil)), st, nil)
+	c := metrics.NewSessionExpiryCollector(s)
+
+	first := testutil.ToFloat64(c)
+	if first <= 0 {
+		t.Fatalf("expected a positive expiry timestamp, got %v", first)
+	}
+	for i := 0; i < 3; i++ {
+		<-time.After(10 * time.Millisecond)
+		if got := testutil.ToFloat64(c); got != first {
+			t.Fatalf("expiry moved across scrapes (%v -> %v): the collector renews sessions", first, got)
+		}
 	}
 }

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -90,6 +90,37 @@ func (s *Sablier) Groups() map[string][]string {
 	return s.groups.Snapshot()
 }
 
+// SessionsSnapshot returns a point-in-time view of every active session for the
+// metrics SessionExpiryCollector. It is non-destructive: it enumerates the store
+// without renewing any session's timeout. The group label is taken from the
+// instance's first group, or "" when it belongs to none.
+func (s *Sablier) SessionsSnapshot() []metrics.SessionEntry {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var out []metrics.SessionEntry
+	err := s.sessions.Range(ctx, func(info InstanceInfo, expiresAt time.Time) {
+		group := ""
+		if len(info.Groups) > 0 {
+			group = info.Groups[0]
+		}
+		out = append(out, metrics.SessionEntry{
+			Instance:  info.Name,
+			Group:     group,
+			ExpiresAt: expiresAt,
+		})
+	})
+	if err != nil {
+		// Enumeration failed partway through, so out only holds a subset of the
+		// live sessions. Emitting that subset would make the missing sessions
+		// look expired; drop the whole snapshot instead, so a scrape is
+		// all-or-nothing.
+		s.l.Warn("could not snapshot sessions for metrics", slog.Any("error", err))
+		return nil
+	}
+	return out
+}
+
 // SetGroups replaces the entire group registry. Changes are logged with a diff.
 func (s *Sablier) SetGroups(groups map[string][]string) {
 	old, changed := s.groups.Set(groups)

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -90,6 +90,9 @@ func (s *Sablier) Groups() map[string][]string {
 	return s.groups.Snapshot()
 }
 
+// Sablier is the source of active-session snapshots for the expiry collector.
+var _ metrics.SessionSource = (*Sablier)(nil)
+
 // SessionsSnapshot returns a point-in-time view of every active session for the
 // metrics SessionExpiryCollector. It is non-destructive: it enumerates the store
 // without renewing any session's timeout. The group label is taken from the

--- a/pkg/sablier/store.go
+++ b/pkg/sablier/store.go
@@ -12,4 +12,9 @@ type Store interface {
 	Put(context.Context, InstanceInfo, time.Duration) error
 	Delete(context.Context, string) error
 	OnExpire(context.Context, func(string)) error
+	// Range calls f for every non-expired session currently held by the store,
+	// passing the instance info and its absolute expiration time. Iterating with
+	// Range is read-only: it never renews a session's timeout, so it is safe to
+	// use for observability (e.g. metrics) without extending sessions.
+	Range(context.Context, func(InstanceInfo, time.Time)) error
 }

--- a/pkg/sabliercmd/start.go
+++ b/pkg/sabliercmd/start.go
@@ -86,6 +86,7 @@ func Start(ctx context.Context, conf config.Config) error {
 	// up alongside everything else when /metrics is scraped.
 	if pr, ok := rec.(*metrics.PromRecorder); ok {
 		pr.Registry().MustRegister(metrics.NewGroupLockCollector(s, pr))
+		pr.Registry().MustRegister(metrics.NewSessionExpiryCollector(s))
 	}
 	s.BlockingRefreshFrequency = conf.Strategy.Blocking.DefaultRefreshFrequency
 

--- a/pkg/store/inmemory/inmemory.go
+++ b/pkg/store/inmemory/inmemory.go
@@ -48,6 +48,13 @@ func (i InMemory) Delete(_ context.Context, s string) error {
 	return nil
 }
 
+func (i InMemory) Range(_ context.Context, f func(sablier.InstanceInfo, time.Time)) error {
+	i.kv.Range(func(_ string, value sablier.InstanceInfo, expiresAt time.Time) {
+		f(value, expiresAt)
+	})
+	return nil
+}
+
 func (i InMemory) OnExpire(_ context.Context, f func(string)) error {
 	i.kv.SetOnExpire(func(k string, _ sablier.InstanceInfo) {
 		f(k)

--- a/pkg/store/inmemory/inmemory_test.go
+++ b/pkg/store/inmemory/inmemory_test.go
@@ -53,6 +53,30 @@ func TestInMemory(t *testing.T) {
 		_, err = vk.Get(ctx, "test")
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
+	t.Run("InMemoryRange", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		vk := NewInMemory()
+
+		err := vk.Put(ctx, sablier.InstanceInfo{Name: "live", Groups: []string{"demo"}}, 30*time.Second)
+		assert.NilError(t, err)
+		err = vk.Put(ctx, sablier.InstanceInfo{Name: "expired"}, 10*time.Millisecond)
+		assert.NilError(t, err)
+
+		<-time.After(30 * time.Millisecond)
+
+		got := make(map[string]time.Time)
+		err = vk.Range(ctx, func(info sablier.InstanceInfo, expiresAt time.Time) {
+			got[info.Name] = expiresAt
+		})
+		assert.NilError(t, err)
+
+		// Only the live session is enumerated; the expired one is skipped.
+		assert.Equal(t, len(got), 1)
+		exp, ok := got["live"]
+		assert.Assert(t, ok)
+		assert.Assert(t, exp.After(time.Now()))
+	})
 	t.Run("InMemoryOnExpire", func(t *testing.T) {
 		t.Parallel()
 		vk := NewInMemory()

--- a/pkg/store/storetest/mocks_store.go
+++ b/pkg/store/storetest/mocks_store.go
@@ -98,3 +98,17 @@ func (mr *MockStoreMockRecorder) Put(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockStore)(nil).Put), arg0, arg1, arg2)
 }
+
+// Range mocks base method.
+func (m *MockStore) Range(arg0 context.Context, arg1 func(sablier.InstanceInfo, time.Time)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Range", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Range indicates an expected call of Range.
+func (mr *MockStoreMockRecorder) Range(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Range", reflect.TypeOf((*MockStore)(nil).Range), arg0, arg1)
+}

--- a/pkg/store/valkey/valkey.go
+++ b/pkg/store/valkey/valkey.go
@@ -64,6 +64,68 @@ func (v *ValKey) Delete(ctx context.Context, s string) error {
 	return v.Client.Do(ctx, v.Client.B().Del().Key(s).Build()).Error()
 }
 
+func (v *ValKey) Range(ctx context.Context, f func(sablier.InstanceInfo, time.Time)) error {
+	// SCAN guarantees a full iteration but may return the same key several times
+	// (e.g. during a keyspace rehash). Deduplicate so the caller never observes a
+	// session twice, which would otherwise produce duplicate metric series.
+	seen := make(map[string]struct{})
+	var cursor uint64
+	for {
+		entry, err := v.Client.Do(ctx, v.Client.B().Scan().Cursor(cursor).Count(100).Build()).AsScanEntry()
+		if err != nil {
+			return err
+		}
+
+		for _, key := range entry.Elements {
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+
+			// PTTL and GET are read-only: they never reset the key's TTL, so
+			// enumerating sessions this way does not renew them.
+			pttl, err := v.Client.Do(ctx, v.Client.B().Pttl().Key(key).Build()).AsInt64()
+			if err != nil {
+				return err
+			}
+			// -2: the key vanished between SCAN and PTTL. -1: the key has no
+			// expiry, so it is not a session. Skip both; only keys with a live
+			// TTL represent an active session.
+			if pttl <= 0 {
+				continue
+			}
+
+			b, err := v.Client.Do(ctx, v.Client.B().Get().Key(key).Build()).AsBytes()
+			if valkey.IsValkeyNil(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+
+			// The store may share its keyspace with keys that are not Sablier
+			// sessions. Skip anything that is not a valid InstanceInfo, or whose
+			// payload does not belong to this key, instead of aborting the whole
+			// enumeration on a single foreign or corrupt key.
+			var i sablier.InstanceInfo
+			if err = json.Unmarshal(b, &i); err != nil {
+				continue
+			}
+			if i.Name != key {
+				continue
+			}
+
+			f(i, time.Now().Add(time.Duration(pttl)*time.Millisecond))
+		}
+
+		cursor = entry.Cursor
+		if cursor == 0 {
+			break
+		}
+	}
+	return nil
+}
+
 func (v *ValKey) OnExpire(ctx context.Context, f func(string)) error {
 	go func() {
 		err := v.Client.Receive(ctx, v.Client.B().Psubscribe().Pattern("__key*__:*").Build(), func(msg valkey.PubSubMessage) {

--- a/pkg/store/valkey/valkey.go
+++ b/pkg/store/valkey/valkey.go
@@ -94,6 +94,10 @@ func (v *ValKey) Range(ctx context.Context, f func(sablier.InstanceInfo, time.Ti
 			if pttl <= 0 {
 				continue
 			}
+			// Compute the absolute expiry from the TTL observed right now, before
+			// the GET + unmarshal below. Deriving it after those calls would push
+			// the reported expiry later than the true TTL under load.
+			expiresAt := time.Now().Add(time.Duration(pttl) * time.Millisecond)
 
 			b, err := v.Client.Do(ctx, v.Client.B().Get().Key(key).Build()).AsBytes()
 			if valkey.IsValkeyNil(err) {
@@ -115,7 +119,7 @@ func (v *ValKey) Range(ctx context.Context, f func(sablier.InstanceInfo, time.Ti
 				continue
 			}
 
-			f(i, time.Now().Add(time.Duration(pttl)*time.Millisecond))
+			f(i, expiresAt)
 		}
 
 		cursor = entry.Cursor

--- a/pkg/store/valkey/valkey_test.go
+++ b/pkg/store/valkey/valkey_test.go
@@ -82,6 +82,44 @@ func TestValKey(t *testing.T) {
 		_, err = vk.Get(ctx, "ValKeyDelete")
 		assert.ErrorIs(t, err, store.ErrKeyNotFound)
 	})
+	t.Run("ValKeyRange", func(t *testing.T) {
+		err := vk.Put(ctx, sablier.InstanceInfo{Name: "ValKeyRange", Groups: []string{"demo"}}, 30*time.Second)
+		assert.NilError(t, err)
+
+		got := make(map[string]time.Time)
+		err = vk.Range(ctx, func(info sablier.InstanceInfo, expiresAt time.Time) {
+			got[info.Name] = expiresAt
+		})
+		assert.NilError(t, err)
+
+		// The live session is enumerated with a future expiry. Other subtests
+		// share the same store, so we only assert on our key.
+		exp, ok := got["ValKeyRange"]
+		assert.Assert(t, ok)
+		assert.Assert(t, exp.After(time.Now()))
+	})
+	t.Run("ValKeyRangeIgnoresForeignKeys", func(t *testing.T) {
+		// A real session.
+		err := vk.Put(ctx, sablier.InstanceInfo{Name: "ValKeyRangeReal"}, 30*time.Second)
+		assert.NilError(t, err)
+		// A foreign, non-JSON key with a TTL (e.g. another app sharing the DB).
+		err = vk.Client.Do(ctx, vk.Client.B().Set().Key("ValKeyRangeForeignPlain").Value("not-json").Ex(30*time.Second).Build()).Error()
+		assert.NilError(t, err)
+		// A foreign JSON key whose payload is not an InstanceInfo for this key.
+		err = vk.Client.Do(ctx, vk.Client.B().Set().Key("ValKeyRangeForeignJSON").Value(`{"foo":"bar"}`).Ex(30*time.Second).Build()).Error()
+		assert.NilError(t, err)
+
+		got := make(map[string]time.Time)
+		err = vk.Range(ctx, func(info sablier.InstanceInfo, expiresAt time.Time) {
+			got[info.Name] = expiresAt
+		})
+		// Foreign/corrupt keys must be skipped, never abort the enumeration.
+		assert.NilError(t, err)
+		_, ok := got["ValKeyRangeReal"]
+		assert.Assert(t, ok)
+		_, emptyName := got[""]
+		assert.Assert(t, !emptyName)
+	})
 	t.Run("ValKeyOnExpire", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()

--- a/pkg/tinykv/tinykv.go
+++ b/pkg/tinykv/tinykv.go
@@ -178,21 +178,31 @@ func (kv *store[T]) Entries() (entries map[string]entry[T]) {
 	return entries
 }
 
-// Range calls f for every non-expired entry currently held by the store,
-// passing the key, its value and its absolute expiration time. The store lock
-// is held for the whole iteration, so f must be fast and must not call back
-// into the store. Entries without a timeout or already past their expiration
-// are skipped. Range only reads: it never renews an entry's timeout, so it is
-// safe to use for observing sessions without extending them.
+// Range calls f for every non-expired entry, passing the key, its value and its
+// absolute expiration time. It takes an instant snapshot under the store lock
+// and then invokes f for each item with the lock released, so f may be slow and
+// may safely call back into the store. Entries without a timeout or already past
+// their expiration are skipped. Range only reads: it never renews an entry's
+// timeout, so it is safe to use for observing sessions without extending them.
 func (kv *store[T]) Range(f func(key string, value T, expiresAt time.Time)) {
-	kv.mx.Lock()
-	defer kv.mx.Unlock()
+	type snapshotItem struct {
+		key       string
+		value     T
+		expiresAt time.Time
+	}
 
+	kv.mx.Lock()
+	snapshot := make([]snapshotItem, 0, len(kv.kv))
 	for k, e := range kv.kv {
 		if e.timeout == nil || e.expired() {
 			continue
 		}
-		f(k, e.value, e.expiresAt)
+		snapshot = append(snapshot, snapshotItem{key: k, value: e.value, expiresAt: e.expiresAt})
+	}
+	kv.mx.Unlock()
+
+	for _, it := range snapshot {
+		f(it.key, it.value, it.expiresAt)
 	}
 }
 

--- a/pkg/tinykv/tinykv.go
+++ b/pkg/tinykv/tinykv.go
@@ -62,6 +62,7 @@ type KV[T any] interface {
 	Keys() (keys []string)
 	Values() (values []T)
 	Entries() (entries map[string]entry[T])
+	Range(f func(key string, value T, expiresAt time.Time))
 	Put(k string, v T, expiresAfter time.Duration) error
 	Stop()
 	SetOnExpire(onExpire func(k string, v T))
@@ -175,6 +176,24 @@ func (kv *store[T]) Entries() (entries map[string]entry[T]) {
 		entries[k] = e
 	}
 	return entries
+}
+
+// Range calls f for every non-expired entry currently held by the store,
+// passing the key, its value and its absolute expiration time. The store lock
+// is held for the whole iteration, so f must be fast and must not call back
+// into the store. Entries without a timeout or already past their expiration
+// are skipped. Range only reads: it never renews an entry's timeout, so it is
+// safe to use for observing sessions without extending them.
+func (kv *store[T]) Range(f func(key string, value T, expiresAt time.Time)) {
+	kv.mx.Lock()
+	defer kv.mx.Unlock()
+
+	for k, e := range kv.kv {
+		if e.timeout == nil || e.expired() {
+			continue
+		}
+		f(k, e.value, e.expiresAt)
+	}
 }
 
 // Put puts an entry inside kv store with provided options

--- a/pkg/tinykv/tinykv_test.go
+++ b/pkg/tinykv/tinykv_test.go
@@ -105,6 +105,46 @@ func TestEntries(t *testing.T) {
 	assert.NotNil(entries["3"])
 }
 
+func TestRange(t *testing.T) {
+	assert := assert.New(t)
+	rg := New[int](0, nil)
+	defer rg.Stop()
+
+	require.NoError(t, rg.Put("live1", 1, time.Minute*50))
+	require.NoError(t, rg.Put("live2", 2, time.Minute*50))
+	require.NoError(t, rg.Put("expired", 3, time.Millisecond))
+
+	<-time.After(time.Millisecond * 20)
+
+	got := make(map[string]int)
+	expiries := make(map[string]time.Time)
+	rg.Range(func(key string, value int, expiresAt time.Time) {
+		got[key] = value
+		expiries[key] = expiresAt
+	})
+
+	// Expired entries must never be yielded.
+	assert.Len(got, 2)
+	assert.Equal(1, got["live1"])
+	assert.Equal(2, got["live2"])
+	_, ok := got["expired"]
+	assert.False(ok, "expired entries must not be yielded by Range")
+
+	// The reported expiry is in the future for live entries.
+	assert.True(expiries["live1"].After(time.Now()))
+
+	// Range must not renew timeouts: the reported expiry is stable across calls.
+	first := expiries["live1"]
+	<-time.After(time.Millisecond * 20)
+	var second time.Time
+	rg.Range(func(key string, _ int, expiresAt time.Time) {
+		if key == "live1" {
+			second = expiresAt
+		}
+	})
+	assert.Equal(first, second, "Range must not renew an entry's timeout")
+}
+
 func TestMarshalJSON(t *testing.T) {
 	require.NoError(t, os.Setenv("TZ", ""))
 	assert := assert.New(t)


### PR DESCRIPTION
## What

Expose the live session expiry as a Prometheus gauge so dashboards can show
"time remaining before scale-to-zero" per instance:

```
sablier_session_expires_at_timestamp_seconds{instance="<name>",group="<group>"} <unix-seconds>
```

One series per **active** session. Emitted by a **non-destructive collector**
that only *reads* the session store at scrape time — it never `Put`s, so
scraping `/metrics` does **not** renew any session. Only active behind the
existing `--server.metrics.enabled` flag; the default behaviour is unchanged.

Closes #986.

## Why

Until now the session expiry was not exposed live anywhere: the HTTP API does
not return it (and reading a session renews it), the `--storage.file` is only
written at shutdown, and the existing metrics are activity counters only. This
gauge makes "remaining time per instance" observable in Grafana.

## Design

- **Store enumeration (non-destructive).** New `Store.Range(ctx, func(InstanceInfo, time.Time)) error`
  that iterates non-expired sessions read-only.
  - `inmemory` delegates to a new `tinykv` `Range` that walks the map under the
    existing lock and skips expired / timeout-less entries (never touches TTLs).
  - `valkey` implements it with `SCAN` + `PTTL` + `GET` (all read-only; TTLs are
    never reset). `expiresAt = now + PTTL`.
- **Collector.** `SessionExpiryCollector` follows the existing `GroupLockCollector`
  pattern (`prometheus.NewDesc` + `MustNewConstMetric` at `Collect` time). To avoid
  an import cycle (`sablier` imports `metrics`) it consumes a small `sessionSource`
  interface; `*Sablier.SessionsSnapshot()` bridges the store to it. The store lock
  is only held to materialise a snapshot, never during metric emission.
- **Registration.** Registered next to `GroupLockCollector` in `start.go`, so it is
  active **only** when `--server.metrics.enabled` is set.
- **`group` label** = `InstanceInfo.Groups[0]` (or `""` when the instance has no group).

### Note from the maintainer, honoured

> "as long as you know that the ExpiresAt is based on the latest access, so it
> would be adjusted every time a session timer is reset."

Yes — this is the intended behaviour. The gauge reflects the current absolute
expiry, so it is pushed back on every renewal. This is documented in the metric
`HELP` string and in `docs/configuration.md`.

### No separate "remaining" metric (intentional)

Remaining time is trivially derivable in Grafana/PromQL and does not need a
second series:

```promql
sablier_session_expires_at_timestamp_seconds - time()
```

Kept the PR minimal.

## Tests

- **Collector unit test** (provider-agnostic): `testutil.CollectAndCompare`
  (exact exposed text, name/labels/value) + `testutil.CollectAndLint` (0 lint
  problems).
- **Non-destructive unit test**: seeds an in-memory store, scrapes the collector
  repeatedly, asserts the exposed `expiresAt` stays constant (a renewing
  collector would make it advance).
- **Store enumeration tests** for `tinykv`, `inmemory` and `valkey` (present vs
  expired entries; `Range` does not renew).
- **Non-regression**: `go build ./...`, `go vet ./...`, `gofmt` (0 diff),
  `golangci-lint run` (0 issues), `go test ./...` (incl. testcontainers).

## End-to-end validation (Podman)

Provider `podman`, `--server.metrics.enabled`, `--sessions.default-duration=2m`.

Before any session — no series (correct):
```
# (no sablier_session_expires_at_timestamp_seconds series)
```

After warming a session (`now ≈ 1782921114`, so expected `≈ 1782921234`):
```
# HELP sablier_session_expires_at_timestamp_seconds Unix timestamp (seconds) at which the instance's session expires and the instance is stopped. ...
# TYPE sablier_session_expires_at_timestamp_seconds gauge
sablier_session_expires_at_timestamp_seconds{group="demo",instance="whoami"} 1.782921234e+09
```

Non-destructive — scraping `/metrics` 4× over 16s of wall-clock leaves the value
unchanged (a renewing collector would advance it):
```
scrape #1 (t=0s):  1.782921234e+09   at 1782921131
scrape #2 (t=6s):  1.782921234e+09   at 1782921137
scrape #3 (t=12s): 1.782921234e+09   at 1782921143
scrape #4 (t=16s): 1.782921234e+09   at 1782921147
```

On expiry (no further warm) the series disappears and the container is stopped:
```
t=1782921231  session_series=1  whoami_status=running
t=1782921241  session_series=0  whoami_status=exited
```

## Notes

- `CHANGELOG.md` is managed by release-please, so it is intentionally not edited
  here — the entry will be generated from the conventional commits.
