### PR TITLE
feat(provider): add auto-warm-externally-started option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -278,6 +278,15 @@ provider:
   # Continuously stop instances with sablier.enable=true that are running but were not started by Sablier (default: false)
   # Uses both event-driven detection and a periodic reconciliation scan (every 30 seconds) as a safety net.
   auto-stop-externally-started: false
+  # Continuously create a session (with the default session duration) for instances with sablier.enable=true
+  # that are running but were not started by Sablier, instead of stopping them (default: false)
+  # This is the non-destructive counterpart to auto-stop-externally-started (the two options are
+  # mutually exclusive): the instance keeps running until its seeded session expires, then hibernates
+  # through the regular expiration lifecycle. Uses both event-driven detection and a periodic
+  # reconciliation scan (every 30 seconds) as a safety net.
+  # Pair it with auto-stop-on-startup: false, otherwise instances already running when Sablier
+  # boots are stopped once at startup before the warm watch takes over.
+  auto-warm-externally-started: false
   # Reject direct named requests for instances without sablier.enable=true
   reject-unlabeled-requests: false
   # Verify sablier.enable=true before stopping expired instances
@@ -398,7 +407,8 @@ sablier start --strategy.dynamic.custom-themes-path /my/path
 ```
   -h, --help                                                  help for start
       --provider.auto-stop-on-startup                         Stop all sablier.enable=true instances running at startup that were not started by Sablier (default true)
-  --provider.auto-stop-externally-started                 Continuously stop instances with sablier.enable=true that are running but were not started by Sablier (default false)
+      --provider.auto-stop-externally-started                 Continuously stop instances with sablier.enable=true that are running but were not started by Sablier (default false)
+      --provider.auto-warm-externally-started                 Continuously create a default-duration session for instances with sablier.enable=true that are running but were not started by Sablier, instead of stopping them (default false)
       --provider.docker.strategy string                       Strategy to use to stop docker containers (stop or pause) (default "stop")
       --provider.name string                                  Provider to use to manage containers [docker swarm kubernetes podman proxmox_lxc] (default "docker")
       --provider.reject-unlabeled-requests                    Reject requests for instances without sablier.enable=true (default false)

--- a/examples/auto-warm-externally-started/Makefile
+++ b/examples/auto-warm-externally-started/Makefile
@@ -1,0 +1,31 @@
+.DEFAULT_GOAL := help
+
+COMPOSE := docker compose
+
+.PHONY: help
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
+
+.PHONY: up
+up: ## Start the full stack (managed gets a seeded session instead of being stopped)
+	$(COMPOSE) up -d
+
+.PHONY: logs
+logs: ## Follow Sablier logs
+	$(COMPOSE) logs -f sablier
+
+.PHONY: status
+status: ## Show running container status
+	$(COMPOSE) ps -a
+
+.PHONY: start-managed
+start-managed: ## Start 'managed' externally to demonstrate the continuous watch
+	$(COMPOSE) start managed
+	@echo ""
+	@echo "Watch the Sablier logs — 'managed' receives a new 1m session and"
+	@echo "will be stopped about a minute later if it receives no traffic."
+	@echo "Run: make logs"
+
+.PHONY: down
+down: ## Tear down the stack
+	$(COMPOSE) down

--- a/examples/auto-warm-externally-started/README.md
+++ b/examples/auto-warm-externally-started/README.md
@@ -1,0 +1,96 @@
+# `auto-warm-externally-started` Example
+
+This example demonstrates the `--provider.auto-warm-externally-started` flag.
+
+Sablier manages containers that carry the `sablier.enable=true` label. If such
+a container starts without Sablier having initiated the start (e.g. via
+`docker compose up`, a deployment tool, or a manual `docker start`), Sablier
+seeds a session for it with the default session duration instead of stopping
+it. The container keeps running until that session expires without traffic,
+then hibernates through the regular scale-to-zero lifecycle.
+
+This is the non-destructive counterpart to
+[`auto-stop-externally-started`](../auto-stop-externally-started): fresh
+deployments are adopted into the session lifecycle instead of being killed.
+The two flags are mutually exclusive; Sablier refuses to start with both
+enabled.
+
+Two containers illustrate the difference:
+
+| Service | Labels | Behaviour |
+|---------|--------|-----------|
+| `managed` | `sablier.enable=true` | Receives a seeded session; stopped only when it expires |
+| `unmanaged` | *(none)* | Left running; Sablier ignores it |
+
+## Flags used
+
+| Flag | Value | Purpose |
+|------|-------|---------|
+| `--provider.auto-stop-on-startup` | `false` | Do not stop already-running managed instances at startup |
+| `--provider.auto-warm-externally-started` | `true` | Continuously seed a session for managed instances that were started externally |
+| `--sessions.default-duration` | `1m` | Duration of the seeded session (shortened for the demo) |
+
+## Prerequisites
+
+- Docker with the Compose plugin (`docker compose version`)
+
+## Walkthrough
+
+### Scenario 1 — Adoption instead of destruction
+
+Start the full stack:
+
+```bash
+make up
+```
+
+Both `managed` and `unmanaged` start via Compose. Because Sablier did not
+initiate the `managed` start, `--provider.auto-warm-externally-started` seeds
+a 1m session for it — the container is **not** stopped.
+
+Watch it happen:
+
+```bash
+make logs
+```
+
+You should see a log line similar to:
+
+```
+level=INFO msg="seeded session for externally started instance" instance=managed duration=1m0s
+```
+
+### Scenario 2 — Hibernation once the session expires
+
+Do not send any traffic to `managed`. About a minute later the seeded session
+expires and Sablier stops the container:
+
+```bash
+make status
+```
+
+Expected output (abridged):
+
+```
+NAME           STATUS
+sablier        Up
+managed        Exited
+unmanaged      Up
+```
+
+### Scenario 3 — Continuous watch
+
+Start `managed` externally again:
+
+```bash
+make start-managed
+```
+
+Sablier receives the Docker `start` event, recognises that it did not initiate
+the start, and seeds a fresh session — the cycle repeats.
+
+### Tear down
+
+```bash
+make down
+```

--- a/examples/auto-warm-externally-started/compose.yml
+++ b/examples/auto-warm-externally-started/compose.yml
@@ -1,0 +1,36 @@
+services:
+  sablier:
+    image: ${SABLIER_IMAGE:-sablierapp/sablier:latest}
+    command:
+      - start
+      - --provider.name=docker
+      - --logging.level=debug
+      - --sessions.default-duration=1m
+      - --sessions.expiration-interval=10s
+      # Keep externally started instances alive: do not stop them at startup...
+      - --provider.auto-stop-on-startup=false
+      # ...instead, seed a default-duration session for them. They hibernate on
+      # their own once that session expires without traffic.
+      - --provider.auto-warm-externally-started=true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "10000:10000"
+
+  # managed has sablier.enable=true.
+  # Sablier will seed a 1m session for it instead of stopping it. If nothing
+  # requests it before the session expires, Sablier then stops it.
+  managed:
+    image: acouvreur/whoami:v1.10.2
+    labels:
+      - "sablier.enable=true"
+      - "sablier.group=managed"
+    ports:
+      - "8080:80"
+
+  # unmanaged has no sablier labels.
+  # Sablier ignores it completely; it keeps running regardless.
+  unmanaged:
+    image: acouvreur/whoami:v1.10.2
+    ports:
+      - "8081:80"

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -28,6 +28,16 @@ type Provider struct {
 	// Default: false
 	AutoStopExternallyStarted bool
 
+	// AutoWarmExternallyStarted continuously creates a session (with the default
+	// session duration) for instances with sablier.enable=true that are running
+	// but were not started by Sablier itself, instead of stopping them. The regular
+	// expiration lifecycle then stops the instance once its session expires.
+	// This is the non-destructive counterpart to AutoStopExternallyStarted.
+	// Env: SABLIER_PROVIDER_AUTO_WARM_EXTERNALLY_STARTED
+	// CLI: --provider.auto-warm-externally-started
+	// Default: false
+	AutoWarmExternallyStarted bool
+
 	// RejectUnlabeledRequests rejects requests for instances that do not carry
 	// the sablier.enable=true label, preventing accidental management of unlabelled workloads.
 	// Env: SABLIER_PROVIDER_REJECT_UNLABELED_REQUESTS
@@ -143,6 +153,9 @@ func NewProviderConfig() Provider {
 }
 
 func (provider Provider) IsValid() error {
+	if provider.AutoStopExternallyStarted && provider.AutoWarmExternallyStarted {
+		return fmt.Errorf("provider.auto-stop-externally-started and provider.auto-warm-externally-started are mutually exclusive")
+	}
 	for _, p := range providers {
 		if p == provider.Name {
 			// Validate Docker-specific settings when using Docker provider

--- a/pkg/config/provider_test.go
+++ b/pkg/config/provider_test.go
@@ -44,6 +44,18 @@ func TestProvider_IsValid(t *testing.T) {
 			wantErr: fmt.Errorf("unrecognized docker strategy invalid. strategies available: [stop pause]"),
 		},
 		{
+			name: "auto-stop and auto-warm externally started are mutually exclusive",
+			provider: Provider{
+				Name:                      "docker",
+				AutoStopExternallyStarted: true,
+				AutoWarmExternallyStarted: true,
+				Docker: Docker{
+					Strategy: "stop",
+				},
+			},
+			wantErr: fmt.Errorf("provider.auto-stop-externally-started and provider.auto-warm-externally-started are mutually exclusive"),
+		},
+		{
 			name: "valid kubernetes provider",
 			provider: Provider{
 				Name: "kubernetes",
@@ -187,6 +199,7 @@ func TestNewProviderConfig_Defaults(t *testing.T) {
 	assert.Equal(t, c.Name, "docker")
 	assert.Equal(t, c.AutoStopOnStartup, true)
 	assert.Equal(t, c.AutoStopExternallyStarted, false)
+	assert.Equal(t, c.AutoWarmExternallyStarted, false)
 	assert.Equal(t, c.Docker.Strategy, "stop")
 	assert.Equal(t, c.Kubernetes.QPS, float32(5))
 	assert.Equal(t, c.Kubernetes.Burst, 10)

--- a/pkg/sablier/autowarm.go
+++ b/pkg/sablier/autowarm.go
@@ -1,0 +1,130 @@
+package sablier
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/provider"
+	"github.com/sablierapp/sablier/pkg/store"
+)
+
+// WarmAllUnregisteredInstances creates a session for all auto-discovered running
+// instances that are not yet registered as running instances by Sablier.
+// This is the non-destructive counterpart to StopAllUnregisteredInstances: instead
+// of stopping an externally started instance, it seeds a session with the default
+// session duration so the regular expiration lifecycle takes over.
+func (s *Sablier) WarmAllUnregisteredInstances(ctx context.Context) error {
+	instances, err := s.provider.InstanceList(ctx, provider.InstanceListOptions{
+		All: false, // Only running instances
+	})
+	if err != nil {
+		return err
+	}
+
+	unregistered := make([]string, 0)
+	for _, instance := range instances {
+		if !s.isStartedByUs(ctx, instance.Name) {
+			unregistered = append(unregistered, instance.Name)
+		}
+	}
+
+	s.l.DebugContext(ctx, "found instances to warm", slog.Any("instances", unregistered))
+
+	for _, name := range unregistered {
+		s.seedSession(ctx, name)
+	}
+
+	return nil
+}
+
+// seedSession registers a session with the default session duration for an
+// already-running instance, without going through the start path.
+// It is a no-op when the instance already has a session (so an existing session
+// is never renewed by the watch loop), when it cannot be inspected, or when it
+// is not ready yet (the reconciliation scan will pick it up once ready).
+func (s *Sablier) seedSession(ctx context.Context, name string) {
+	_, err := s.sessions.Get(ctx, name)
+	if err == nil {
+		return // the instance already has a session
+	}
+	if !errors.Is(err, store.ErrKeyNotFound) {
+		s.l.WarnContext(ctx, "session lookup failed, not warming instance", slog.String("instance", name), slog.Any("error", err))
+		return
+	}
+
+	info, err := s.provider.InstanceInspect(ctx, name)
+	if err != nil {
+		s.l.WarnContext(ctx, "instance inspect failed, not warming instance", slog.String("instance", name), slog.Any("error", err))
+		return
+	}
+	if info.Status != InstanceStatusReady {
+		return
+	}
+
+	if err := s.sessions.Put(ctx, info, s.DefaultSessionDuration); err != nil {
+		s.l.WarnContext(ctx, "failed to seed session for instance", slog.String("instance", name), slog.Any("error", err))
+		return
+	}
+	s.l.InfoContext(ctx, "seeded session for externally started instance",
+		slog.String("instance", name),
+		slog.Duration("duration", s.DefaultSessionDuration),
+		slog.String("reason", "instance is enabled but not started by Sablier"))
+}
+
+// WatchAndWarmExternallyStarted continuously creates sessions for instances that
+// have sablier.enable=true but were not started by Sablier. It combines
+// event-driven detection (InstanceEventStarted) with a periodic
+// reconciliation ticker as a safety net.
+//
+// This is the non-destructive counterpart to WatchAndStopExternallyStarted:
+// instead of stopping an externally started instance, it seeds a session with
+// the default session duration. The instance then hibernates through the
+// regular expiration lifecycle if it stays idle. Call it in a dedicated goroutine.
+func (s *Sablier) WatchAndWarmExternallyStarted(ctx context.Context) {
+	stream := s.provider.InstanceEvents(ctx, provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	})
+	eventsC := stream.Events
+	errC := stream.Err
+
+	ticker := time.NewTicker(s.ExternallyStartedScanInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.l.InfoContext(ctx, "stop watching for unregistered instances to warm", slog.Any("reason", ctx.Err()))
+			return
+		case info, ok := <-eventsC:
+			if !ok {
+				s.l.WarnContext(ctx, "started event stream closed; relying on reconciliation ticker")
+				eventsC = nil // disable this select case
+				continue
+			}
+			// Only act on Sablier-managed instances.
+			if info.Info.Enabled != "true" {
+				continue
+			}
+			if s.isStartedByUs(ctx, info.Info.Name) {
+				s.l.DebugContext(ctx, "instance started by Sablier, skipping", slog.String("instance", info.Info.Name))
+				continue
+			}
+			s.l.InfoContext(ctx, "externally started instance detected, warming", slog.String("instance", info.Info.Name))
+			s.seedSession(ctx, info.Info.Name)
+		case err, ok := <-errC:
+			if !ok {
+				errC = nil // disable this select case
+				continue
+			}
+			s.l.ErrorContext(ctx, "started event stream permanently lost; relying on reconciliation ticker", slog.Any("error", err))
+			errC = nil
+			eventsC = nil
+		case <-ticker.C:
+			if err := s.WarmAllUnregisteredInstances(ctx); err != nil {
+				s.l.ErrorContext(ctx, "unregistered instance warm scan failed", slog.Any("error", err))
+			}
+		}
+	}
+}

--- a/pkg/sablier/autowarm_test.go
+++ b/pkg/sablier/autowarm_test.go
@@ -1,0 +1,411 @@
+package sablier_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/provider"
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"github.com/sablierapp/sablier/pkg/store"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+)
+
+func TestWarmAllUnregisteredInstances(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.DefaultSessionDuration = 3 * time.Minute
+
+	ctx := t.Context()
+
+	// Define instances and registered instances
+	instances := []sablier.InstanceConfiguration{
+		{Name: "instance1"},
+		{Name: "instance2"},
+	}
+
+	// instance1 has no session: looked up once by isStartedByUs and once by seedSession.
+	sessions.EXPECT().Get(ctx, "instance1").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).Times(2)
+	// instance2 already has a session: it must not be touched.
+	sessions.EXPECT().Get(ctx, "instance2").Return(sablier.InstanceInfo{
+		Name:   "instance2",
+		Status: sablier.InstanceStatusReady,
+	}, nil)
+
+	// Set up expectations for InstanceList
+	p.EXPECT().InstanceList(ctx, provider.InstanceListOptions{
+		All: false,
+	}).Return(instances, nil)
+
+	// instance1 is running: it receives a session with the default session duration.
+	ready := sablier.InstanceInfo{Name: "instance1", Status: sablier.InstanceStatusReady}
+	p.EXPECT().InstanceInspect(ctx, "instance1").Return(ready, nil)
+	sessions.EXPECT().Put(ctx, ready, 3*time.Minute).Return(nil)
+
+	// Call the function under test
+	err := s.WarmAllUnregisteredInstances(ctx)
+	assert.NilError(t, err)
+}
+
+func TestWarmAllUnregisteredInstances_SkipsNotReadyInstance(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+
+	ctx := t.Context()
+
+	instances := []sablier.InstanceConfiguration{
+		{Name: "instance1"},
+	}
+
+	sessions.EXPECT().Get(ctx, "instance1").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).Times(2)
+
+	p.EXPECT().InstanceList(ctx, provider.InstanceListOptions{
+		All: false,
+	}).Return(instances, nil)
+
+	// instance1 is not ready yet: no session is seeded (Put must not be called).
+	p.EXPECT().InstanceInspect(ctx, "instance1").Return(sablier.InstanceInfo{
+		Name:   "instance1",
+		Status: sablier.InstanceStatusStarting,
+	}, nil)
+
+	err := s.WarmAllUnregisteredInstances(ctx)
+	assert.NilError(t, err)
+}
+
+func TestWarmAllUnregisteredInstances_WithError(t *testing.T) {
+	s, _, p := setupSablier(t)
+	ctx := t.Context()
+
+	p.EXPECT().InstanceList(ctx, provider.InstanceListOptions{
+		All: false,
+	}).Return(nil, errors.New("list error"))
+
+	err := s.WarmAllUnregisteredInstances(ctx)
+	assert.Error(t, err, "list error")
+}
+
+// --- WatchAndWarmExternallyStarted tests ---
+
+// startAutowarmWatcher launches s.WatchAndWarmExternallyStarted in a goroutine
+// and registers a t.Cleanup that cancels the context and waits for the goroutine
+// to exit. This prevents "Log called after test finished" panics from the slogt
+// logger.
+func startAutowarmWatcher(t *testing.T, s *sablier.Sablier, ctx context.Context, cancel context.CancelFunc) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		s.WatchAndWarmExternallyStarted(ctx)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+}
+
+// TestWatchAndWarmExternallyStarted_WarmsExternalInstance verifies that when a
+// "started" event arrives for a Sablier-managed instance that is NOT in the
+// sessions store (i.e. externally started), a session is seeded for it with
+// the default session duration instead of stopping it.
+func TestWatchAndWarmExternallyStarted_WarmsExternalInstance(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 24 * time.Hour // prevent ticker from firing
+	s.DefaultSessionDuration = 3 * time.Minute
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	// Instance is not in the sessions store: looked up by isStartedByUs and seedSession.
+	sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).Times(2)
+
+	ready := sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusReady, Enabled: "true"}
+	p.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(ready, nil)
+
+	seeded := make(chan struct{})
+	sessions.EXPECT().Put(gomock.Any(), ready, 3*time.Minute).DoAndReturn(func(_ context.Context, _ sablier.InstanceInfo, _ time.Duration) error {
+		close(seeded)
+		return nil
+	})
+
+	// Send the event before starting the goroutine so the channel is pre-filled.
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusReady, Enabled: "true"}}
+
+	startAutowarmWatcher(t, s, ctx, cancel)
+
+	select {
+	case <-seeded:
+		// success
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for externally-started instance to be warmed")
+	}
+}
+
+// TestWatchAndWarmExternallyStarted_SkipsSablierStartedInstance_InStore verifies
+// that a "started" event for an instance already in the sessions store is
+// not touched (Sablier started it, or it already holds a session): the session
+// must not be re-created, so it is never renewed in a loop.
+func TestWatchAndWarmExternallyStarted_SkipsSablierStartedInstance_InStore(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	// Instance IS in the sessions store → started by Sablier / already has a session
+	sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
+		Name:   "nginx",
+		Status: sablier.InstanceStatusReady,
+	}, nil)
+
+	// Put must NOT be called; gomock will fail the test if it is.
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}}
+
+	startAutowarmWatcher(t, s, ctx, cancel)
+
+	// Give the goroutine time to process the event then verify no seed happened.
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestWatchAndWarmExternallyStarted_DoesNotReseedWhenSessionAppearsBetweenChecks
+// verifies the seedSession-level session lookup: if a session is registered
+// between the isStartedByUs check and the seed (e.g. a concurrent RequestSession),
+// no session is put on top of it.
+func TestWatchAndWarmExternallyStarted_DoesNotReseedWhenSessionAppearsBetweenChecks(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	// First lookup (isStartedByUs): no session yet. Second lookup (seedSession):
+	// a session appeared in between. InstanceInspect and Put must NOT be called.
+	first := sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+	sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
+		Name:   "nginx",
+		Status: sablier.InstanceStatusReady,
+	}, nil).After(first)
+
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusReady, Enabled: "true"}}
+
+	startAutowarmWatcher(t, s, ctx, cancel)
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestWatchAndWarmExternallyStarted_SkipsPendingSablierStart verifies the
+// pendingStarts half of the isStartedByUs guard: when Sablier itself has an
+// in-progress start for an instance whose session entry is not written yet,
+// the "started" event emitted by the provider must not trigger a seed.
+func TestWatchAndWarmExternallyStarted_SkipsPendingSablierStart(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	// Simulate the window between a Sablier-initiated start and its session
+	// write: the store keeps answering "not found" for the whole test.
+	sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
+
+	// InstanceRequest performs exactly one pre-start inspect; the warm watcher
+	// must not add a second inspect (seedSession would).
+	p.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
+		Name:    "nginx",
+		Status:  sablier.InstanceStatusStopped,
+		Enabled: "true",
+	}, nil).Times(1)
+
+	// A failed async start leaves the pendingStarts entry in place (it is only
+	// consumed by the next request), which is exactly the state we need.
+	p.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("start failed"))
+
+	// The only allowed Put is the one from InstanceRequest itself.
+	sessions.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	// Sablier initiates the start: nginx is now registered in pendingStarts.
+	_, err := s.InstanceRequest(ctx, "nginx", time.Minute)
+	assert.NilError(t, err)
+
+	// The provider emits the started event for the Sablier-initiated start.
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusReady, Enabled: "true"}}
+
+	startAutowarmWatcher(t, s, ctx, cancel)
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestWarmAllUnregisteredInstances_SkipsOnInspectError verifies that an
+// inspect failure during seeding is skipped without putting a session.
+func TestWarmAllUnregisteredInstances_SkipsOnInspectError(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	ctx := t.Context()
+
+	p.EXPECT().InstanceList(ctx, provider.InstanceListOptions{
+		All: false,
+	}).Return([]sablier.InstanceConfiguration{{Name: "instance1"}}, nil)
+
+	sessions.EXPECT().Get(ctx, "instance1").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).Times(2)
+
+	// Inspect fails: Put must NOT be called.
+	p.EXPECT().InstanceInspect(ctx, "instance1").Return(sablier.InstanceInfo{}, errors.New("inspect error"))
+
+	err := s.WarmAllUnregisteredInstances(ctx)
+	assert.NilError(t, err)
+}
+
+// TestWarmAllUnregisteredInstances_SkipsOnSessionLookupError verifies that a
+// store error (other than ErrKeyNotFound) on the seed-time lookup does not
+// lead to seeding a session blindly.
+func TestWarmAllUnregisteredInstances_SkipsOnSessionLookupError(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	ctx := t.Context()
+
+	p.EXPECT().InstanceList(ctx, provider.InstanceListOptions{
+		All: false,
+	}).Return([]sablier.InstanceConfiguration{{Name: "instance1"}}, nil)
+
+	// Both lookups fail with a store error: isStartedByUs treats it as "not started
+	// by us", then seedSession bails out. InstanceInspect and Put must NOT be called.
+	sessions.EXPECT().Get(ctx, "instance1").Return(sablier.InstanceInfo{}, errors.New("store unavailable")).Times(2)
+
+	err := s.WarmAllUnregisteredInstances(ctx)
+	assert.NilError(t, err)
+}
+
+// TestWatchAndWarmExternallyStarted_SkipsNonSablierInstance verifies that a
+// "started" event for an instance without sablier.enable=true is ignored.
+func TestWatchAndWarmExternallyStarted_SkipsNonSablierInstance(t *testing.T) {
+	s, _, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 24 * time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eventsC := make(chan sablier.InstanceEvent, 1)
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	// No sessions.Get or Put expected.
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "false"}}
+
+	startAutowarmWatcher(t, s, ctx, cancel)
+
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestWatchAndWarmExternallyStarted_ReconciliationTicker verifies that even without
+// incoming events, the periodic ticker triggers a reconciliation scan that seeds
+// sessions for unregistered running instances.
+func TestWatchAndWarmExternallyStarted_ReconciliationTicker(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 20 * time.Millisecond // fire quickly
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eventsC := make(chan sablier.InstanceEvent) // no events sent
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	instances := []sablier.InstanceConfiguration{{Name: "external"}}
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: false}).
+		Return(instances, nil).AnyTimes()
+	sessions.EXPECT().Get(gomock.Any(), "external").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
+	ready := sablier.InstanceInfo{Name: "external", Status: sablier.InstanceStatusReady}
+	p.EXPECT().InstanceInspect(gomock.Any(), "external").Return(ready, nil).AnyTimes()
+
+	seeded := make(chan struct{}, 1)
+	sessions.EXPECT().Put(gomock.Any(), ready, gomock.Any()).DoAndReturn(func(_ context.Context, _ sablier.InstanceInfo, _ time.Duration) error {
+		select {
+		case seeded <- struct{}{}:
+		default:
+		}
+		return nil
+	}).AnyTimes()
+
+	startAutowarmWatcher(t, s, ctx, cancel)
+
+	select {
+	case <-seeded:
+		// success: reconciliation ticker fired and warmed the external instance
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconciliation ticker to warm external instance")
+	}
+}
+
+// TestWatchAndWarmExternallyStarted_EventStreamClosed verifies that when the
+// started event stream closes, the function falls back to ticker-only mode
+// and continues reconciliation.
+func TestWatchAndWarmExternallyStarted_EventStreamClosed(t *testing.T) {
+	s, sessions, p := setupSablier(t)
+	s.ExternallyStartedScanInterval = 20 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eventsC := make(chan sablier.InstanceEvent)
+	errC := make(chan error, 1)
+
+	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+
+	// Close the events channel immediately to simulate stream closure.
+	close(eventsC)
+
+	instances := []sablier.InstanceConfiguration{{Name: "external"}}
+	p.EXPECT().InstanceList(gomock.Any(), provider.InstanceListOptions{All: false}).
+		Return(instances, nil).AnyTimes()
+	sessions.EXPECT().Get(gomock.Any(), "external").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
+	ready := sablier.InstanceInfo{Name: "external", Status: sablier.InstanceStatusReady}
+	p.EXPECT().InstanceInspect(gomock.Any(), "external").Return(ready, nil).AnyTimes()
+
+	seeded := make(chan struct{}, 1)
+	sessions.EXPECT().Put(gomock.Any(), ready, gomock.Any()).DoAndReturn(func(_ context.Context, _ sablier.InstanceInfo, _ time.Duration) error {
+		select {
+		case seeded <- struct{}{}:
+		default:
+		}
+		return nil
+	}).AnyTimes()
+
+	startAutowarmWatcher(t, s, ctx, cancel)
+
+	select {
+	case <-seeded:
+		// success: reconciliation ticker still fires despite stream closure
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for reconciliation after stream closure")
+	}
+}

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -30,9 +30,14 @@ type Sablier struct {
 	// call before it is cancelled. Defaults to 5 minutes.
 	InstanceStartTimeout time.Duration
 
-	// ExternallyStartedScanInterval is how often WatchAndStopExternallyStarted performs a
-	// full reconciliation scan. Defaults to 30 seconds.
+	// ExternallyStartedScanInterval is how often WatchAndStopExternallyStarted and
+	// WatchAndWarmExternallyStarted perform a full reconciliation scan. Defaults to 30 seconds.
 	ExternallyStartedScanInterval time.Duration
+
+	// DefaultSessionDuration is the session duration used when seeding sessions
+	// for externally started instances (WatchAndWarmExternallyStarted).
+	// Defaults to 5 minutes.
+	DefaultSessionDuration time.Duration
 
 	// RunningHoursRefreshFrequency is how often running-hours windows are
 	// reconciled. Defaults to 30 seconds.
@@ -62,6 +67,7 @@ func New(logger *slog.Logger, store Store, provider Provider) *Sablier {
 		BlockingRefreshFrequency:      5 * time.Second,
 		InstanceStartTimeout:          5 * time.Minute,
 		ExternallyStartedScanInterval: 30 * time.Second,
+		DefaultSessionDuration:        5 * time.Minute,
 		RunningHoursRefreshFrequency:  30 * time.Second,
 	}
 }

--- a/pkg/sabliercmd/root.go
+++ b/pkg/sabliercmd/root.go
@@ -44,6 +44,8 @@ It provides integrations with multiple reverse proxies and different loading str
 	_ = viper.BindPFlag("provider.auto-stop-on-startup", startCmd.Flags().Lookup("provider.auto-stop-on-startup"))
 	startCmd.Flags().BoolVar(&conf.Provider.AutoStopExternallyStarted, "provider.auto-stop-externally-started", false, "Continuously stop instances with sablier.enable=true that are running but were not started by Sablier")
 	_ = viper.BindPFlag("provider.auto-stop-externally-started", startCmd.Flags().Lookup("provider.auto-stop-externally-started"))
+	startCmd.Flags().BoolVar(&conf.Provider.AutoWarmExternallyStarted, "provider.auto-warm-externally-started", false, "Continuously create a default-duration session for instances with sablier.enable=true that are running but were not started by Sablier, instead of stopping them")
+	_ = viper.BindPFlag("provider.auto-warm-externally-started", startCmd.Flags().Lookup("provider.auto-warm-externally-started"))
 	startCmd.Flags().BoolVar(&conf.Provider.RejectUnlabeledRequests, "provider.reject-unlabeled-requests", false, "Reject direct named requests for instances without sablier.enable=true")
 	_ = viper.BindPFlag("provider.reject-unlabeled-requests", startCmd.Flags().Lookup("provider.reject-unlabeled-requests"))
 	startCmd.Flags().BoolVar(&conf.Provider.VerifyEnabledOnExpiration, "provider.verify-enabled-on-expiration", false, "Verify sablier.enable=true before stopping expired instances")

--- a/pkg/sabliercmd/start.go
+++ b/pkg/sabliercmd/start.go
@@ -88,6 +88,7 @@ func Start(ctx context.Context, conf config.Config) error {
 		pr.Registry().MustRegister(metrics.NewGroupLockCollector(s, pr))
 	}
 	s.BlockingRefreshFrequency = conf.Strategy.Blocking.DefaultRefreshFrequency
+	s.DefaultSessionDuration = conf.Sessions.DefaultDuration
 
 	groups, err := provider.InstanceGroups(ctx)
 	if err != nil {
@@ -130,6 +131,9 @@ func Start(ctx context.Context, conf config.Config) error {
 
 	if conf.Provider.AutoStopExternallyStarted {
 		go s.WatchAndStopExternallyStarted(ctx)
+	}
+	if conf.Provider.AutoWarmExternallyStarted {
+		go s.WatchAndWarmExternallyStarted(ctx)
 	}
 	go s.WatchRunningHours(ctx)
 

--- a/pkg/sabliercmd/testdata/config_cli_wanted.json
+++ b/pkg/sabliercmd/testdata/config_cli_wanted.json
@@ -13,6 +13,7 @@
     "Name": "cli",
     "AutoStopOnStartup": false,
     "AutoStopExternallyStarted": false,
+    "AutoWarmExternallyStarted": false,
     "RejectUnlabeledRequests": false,
     "VerifyEnabledOnExpiration": false,
     "Kubernetes": {

--- a/pkg/sabliercmd/testdata/config_default.json
+++ b/pkg/sabliercmd/testdata/config_default.json
@@ -13,6 +13,7 @@
     "Name": "docker",
     "AutoStopOnStartup": true,
     "AutoStopExternallyStarted": false,
+    "AutoWarmExternallyStarted": false,
     "RejectUnlabeledRequests": false,
     "VerifyEnabledOnExpiration": false,
     "Kubernetes": {

--- a/pkg/sabliercmd/testdata/config_env_wanted.json
+++ b/pkg/sabliercmd/testdata/config_env_wanted.json
@@ -13,6 +13,7 @@
     "Name": "envvar",
     "AutoStopOnStartup": false,
     "AutoStopExternallyStarted": false,
+    "AutoWarmExternallyStarted": false,
     "RejectUnlabeledRequests": false,
     "VerifyEnabledOnExpiration": false,
     "Kubernetes": {

--- a/pkg/sabliercmd/testdata/config_yaml_wanted.json
+++ b/pkg/sabliercmd/testdata/config_yaml_wanted.json
@@ -13,6 +13,7 @@
     "Name": "configfile",
     "AutoStopOnStartup": false,
     "AutoStopExternallyStarted": false,
+    "AutoWarmExternallyStarted": false,
     "RejectUnlabeledRequests": false,
     "VerifyEnabledOnExpiration": false,
     "Kubernetes": {


### PR DESCRIPTION
Closes #985

## What

Adds an opt-in `--provider.auto-warm-externally-started` flag (default `false`, env `SABLIER_PROVIDER_AUTO_WARM_EXTERNALLY_STARTED`).

When enabled, Sablier continuously watches for instances that carry `sablier.enable=true`, are running, but hold **no session** (i.e. externally started) — the exact same detection as `--provider.auto-stop-externally-started` — and, instead of stopping them, **seeds a session** for them with the default session duration (`--sessions.default-duration`). The regular expiration lifecycle then takes over: if the instance receives no traffic, it hibernates on its own when the seeded session expires.

This is the non-destructive counterpart to `auto-stop-externally-started`, for setups where workloads are deployed/started by external tooling and adopted into the scale-to-zero lifecycle afterwards (see #985 for the full discussion and @acouvreur's design approval). The two options are contradictory by nature, so enabling both is rejected by `Provider.IsValid()` at startup. The docs also point out that this flag pairs with `auto-stop-on-startup: false` (otherwise instances running at boot are stopped once at startup before the warm watch takes over).

## How

`pkg/sablier/autowarm.go` is a mirror of `autostop.go`:

- `WatchAndWarmExternallyStarted` — same structure as `WatchAndStopExternallyStarted`: event-driven detection (`InstanceEventStarted`) plus a periodic reconciliation ticker (`ExternallyStartedScanInterval`, 30s) as a safety net.
- `WarmAllUnregisteredInstances` — mirror of `StopAllUnregisteredInstances`: lists running instances and seeds the unregistered ones. Reuses the `isStartedByUs` guard (pending starts + session presence).
- `seedSession` — reuses the session-seeding logic from #980 by @louisdtt (`seedGroupSession`): skip if a session already exists (`store.ErrKeyNotFound` check, so a seeded session is never renewed in a loop), inspect the instance, only seed `ready` instances, then `sessions.Put` directly with the default duration (no `RequestSession`, since the instance is already running).

Invariants:
- Default `false` → behavior strictly unchanged.
- Only instances **without** a session are seeded → no renewal loop (`Get` does not refresh the TTL in either store backend).
- Only `ready`, labelled instances not started by Sablier itself.
- `auto-stop-externally-started` is untouched.

This converges with #980: same seeding semantics, but hooked on the externally-started detection path rather than group discovery, per the discussion in #985. Credit to @louisdtt for the seed logic (co-authored).

## Tests

- Unit tests (`pkg/sablier/autowarm_test.go`, mirror of `autostop_test.go`): seeding with the default duration, skip when a session already exists, skip instances started by Sablier (both the session-presence and the `pendingStarts` halves of `isStartedByUs` — the latter verified mutation-style: removing the guard fails the test), skip non-`ready` instances, no re-seed when a session appears between the guard check and the seed, store/inspect error paths, reconciliation ticker, event-stream-closure fallback.
- `go build ./...`, `go vet ./...`, `gofmt -l` clean, `golangci-lint run` → 0 issues, `go test ./...` green.
- Podman testcontainers integration: `DOCKER_HOST=<podman.sock> go test ./pkg/provider/podman/... ./pkg/sablier/...` green.

## End-to-end validation (podman)

Full lifecycle proof — instance started externally, then Sablier started with `--provider.auto-warm-externally-started --sessions.default-duration=2m`:

```text
[14:46:11] STEP 1: start whoami EXTERNALLY (labelled, no session)
daf50698d2991f3ff41f940f58cf20584e60c38fed240bde2ab97223073d65f9
[14:46:12] whoami status: whoami Up Less than a second
[14:46:12] STEP 2: start sablier with --provider.auto-warm-externally-started, default-duration=2m
[14:46:12] sablier pid=81653
[14:46:32] STEP 3 (t+20s): non-destructivity check — whoami must still be Up
[14:46:32] whoami status: whoami Up 20 seconds
[14:46:57] STEP 4 (t+45s): reconciliation tick (30s) must have auto-seeded a session
2:46PM INF sablier/autowarm.go:70 seeded session for externally started instance instance=whoami duration=2m0s reason="instance is enabled but not started by Sablier"
[14:46:57] whoami status: whoami Up 45 seconds
[14:46:57] STEP 5: no traffic sent; waiting for the 2m seeded session to expire...
[14:49:12] STEP 6 (t+180s): after expiry whoami must be stopped by sablier
[14:49:12] whoami status: whoami Exited (2) 28 seconds ago
2:48PM INF sablier/instance_expired.go:26 instance expired instance=whoami
[14:49:12] cleanup
[14:49:14] DONE
```

The instance is never killed on startup (unlike `auto-stop-externally-started`), gets its session seeded at the first reconciliation tick, and is stopped by the normal expiration lifecycle ~2 minutes later without any traffic.

## Docs

- `docs/configuration.md`: YAML section + CLI reference.
- New `examples/auto-warm-externally-started/` (mirror of `examples/auto-stop-externally-started/`).
