### PR TITLE
Add running-days, make sure to use annotations for kubernetes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,7 @@ Instance labels are applied directly to your containers or workloads. They contr
 | `sablier.group` | No | `"myapp"` | Assign the instance to one or more named groups (comma-separated, e.g. `"team-a,team-b"`). Defaults to `"default"` when `sablier.enable=true` and no group is set. |
 | `sablier.ready-after` | No | `"30s"` | Minimum duration to wait after the instance first reports ready before Sablier considers it truly ready. Accepts any Go duration string (`"500ms"`, `"1m30s"`, …). Useful for services that are started or pass their health check before they can actually serve traffic. |
 | `sablier.running-hours` | No | `"09:00-18:00"` | Daily keep-warm window in local time (`HH:MM-HH:MM`). Sablier starts the instance at window start and keeps it running until window end. Overnight windows like `"22:00-06:00"` are supported. |
+| `sablier.running-days` | No | `"Mon,Tue,Wed,Thu,Fri"` | Restrict the `sablier.running-hours` window to specific weekdays. Comma-separated list accepting full names (`Monday`) and abbreviations (`Mon`). Defaults to every day when unset. |
 | `sablier.idle.cpu` | No | `"0.1"` | CPU limit applied when the session expires (scale mode). Requires `sablier.idle.replicas >= 1`. |
 | `sablier.idle.memory` | No | `"128m"` | Memory limit applied when the session expires (scale mode). Requires `sablier.idle.replicas >= 1`. |
 | `sablier.idle.replicas` | No | `"1"` | Replica count when idle. Default `0` (stop the workload). Set to `1` or higher to keep the workload running and optionally throttle its resources. |
@@ -116,6 +117,34 @@ Format rules:
 - Use 24-hour format `HH:MM-HH:MM`.
 - If start is later than end (for example `22:00-06:00`), the window spans midnight.
 - If the label cannot be parsed, Sablier ignores it.
+
+### `sablier.running-days`
+
+Use `sablier.running-days` together with `sablier.running-hours` to restrict the keep-warm window to specific weekdays. This is useful to only keep an instance warm during, for example, weekdays.
+
+Behavior:
+
+- When set, the `sablier.running-hours` window only applies on the listed days.
+- When absent, the window applies every day.
+- For overnight windows (e.g. `22:00-06:00`), the day is evaluated against the day the window **starts**. For example, a `Fri` window with `22:00-06:00` keeps the instance warm from Friday 22:00 through Saturday 06:00.
+
+```yaml
+services:
+  myapp:
+    image: myapp:latest
+    labels:
+      - "sablier.enable=true"
+      - "sablier.group=myapp"
+      - "sablier.running-hours=09:00-18:00"
+      - "sablier.running-days=Mon,Tue,Wed,Thu,Fri"
+```
+
+Format rules:
+
+- Comma-separated list of days.
+- Accepts full names (`Monday`) and common abbreviations (`Mon`).
+- Matching is case-insensitive; surrounding whitespace is ignored.
+- If the label cannot be parsed, Sablier ignores it (the window then applies every day).
 
 ### Timezone (`TZ`)
 

--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -119,7 +119,7 @@ Sablier checks for the deployment replicas. As soon as the current replicas matc
 
 ## Configure with labels or annotations
 
-On Kubernetes, every `sablier.*` key can be set either as a **label** or as an **annotation**. This applies to Deployments, StatefulSets, CloudNativePG Clusters and OT-CONTAINER-KIT Redis instances.
+On Kubernetes, `sablier.*` keys can be set either as a **label** or as an **annotation**, with one exception: `sablier.enable` must always be a label (see the note below). This applies to Deployments, StatefulSets, CloudNativePG Clusters and OT-CONTAINER-KIT Redis instances.
 
 Annotations are useful because Kubernetes **label values are restricted** (max 63 characters, only `[A-Za-z0-9._-]`, no commas or colons). Some Sablier values cannot be expressed as labels and must use annotations, for example:
 

--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -117,6 +117,36 @@ Sablier checks for the deployment replicas. As soon as the current replicas matc
 
 ?> Kubernetes uses the Pod healthcheck to check if the Pod is up and running. So the provider has a native healthcheck support.
 
+## Configure with labels or annotations
+
+On Kubernetes, every `sablier.*` key can be set either as a **label** or as an **annotation**. This applies to Deployments, StatefulSets, CloudNativePG Clusters and OT-CONTAINER-KIT Redis instances.
+
+Annotations are useful because Kubernetes **label values are restricted** (max 63 characters, only `[A-Za-z0-9._-]`, no commas or colons). Some Sablier values cannot be expressed as labels and must use annotations, for example:
+
+- `sablier.group` with multiple comma-separated groups (e.g. `team-a,team-b`)
+- `sablier.running-hours` (e.g. `09:00-18:00`) — the colon is invalid in a label value
+- `sablier.running-days` (e.g. `Mon,Tue,Wed,Thu,Fri`)
+
+When the same key is present as both a label and an annotation, the **annotation takes precedence**.
+
+!> `sablier.enable` must be set as a **label**. Workload discovery relies on a server-side label selector, which cannot match annotations. All other keys work as labels or annotations.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whoami
+  labels:
+    app: whoami
+    sablier.enable: "true"       # must be a label
+  annotations:
+    sablier.group: "team-a,team-b"          # comma is invalid as a label value
+    sablier.running-hours: "09:00-18:00"    # colon is invalid as a label value
+    sablier.running-days: "Mon,Tue,Wed,Thu,Fri"
+spec:
+  # ...existing spec...
+```
+
 ## Register CloudNativePG Clusters
 
 Sablier can also start and stop [CloudNativePG](https://cloudnative-pg.io/) `Cluster` resources. Instead of scaling a replica count, Sablier toggles CloudNativePG's [declarative hibernation](https://cloudnative-pg.io/documentation/current/declarative_hibernation/) annotation:

--- a/examples/running-hours/README.md
+++ b/examples/running-hours/README.md
@@ -12,6 +12,9 @@ When the current time is outside the window:
 
 - The instance behaves normally and can expire according to session settings.
 
+The optional `sablier.running-days` label further restricts the window to
+specific weekdays (this example uses `Mon,Tue,Wed,Thu,Fri`).
+
 ## Services
 
 | Service | Role |
@@ -26,6 +29,7 @@ labels:
   - "sablier.enable=true"
   - "sablier.group=office-app"
   - "sablier.running-hours=09:00-18:00"
+  - "sablier.running-days=Mon,Tue,Wed,Thu,Fri"
 ```
 
 ## Prerequisites
@@ -42,9 +46,12 @@ This compose stack supports both values as environment variables:
 ```bash
 export TZ=Europe/Paris
 export RUNNING_HOURS=09:00-18:00
+export RUNNING_DAYS=Mon,Tue,Wed,Thu,Fri
 ```
 
-You can keep defaults by leaving them unset (`TZ=UTC`, `RUNNING_HOURS=09:00-18:00`).
+You can keep defaults by leaving them unset (`TZ=UTC`, `RUNNING_HOURS=09:00-18:00`, `RUNNING_DAYS=Mon,Tue,Wed,Thu,Fri`).
+
+`RUNNING_DAYS` accepts a comma-separated list of days (full names like `Monday` or abbreviations like `Mon`).
 
 ## Walkthrough
 

--- a/examples/running-hours/compose.yml
+++ b/examples/running-hours/compose.yml
@@ -23,5 +23,6 @@ services:
       - "sablier.enable=true"
       - "sablier.group=office-app"
       - "sablier.running-hours=${RUNNING_HOURS:-09:00-18:00}"
+      - "sablier.running-days=${RUNNING_DAYS:-Mon,Tue,Wed,Thu,Fri}"
     ports:
       - "8080:80"

--- a/pkg/provider/kubernetes/cnpgcluster_events.go
+++ b/pkg/provider/kubernetes/cnpgcluster_events.go
@@ -126,7 +126,7 @@ func (p *Provider) watchClusters(ctx context.Context, instance chan<- sablier.In
 					Labels:    labels,
 				},
 			}
-			sablier.PopulateEnabledAndGroup(&info, labels)
+			sablier.PopulateEnabledAndGroup(&info, sablierConfig(labels, u.GetAnnotations()))
 			if wantRemoved {
 				instance <- sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: info}
 			}

--- a/pkg/provider/kubernetes/cnpgcluster_inspect.go
+++ b/pkg/provider/kubernetes/cnpgcluster_inspect.go
@@ -61,7 +61,7 @@ func (p *Provider) ClusterInspect(ctx context.Context, config ParsedName) (sabli
 	if labels == nil {
 		labels = map[string]string{}
 	}
-	sablier.PopulateEnabledAndGroup(&info, labels)
+	sablier.PopulateEnabledAndGroup(&info, sablierConfig(labels, u.GetAnnotations()))
 	info.Kubernetes = &sablier.KubernetesWorkloadInfo{
 		Namespace: config.Namespace,
 		Kind:      KindCNPGCluster,

--- a/pkg/provider/kubernetes/cnpgcluster_list.go
+++ b/pkg/provider/kubernetes/cnpgcluster_list.go
@@ -48,11 +48,11 @@ func (p *Provider) ClusterList(ctx context.Context) ([]sablier.InstanceConfigura
 }
 
 func (p *Provider) clusterToInstance(u *unstructured.Unstructured) sablier.InstanceConfiguration {
-	labels := u.GetLabels()
-	enabled := labels["sablier.enable"]
+	config := sablierConfig(u.GetLabels(), u.GetAnnotations())
+	enabled := config["sablier.enable"]
 	var groups []string
 	if enabled == "true" {
-		groups = sablier.ParseGroups(labels["sablier.group"])
+		groups = sablier.ParseGroups(config["sablier.group"])
 	}
 
 	parsed := ClusterName(u.GetNamespace(), u.GetName(), ParseOptions{Delimiter: p.delimiter})
@@ -74,7 +74,8 @@ func (p *Provider) ClusterGroups(ctx context.Context) (map[string][]string, erro
 	for i := range items {
 		u := &items[i]
 		parsed := ClusterName(u.GetNamespace(), u.GetName(), ParseOptions{Delimiter: p.delimiter})
-		for _, groupName := range sablier.ParseGroups(u.GetLabels()["sablier.group"]) {
+		config := sablierConfig(u.GetLabels(), u.GetAnnotations())
+		for _, groupName := range sablier.ParseGroups(config["sablier.group"]) {
 			groups[groupName] = append(groups[groupName], parsed.Original)
 		}
 	}

--- a/pkg/provider/kubernetes/deployment_events.go
+++ b/pkg/provider/kubernetes/deployment_events.go
@@ -83,7 +83,7 @@ func (p *Provider) watchDeployments(ctx context.Context, instance chan<- sablier
 					Labels:    d.Labels,
 				},
 			}
-			sablier.PopulateEnabledAndGroup(&info, d.Labels)
+			sablier.PopulateEnabledAndGroup(&info, sablierConfig(d.Labels, d.Annotations))
 			if wantRemoved {
 				instance <- sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: info}
 			}

--- a/pkg/provider/kubernetes/deployment_inspect.go
+++ b/pkg/provider/kubernetes/deployment_inspect.go
@@ -41,7 +41,7 @@ func (p *Provider) DeploymentInspect(ctx context.Context, config ParsedName) (sa
 		}
 	}
 
-	sablier.PopulateEnabledAndGroup(&info, d.Labels)
+	sablier.PopulateEnabledAndGroup(&info, sablierConfig(d.Labels, d.Annotations))
 
 	var image string
 	if len(d.Spec.Template.Spec.Containers) > 0 {

--- a/pkg/provider/kubernetes/deployment_inspect_test.go
+++ b/pkg/provider/kubernetes/deployment_inspect_test.go
@@ -154,6 +154,86 @@ func TestKubernetesProvider_DeploymentInspect(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "deployment with sablier config via annotations",
+			args: args{
+				do: func(dind *kindContainer) (string, error) {
+					// sablier.group with a comma-separated value is invalid as a
+					// Kubernetes label, so it can only be expressed as an annotation.
+					d, err := dind.CreateMimicDeployment(ctx, MimicOptions{
+						Cmd: []string{"/mimic"},
+						Labels: map[string]string{
+							"sablier.enable": "true",
+						},
+						Annotations: map[string]string{
+							"sablier.group":          "group-a,group-b",
+							"sablier.ready-on-start": "true",
+						},
+					})
+					if err != nil {
+						return "", err
+					}
+
+					if err = WaitForDeploymentReady(ctx, dind.client, "default", d.Name); err != nil {
+						return "", fmt.Errorf("error waiting for deployment: %w", err)
+					}
+
+					return kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original, nil
+				},
+			},
+			want: sablier.InstanceInfo{
+				CurrentReplicas: 1,
+				DesiredReplicas: 1,
+				Status:          sablier.InstanceStatusReady,
+				Enabled:         "true",
+				Groups:          []string{"group-a", "group-b"},
+				ReadyOnStart:    true,
+			},
+			// Kubernetes.Labels reflects the raw workload labels only, not the
+			// merged annotation config.
+			wantLabels: map[string]string{
+				"sablier.enable": "true",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "deployment annotations override labels",
+			args: args{
+				do: func(dind *kindContainer) (string, error) {
+					d, err := dind.CreateMimicDeployment(ctx, MimicOptions{
+						Cmd: []string{"/mimic"},
+						Labels: map[string]string{
+							"sablier.enable": "true",
+							"sablier.group":  "from-label",
+						},
+						Annotations: map[string]string{
+							"sablier.group": "from-annotation",
+						},
+					})
+					if err != nil {
+						return "", err
+					}
+
+					if err = WaitForDeploymentReady(ctx, dind.client, "default", d.Name); err != nil {
+						return "", fmt.Errorf("error waiting for deployment: %w", err)
+					}
+
+					return kubernetes.DeploymentName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original, nil
+				},
+			},
+			want: sablier.InstanceInfo{
+				CurrentReplicas: 1,
+				DesiredReplicas: 1,
+				Status:          sablier.InstanceStatusReady,
+				Enabled:         "true",
+				Groups:          []string{"from-annotation"},
+			},
+			wantLabels: map[string]string{
+				"sablier.enable": "true",
+				"sablier.group":  "from-label",
+			},
+			wantErr: nil,
+		},
 	}
 	c := sharedKinD
 	for _, tt := range tests {

--- a/pkg/provider/kubernetes/deployment_list.go
+++ b/pkg/provider/kubernetes/deployment_list.go
@@ -32,10 +32,11 @@ func (p *Provider) DeploymentList(ctx context.Context) ([]sablier.InstanceConfig
 }
 
 func (p *Provider) deploymentToInstance(d *v1.Deployment) sablier.InstanceConfiguration {
-	enabled := d.Labels["sablier.enable"]
+	config := sablierConfig(d.Labels, d.Annotations)
+	enabled := config["sablier.enable"]
 	var groups []string
 	if enabled == "true" {
-		groups = sablier.ParseGroups(d.Labels["sablier.group"])
+		groups = sablier.ParseGroups(config["sablier.group"])
 	}
 
 	parsed := DeploymentName(d, ParseOptions{Delimiter: p.delimiter})
@@ -64,7 +65,8 @@ func (p *Provider) DeploymentGroups(ctx context.Context) (map[string][]string, e
 	groups := make(map[string][]string)
 	for _, deployment := range deployments.Items {
 		parsed := DeploymentName(&deployment, ParseOptions{Delimiter: p.delimiter})
-		for _, groupName := range sablier.ParseGroups(deployment.Labels["sablier.group"]) {
+		config := sablierConfig(deployment.Labels, deployment.Annotations)
+		for _, groupName := range sablier.ParseGroups(config["sablier.group"]) {
 			groups[groupName] = append(groups[groupName], parsed.Original)
 		}
 	}

--- a/pkg/provider/kubernetes/instance_list_test.go
+++ b/pkg/provider/kubernetes/instance_list_test.go
@@ -174,3 +174,65 @@ func TestKubernetesProvider_InstanceGroups(t *testing.T) {
 	}
 	assert.DeepEqual(t, got, want)
 }
+
+// TestKubernetesProvider_InstanceGroups_Annotations verifies the real-world
+// motivation for annotation support: workloads are discovered through the
+// server-side "sablier.enable=true" label selector, while "sablier.group" —
+// which here holds a comma-separated value that is invalid as a Kubernetes
+// label — is read from annotations. It also asserts that an annotation takes
+// precedence over a label for the same key.
+func TestKubernetesProvider_InstanceGroups_Annotations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx := t.Context()
+	kind := sharedKinD
+	p, err := kubernetes.New(ctx, kind.client, kind.dynamic, slogt.New(t), config.NewProviderConfig().Kubernetes)
+	assert.NilError(t, err)
+
+	// enable is a label (required for discovery), group is a comma-separated
+	// annotation — impossible to express as a single label value.
+	d1, err := kind.CreateMimicDeployment(ctx, MimicOptions{
+		Labels: map[string]string{
+			"sablier.enable": "true",
+		},
+		Annotations: map[string]string{
+			"sablier.group": "annotated-a,annotated-b",
+		},
+	})
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = kind.client.AppsV1().Deployments(d1.Namespace).Delete(context.Background(), d1.Name, metav1.DeleteOptions{})
+	})
+
+	// The annotation value must win over the label value for the same key.
+	ss1, err := kind.CreateMimicStatefulSet(ctx, MimicOptions{
+		Labels: map[string]string{
+			"sablier.enable": "true",
+			"sablier.group":  "from-label",
+		},
+		Annotations: map[string]string{
+			"sablier.group": "from-annotation",
+		},
+	})
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = kind.client.AppsV1().StatefulSets(ss1.Namespace).Delete(context.Background(), ss1.Name, metav1.DeleteOptions{})
+	})
+
+	got, err := p.InstanceGroups(ctx)
+	assert.NilError(t, err)
+
+	dName := kubernetes.DeploymentName(d1, kubernetes.ParseOptions{Delimiter: "_"}).Original
+	ssName := kubernetes.StatefulSetName(ss1, kubernetes.ParseOptions{Delimiter: "_"}).Original
+
+	// InstanceGroups returns a cluster-wide view, so assert only on the groups
+	// uniquely created by this test rather than the entire map.
+	assert.DeepEqual(t, got["annotated-a"], []string{dName})
+	assert.DeepEqual(t, got["annotated-b"], []string{dName})
+	assert.DeepEqual(t, got["from-annotation"], []string{ssName})
+	// The label value must not survive once overridden by the annotation.
+	_, hasLabelGroup := got["from-label"]
+	assert.Assert(t, !hasLabelGroup, "annotation should override label; group 'from-label' must not appear")
+}

--- a/pkg/provider/kubernetes/resource_scale.go
+++ b/pkg/provider/kubernetes/resource_scale.go
@@ -114,7 +114,10 @@ func (p *Provider) scaleStatefulSetResources(ctx context.Context, config ParsedN
 	return nil
 }
 
-// getWorkloadLabels retrieves the labels of a deployment or statefulset.
+// getWorkloadLabels retrieves the Sablier configuration of a deployment or
+// statefulset, merging labels with "sablier.*" annotations (annotations take
+// precedence). This lets scale-mode values that are invalid as label values
+// (e.g. comma-separated blkio device lists) be provided via annotations.
 func (p *Provider) getWorkloadLabels(ctx context.Context, config ParsedName) (map[string]string, error) {
 	switch config.Kind {
 	case "deployment":
@@ -122,19 +125,13 @@ func (p *Provider) getWorkloadLabels(ctx context.Context, config ParsedName) (ma
 		if err != nil {
 			return nil, err
 		}
-		if d.Labels == nil {
-			return map[string]string{}, nil
-		}
-		return d.Labels, nil
+		return sablierConfig(d.Labels, d.Annotations), nil
 	case "statefulset":
 		ss, err := p.Client.AppsV1().StatefulSets(config.Namespace).Get(ctx, config.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
-		if ss.Labels == nil {
-			return map[string]string{}, nil
-		}
-		return ss.Labels, nil
+		return sablierConfig(ss.Labels, ss.Annotations), nil
 	default:
 		return nil, fmt.Errorf("unsupported kind %q", config.Kind)
 	}

--- a/pkg/provider/kubernetes/sablier_config.go
+++ b/pkg/provider/kubernetes/sablier_config.go
@@ -1,0 +1,38 @@
+package kubernetes
+
+import "strings"
+
+// sablierConfigPrefix is the common prefix for all Sablier configuration keys.
+const sablierConfigPrefix = "sablier."
+
+// sablierConfig merges a workload's labels and annotations into a single
+// configuration map from which Sablier reads its "sablier.*" keys.
+//
+// On Kubernetes, label values are restricted (max 63 chars, only
+// [A-Za-z0-9._-], no commas or colons), which makes several Sablier values
+// impossible to express as labels — for example a comma-separated
+// "sablier.group" / "sablier.running-days", or the colon-based
+// "sablier.running-hours=09:00-18:00". Annotations have no such restriction, so
+// they are supported as an alternative source for every Sablier key.
+//
+// Only keys carrying the "sablier." prefix are copied from annotations, so
+// unrelated (and potentially large) annotations such as
+// kubectl.kubernetes.io/last-applied-configuration are never included.
+// Annotations take precedence over labels when the same key is present in both.
+//
+// Note: "sablier.enable" should still be set as a label because workload
+// discovery relies on a server-side label selector; annotations are not
+// selectable. Setting it only as an annotation keeps it out of discovery.
+func sablierConfig(labels, annotations map[string]string) map[string]string {
+	merged := make(map[string]string, len(labels)+len(annotations))
+	for k, v := range labels {
+		merged[k] = v
+	}
+	for k, v := range annotations {
+		if strings.HasPrefix(k, sablierConfigPrefix) {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+

--- a/pkg/provider/kubernetes/sablier_config_test.go
+++ b/pkg/provider/kubernetes/sablier_config_test.go
@@ -1,0 +1,58 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSablierConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		annotations map[string]string
+		want        map[string]string
+	}{
+		{
+			name:   "labels only",
+			labels: map[string]string{"sablier.enable": "true", "sablier.group": "myapp"},
+			want:   map[string]string{"sablier.enable": "true", "sablier.group": "myapp"},
+		},
+		{
+			name:        "annotations add sablier keys invalid as labels",
+			labels:      map[string]string{"sablier.enable": "true"},
+			annotations: map[string]string{"sablier.running-days": "Mon,Tue,Wed", "sablier.running-hours": "09:00-18:00"},
+			want: map[string]string{
+				"sablier.enable":        "true",
+				"sablier.running-days":  "Mon,Tue,Wed",
+				"sablier.running-hours": "09:00-18:00",
+			},
+		},
+		{
+			name:        "annotations override labels",
+			labels:      map[string]string{"sablier.enable": "true", "sablier.group": "from-label"},
+			annotations: map[string]string{"sablier.group": "from-annotation"},
+			want:        map[string]string{"sablier.enable": "true", "sablier.group": "from-annotation"},
+		},
+		{
+			name:        "non sablier annotations are ignored",
+			labels:      map[string]string{"sablier.enable": "true"},
+			annotations: map[string]string{"kubectl.kubernetes.io/last-applied-configuration": "{...}", "app": "demo"},
+			want:        map[string]string{"sablier.enable": "true"},
+		},
+		{
+			name:        "nil maps",
+			labels:      nil,
+			annotations: nil,
+			want:        map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sablierConfig(tt.labels, tt.annotations)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}
+

--- a/pkg/provider/kubernetes/statefulset_events.go
+++ b/pkg/provider/kubernetes/statefulset_events.go
@@ -84,7 +84,7 @@ func (p *Provider) watchStatefulSets(ctx context.Context, instance chan<- sablie
 					Labels:    ss.Labels,
 				},
 			}
-			sablier.PopulateEnabledAndGroup(&info, ss.Labels)
+			sablier.PopulateEnabledAndGroup(&info, sablierConfig(ss.Labels, ss.Annotations))
 			if wantRemoved {
 				instance <- sablier.InstanceEvent{Type: provider.InstanceEventRemoved, Info: info}
 			}

--- a/pkg/provider/kubernetes/statefulset_inspect.go
+++ b/pkg/provider/kubernetes/statefulset_inspect.go
@@ -37,7 +37,7 @@ func (p *Provider) StatefulSetInspect(ctx context.Context, config ParsedName) (s
 		}
 	}
 
-	sablier.PopulateEnabledAndGroup(&info, ss.Labels)
+	sablier.PopulateEnabledAndGroup(&info, sablierConfig(ss.Labels, ss.Annotations))
 
 	var image string
 	if len(ss.Spec.Template.Spec.Containers) > 0 {

--- a/pkg/provider/kubernetes/statefulset_inspect_test.go
+++ b/pkg/provider/kubernetes/statefulset_inspect_test.go
@@ -151,6 +151,46 @@ func TestKubernetesProvider_InspectStatefulSet(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "statefulset with sablier config via annotations",
+			args: args{
+				do: func(dind *kindContainer) (string, error) {
+					// sablier.group with a comma-separated value is invalid as a
+					// Kubernetes label, so it can only be expressed as an annotation.
+					d, err := dind.CreateMimicStatefulSet(ctx, MimicOptions{
+						Cmd: []string{"/mimic"},
+						Labels: map[string]string{
+							"sablier.enable": "true",
+						},
+						Annotations: map[string]string{
+							"sablier.group": "group-a,group-b",
+						},
+					})
+					if err != nil {
+						return "", err
+					}
+
+					if err = WaitForStatefulSetReady(ctx, dind.client, "default", d.Name); err != nil {
+						return "", fmt.Errorf("error waiting for statefulset: %w", err)
+					}
+
+					return kubernetes.StatefulSetName(d, kubernetes.ParseOptions{Delimiter: "_"}).Original, nil
+				},
+			},
+			want: sablier.InstanceInfo{
+				CurrentReplicas: 1,
+				DesiredReplicas: 1,
+				Status:          sablier.InstanceStatusReady,
+				Enabled:         "true",
+				Groups:          []string{"group-a", "group-b"},
+			},
+			// Kubernetes.Labels reflects the raw workload labels only, not the
+			// merged annotation config.
+			wantLabels: map[string]string{
+				"sablier.enable": "true",
+			},
+			wantErr: nil,
+		},
 	}
 	c := sharedKinD
 	for _, tt := range tests {

--- a/pkg/provider/kubernetes/statefulset_list.go
+++ b/pkg/provider/kubernetes/statefulset_list.go
@@ -32,10 +32,11 @@ func (p *Provider) StatefulSetList(ctx context.Context) ([]sablier.InstanceConfi
 }
 
 func (p *Provider) statefulSetToInstance(ss *v1.StatefulSet) sablier.InstanceConfiguration {
-	enabled := ss.Labels["sablier.enable"]
+	config := sablierConfig(ss.Labels, ss.Annotations)
+	enabled := config["sablier.enable"]
 	var groups []string
 	if enabled == "true" {
-		groups = sablier.ParseGroups(ss.Labels["sablier.group"])
+		groups = sablier.ParseGroups(config["sablier.group"])
 	}
 
 	parsed := StatefulSetName(ss, ParseOptions{Delimiter: p.delimiter})
@@ -63,7 +64,8 @@ func (p *Provider) StatefulSetGroups(ctx context.Context) (map[string][]string, 
 	groups := make(map[string][]string)
 	for _, ss := range statefulSets.Items {
 		parsed := StatefulSetName(&ss, ParseOptions{Delimiter: p.delimiter})
-		for _, groupName := range sablier.ParseGroups(ss.Labels["sablier.group"]) {
+		config := sablierConfig(ss.Labels, ss.Annotations)
+		for _, groupName := range sablier.ParseGroups(config["sablier.group"]) {
 			groups[groupName] = append(groups[groupName], parsed.Original)
 		}
 	}

--- a/pkg/provider/kubernetes/testcontainers_test.go
+++ b/pkg/provider/kubernetes/testcontainers_test.go
@@ -40,6 +40,7 @@ type MimicOptions struct {
 	Cmd         []string
 	Healthcheck *corev1.Probe
 	Labels      map[string]string
+	Annotations map[string]string
 }
 
 func (d *kindContainer) CreateMimicDeployment(ctx context.Context, opts MimicOptions) (*v1.Deployment, error) {
@@ -54,8 +55,9 @@ func (d *kindContainer) CreateMimicDeployment(ctx context.Context, opts MimicOpt
 	replicas := int32(1)
 	return d.client.AppsV1().Deployments("default").Create(ctx, &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: opts.Labels,
+			Name:        name,
+			Labels:      opts.Labels,
+			Annotations: opts.Annotations,
 		},
 		Spec: v1.DeploymentSpec{
 			Replicas: &replicas,
@@ -96,8 +98,9 @@ func (d *kindContainer) CreateMimicStatefulSet(ctx context.Context, opts MimicOp
 	replicas := int32(1)
 	return d.client.AppsV1().StatefulSets("default").Create(ctx, &v1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: opts.Labels,
+			Name:        name,
+			Labels:      opts.Labels,
+			Annotations: opts.Annotations,
 		},
 		Spec: v1.StatefulSetSpec{
 			Replicas: &replicas,

--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -52,6 +52,11 @@ type InstanceInfo struct {
 	// the sablier.running-hours label (format: HH:MM-HH:MM).
 	RunningHours string `json:"runningHours,omitempty"`
 
+	// RunningDays restricts the RunningHours window to specific weekdays,
+	// parsed from the sablier.running-days label (e.g. "Mon,Tue,Wed,Thu,Fri").
+	// Empty means the window applies every day.
+	RunningDays string `json:"runningDays,omitempty"`
+
 	// ScaleConfig configures resource-based scale mode for this instance.
 	// When present, Sablier throttles CPU/memory instead of stopping the container.
 	ScaleConfig *ScaleConfig `json:"scaleConfig,omitempty"`
@@ -339,6 +344,17 @@ func PopulateEnabledAndGroup(info *InstanceInfo, labels map[string]string) {
 			info.RunningHours = v
 		} else {
 			slog.Warn("invalid sablier.running-hours label value, ignoring",
+				slog.String("instance", info.Name),
+				slog.String("value", v),
+				slog.Any("error", err),
+			)
+		}
+	}
+	if v := labels["sablier.running-days"]; v != "" {
+		if _, err := ParseRunningDays(v); err == nil {
+			info.RunningDays = v
+		} else {
+			slog.Warn("invalid sablier.running-days label value, ignoring",
 				slog.String("instance", info.Name),
 				slog.String("value", v),
 				slog.Any("error", err),

--- a/pkg/sablier/instance_request.go
+++ b/pkg/sablier/instance_request.go
@@ -240,7 +240,7 @@ func (s *Sablier) instanceRequest(ctx context.Context, name string, duration tim
 	if state.RunningHours != "" {
 		remaining, inWindow, runningHoursErr := runningHoursRemaining(state.RunningHours, state.RunningDays, time.Now())
 		if runningHoursErr != nil {
-			s.l.WarnContext(ctx, "invalid running-hours value in state, ignoring", slog.String("instance", name), slog.String("value", state.RunningHours), slog.Any("error", runningHoursErr))
+			s.l.WarnContext(ctx, "invalid running-hours or running-days value in state, ignoring", slog.String("instance", name), slog.String("running-hours", state.RunningHours), slog.String("running-days", state.RunningDays), slog.Any("error", runningHoursErr))
 		} else if inWindow && remaining > effectiveDuration {
 			effectiveDuration = remaining
 			s.l.DebugContext(ctx, "running-hours window active, extending expiration", slog.String("instance", name), slog.Duration("expiration", effectiveDuration), slog.Duration("window_remaining", remaining))

--- a/pkg/sablier/instance_request.go
+++ b/pkg/sablier/instance_request.go
@@ -238,7 +238,7 @@ func (s *Sablier) instanceRequest(ctx context.Context, name string, duration tim
 
 	effectiveDuration := duration
 	if state.RunningHours != "" {
-		remaining, inWindow, runningHoursErr := runningHoursRemaining(state.RunningHours, time.Now())
+		remaining, inWindow, runningHoursErr := runningHoursRemaining(state.RunningHours, state.RunningDays, time.Now())
 		if runningHoursErr != nil {
 			s.l.WarnContext(ctx, "invalid running-hours value in state, ignoring", slog.String("instance", name), slog.String("value", state.RunningHours), slog.Any("error", runningHoursErr))
 		} else if inWindow && remaining > effectiveDuration {

--- a/pkg/sablier/instance_request_running_hours_test.go
+++ b/pkg/sablier/instance_request_running_hours_test.go
@@ -3,6 +3,7 @@ package sablier_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -61,3 +62,36 @@ func TestInstanceRequest_DoesNotExtendExpirationOutsideRunningHours(t *testing.T
 	assert.NilError(t, err)
 	assert.Equal(t, info.Name, "nginx")
 }
+
+func TestInstanceRequest_DoesNotExtendExpirationOnExcludedDay(t *testing.T) {
+	manager, sessions, _ := setupSablier(t)
+	ctx := t.Context()
+
+	now := time.Now()
+	start := now.Add(-time.Minute)
+	end := now.Add(3 * time.Minute)
+	spec := fmt.Sprintf("%02d:%02d-%02d:%02d", start.Hour(), start.Minute(), end.Hour(), end.Minute())
+
+	// Restrict the window to every weekday except today so the window is inactive.
+	var days []string
+	for d := time.Sunday; d <= time.Saturday; d++ {
+		if d != start.Weekday() {
+			days = append(days, d.String())
+		}
+	}
+
+	state := sablier.InstanceInfo{
+		Name:         "nginx",
+		Status:       sablier.InstanceStatusReady,
+		RunningHours: spec,
+		RunningDays:  strings.Join(days, ","),
+	}
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(state, nil)
+	sessions.EXPECT().Put(ctx, state, 20*time.Second).Return(nil)
+
+	info, err := manager.InstanceRequest(ctx, "nginx", 20*time.Second)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Name, "nginx")
+}
+

--- a/pkg/sablier/running_hours.go
+++ b/pkg/sablier/running_hours.go
@@ -83,15 +83,68 @@ func (r RunningHours) WindowAt(now time.Time) (start time.Time, end time.Time, i
 	return start, end, !now.Before(start) && now.Before(end)
 }
 
-func runningHoursRemaining(spec string, now time.Time) (time.Duration, bool, error) {
-	rh, err := ParseRunningHours(spec)
+func runningHoursRemaining(hours, days string, now time.Time) (time.Duration, bool, error) {
+	rh, err := ParseRunningHours(hours)
 	if err != nil {
 		return 0, false, err
 	}
-	_, end, in := rh.WindowAt(now)
+	start, end, in := rh.WindowAt(now)
 	if !in {
 		return 0, false, nil
+	}
+	if days != "" {
+		rd, err := ParseRunningDays(days)
+		if err != nil {
+			return 0, false, err
+		}
+		// Evaluate the day against the window's start day so overnight windows
+		// (e.g. Fri 22:00-06:00) are attributed to the day they began.
+		if !rd.Contains(start.Weekday()) {
+			return 0, false, nil
+		}
 	}
 	remaining := max(end.Sub(now), 0)
 	return remaining, true, nil
 }
+
+// RunningDays is the set of weekdays on which a running-hours window applies.
+type RunningDays map[time.Weekday]bool
+
+var weekdayNames = map[string]time.Weekday{
+	"sun": time.Sunday, "sunday": time.Sunday,
+	"mon": time.Monday, "monday": time.Monday,
+	"tue": time.Tuesday, "tuesday": time.Tuesday,
+	"wed": time.Wednesday, "wednesday": time.Wednesday,
+	"thu": time.Thursday, "thursday": time.Thursday,
+	"fri": time.Friday, "friday": time.Friday,
+	"sat": time.Saturday, "saturday": time.Saturday,
+}
+
+// ParseRunningDays parses a comma-separated list of days into a set.
+//
+// It accepts full names ("Monday") and common abbreviations ("Mon"). Matching
+// is case-insensitive and whitespace around entries is ignored.
+func ParseRunningDays(v string) (RunningDays, error) {
+	days := make(RunningDays)
+	for _, p := range strings.Split(v, ",") {
+		token := strings.ToLower(strings.TrimSpace(p))
+		if token == "" {
+			continue
+		}
+		wd, ok := weekdayNames[token]
+		if !ok {
+			return nil, fmt.Errorf("invalid running-days %q: unknown day %q", v, strings.TrimSpace(p))
+		}
+		days[wd] = true
+	}
+	if len(days) == 0 {
+		return nil, fmt.Errorf("invalid running-days %q: no days specified", v)
+	}
+	return days, nil
+}
+
+// Contains reports whether the given weekday is part of the set.
+func (d RunningDays) Contains(day time.Weekday) bool {
+	return d[day]
+}
+

--- a/pkg/sablier/running_hours_test.go
+++ b/pkg/sablier/running_hours_test.go
@@ -59,3 +59,44 @@ func TestRunningHoursWindowAt(t *testing.T) {
 	assert.Equal(t, overnightEnd.Day(), 6)
 	assert.Equal(t, overnightEnd.Hour(), 6)
 }
+
+func TestParseRunningDays(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  []time.Weekday
+		err   bool
+	}{
+		{name: "abbreviations", value: "Mon,Tue,Wed,Thu,Fri", want: []time.Weekday{time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday}},
+		{name: "full names", value: "Saturday, Sunday", want: []time.Weekday{time.Saturday, time.Sunday}},
+		{name: "case insensitive", value: "mon,SUN", want: []time.Weekday{time.Monday, time.Sunday}},
+		{name: "unknown day", value: "Mon,Funday", err: true},
+		{name: "empty", value: "", err: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			days, err := sablier.ParseRunningDays(tt.value)
+			if tt.err {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			for _, d := range tt.want {
+				assert.Assert(t, days.Contains(d), "expected %s to be included", d)
+			}
+			// Days not in want must not be present.
+			for d := time.Sunday; d <= time.Saturday; d++ {
+				expected := false
+				for _, w := range tt.want {
+					if w == d {
+						expected = true
+						break
+					}
+				}
+				assert.Equal(t, days.Contains(d), expected)
+			}
+		})
+	}
+}
+

--- a/pkg/sablier/running_hours_watch.go
+++ b/pkg/sablier/running_hours_watch.go
@@ -52,7 +52,7 @@ func (s *Sablier) reconcileRunningHours(ctx context.Context) {
 
 		remaining, inWindow, err := runningHoursRemaining(info.RunningHours, info.RunningDays, now)
 		if err != nil {
-			s.l.WarnContext(ctx, "invalid running-hours label, skipping instance", slog.String("instance", info.Name), slog.String("value", info.RunningHours), slog.Any("error", err))
+			s.l.WarnContext(ctx, "invalid running-hours or running-days value, skipping instance", slog.String("instance", info.Name), slog.String("running-hours", info.RunningHours), slog.String("running-days", info.RunningDays), slog.Any("error", err))
 			continue
 		}
 		if !inWindow || remaining <= 0 {

--- a/pkg/sablier/running_hours_watch.go
+++ b/pkg/sablier/running_hours_watch.go
@@ -50,7 +50,7 @@ func (s *Sablier) reconcileRunningHours(ctx context.Context) {
 			continue
 		}
 
-		remaining, inWindow, err := runningHoursRemaining(info.RunningHours, now)
+		remaining, inWindow, err := runningHoursRemaining(info.RunningHours, info.RunningDays, now)
 		if err != nil {
 			s.l.WarnContext(ctx, "invalid running-hours label, skipping instance", slog.String("instance", info.Name), slog.String("value", info.RunningHours), slog.Any("error", err))
 			continue


### PR DESCRIPTION
Add running-days label/annotation support to only run workloads on certain days of the week. Add annotation support to the kubernetes provider, since labels in Kubernetes don't support chars like , or :.