### PR TITLE
fix(tinykv): never delete an entry on expiry without firing onExpire

### DIFF
--- a/pkg/tinykv/expire_notify_test.go
+++ b/pkg/tinykv/expire_notify_test.go
@@ -18,6 +18,11 @@ func TestExpireFuncNotifiesEveryDeletedEntry(t *testing.T) {
 	for trial := 0; trial < 200; trial++ {
 		var mu sync.Mutex
 		notified := map[string]bool{}
+		notifiedCount := func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return len(notified)
+		}
 		kv := New[int](time.Hour, func(k string, _ int) {
 			mu.Lock()
 			notified[k] = true
@@ -35,10 +40,19 @@ func TestExpireFuncNotifiesEveryDeletedEntry(t *testing.T) {
 			_ = kv.Put(k, i, time.Hour)    // current entry, not expired
 		}
 
+		// expireFunc removes expired entries from the store synchronously and
+		// dispatches onExpire asynchronously. Drain the heap, then wait for the
+		// notifications to catch up rather than sleeping a fixed amount: poll
+		// until every survivor has been notified, up to a generous deadline. A
+		// dropped notification never arrives, so the loop hits the deadline and
+		// the assertions below fail deterministically (not on scheduling jitter).
 		for i := 0; i < survivors+2*reputs+5; i++ {
 			kv.expireFunc()
 		}
-		time.Sleep(15 * time.Millisecond) // let async notifyExpirations run
+		deadline := time.Now().Add(2 * time.Second)
+		for notifiedCount() < survivors && time.Now().Before(deadline) {
+			time.Sleep(time.Millisecond)
+		}
 
 		mu.Lock()
 		for i := 0; i < survivors; i++ {
@@ -54,13 +68,21 @@ func TestExpireFuncNotifiesEveryDeletedEntry(t *testing.T) {
 		}
 		mu.Unlock()
 
-		// A re-Put (not-expired) key must never be notified or removed.
+		// A re-Put (not-expired) key must never be removed from the store nor
+		// notified: it still holds a live session.
 		for i := 0; i < reputs; i++ {
 			k := fmt.Sprintf("r%02d", i)
+			kv.mx.Lock()
+			_, inStore := kv.kv[k]
+			kv.mx.Unlock()
 			mu.Lock()
-			wrong := notified[k]
+			wasNotified := notified[k]
 			mu.Unlock()
-			if wrong {
+			if !inStore {
+				kv.Stop()
+				t.Fatalf("trial %d: re-Put key %q was wrongly removed from the store", trial, k)
+			}
+			if wasNotified {
 				kv.Stop()
 				t.Fatalf("trial %d: re-Put key %q was wrongly expired", trial, k)
 			}

--- a/pkg/tinykv/expire_notify_test.go
+++ b/pkg/tinykv/expire_notify_test.go
@@ -32,12 +32,21 @@ func TestExpireFuncNotifiesEveryDeletedEntry(t *testing.T) {
 		const survivors = 30
 		const reputs = 30
 		for i := 0; i < survivors; i++ {
-			_ = kv.Put(fmt.Sprintf("s%02d", i), i, -time.Second)
+			if err := kv.Put(fmt.Sprintf("s%02d", i), i, -time.Second); err != nil {
+				kv.Stop()
+				t.Fatalf("trial %d: Put survivor failed: %v", trial, err)
+			}
 		}
 		for i := 0; i < reputs; i++ {
 			k := fmt.Sprintf("r%02d", i)
-			_ = kv.Put(k, i, -time.Second) // stale timeout left in the heap
-			_ = kv.Put(k, i, time.Hour)    // current entry, not expired
+			if err := kv.Put(k, i, -time.Second); err != nil { // stale timeout left in the heap
+				kv.Stop()
+				t.Fatalf("trial %d: Put stale re-Put failed: %v", trial, err)
+			}
+			if err := kv.Put(k, i, time.Hour); err != nil { // current entry, not expired
+				kv.Stop()
+				t.Fatalf("trial %d: Put re-Put failed: %v", trial, err)
+			}
 		}
 
 		// expireFunc removes expired entries from the store synchronously and
@@ -54,19 +63,26 @@ func TestExpireFuncNotifiesEveryDeletedEntry(t *testing.T) {
 			time.Sleep(time.Millisecond)
 		}
 
+		// Snapshot the notification set once, then verify against the snapshot
+		// without holding mu, so the assertions never contend with the async
+		// onExpire callback (which also takes mu).
 		mu.Lock()
+		notifiedSnapshot := make(map[string]bool, len(notified))
+		for k := range notified {
+			notifiedSnapshot[k] = true
+		}
+		mu.Unlock()
+
 		for i := 0; i < survivors; i++ {
 			k := fmt.Sprintf("s%02d", i)
 			kv.mx.Lock()
 			_, inStore := kv.kv[k]
 			kv.mx.Unlock()
-			if !inStore && !notified[k] {
-				mu.Unlock()
+			if !inStore && !notifiedSnapshot[k] {
 				kv.Stop()
 				t.Fatalf("trial %d: %q was deleted from the store without firing onExpire", trial, k)
 			}
 		}
-		mu.Unlock()
 
 		// A re-Put (not-expired) key must never be removed from the store nor
 		// notified: it still holds a live session.
@@ -75,14 +91,11 @@ func TestExpireFuncNotifiesEveryDeletedEntry(t *testing.T) {
 			kv.mx.Lock()
 			_, inStore := kv.kv[k]
 			kv.mx.Unlock()
-			mu.Lock()
-			wasNotified := notified[k]
-			mu.Unlock()
 			if !inStore {
 				kv.Stop()
 				t.Fatalf("trial %d: re-Put key %q was wrongly removed from the store", trial, k)
 			}
-			if wasNotified {
+			if notifiedSnapshot[k] {
 				kv.Stop()
 				t.Fatalf("trial %d: re-Put key %q was wrongly expired", trial, k)
 			}

--- a/pkg/tinykv/expire_notify_test.go
+++ b/pkg/tinykv/expire_notify_test.go
@@ -1,0 +1,70 @@
+package tinykv
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestExpireFuncNotifiesEveryDeletedEntry guards against a silent-drop
+// regression in expireFunc: every entry removed from the store on expiration
+// MUST fire onExpire. The bug occurred when an expiry batch mixed genuinely
+// expired keys with keys that had been re-Put (a stale timeout still queued in
+// the heap); the re-validation pass could delete survivors from the store yet
+// drop them from the notification set, leaving an expired instance running with
+// no session (an orphan).
+func TestExpireFuncNotifiesEveryDeletedEntry(t *testing.T) {
+	for trial := 0; trial < 200; trial++ {
+		var mu sync.Mutex
+		notified := map[string]bool{}
+		kv := New[int](time.Hour, func(k string, _ int) {
+			mu.Lock()
+			notified[k] = true
+			mu.Unlock()
+		}).(*store[int])
+
+		const survivors = 30
+		const reputs = 30
+		for i := 0; i < survivors; i++ {
+			_ = kv.Put(fmt.Sprintf("s%02d", i), i, -time.Second)
+		}
+		for i := 0; i < reputs; i++ {
+			k := fmt.Sprintf("r%02d", i)
+			_ = kv.Put(k, i, -time.Second) // stale timeout left in the heap
+			_ = kv.Put(k, i, time.Hour)    // current entry, not expired
+		}
+
+		for i := 0; i < survivors+2*reputs+5; i++ {
+			kv.expireFunc()
+		}
+		time.Sleep(15 * time.Millisecond) // let async notifyExpirations run
+
+		mu.Lock()
+		for i := 0; i < survivors; i++ {
+			k := fmt.Sprintf("s%02d", i)
+			kv.mx.Lock()
+			_, inStore := kv.kv[k]
+			kv.mx.Unlock()
+			if !inStore && !notified[k] {
+				mu.Unlock()
+				kv.Stop()
+				t.Fatalf("trial %d: %q was deleted from the store without firing onExpire", trial, k)
+			}
+		}
+		mu.Unlock()
+
+		// A re-Put (not-expired) key must never be notified or removed.
+		for i := 0; i < reputs; i++ {
+			k := fmt.Sprintf("r%02d", i)
+			mu.Lock()
+			wrong := notified[k]
+			mu.Unlock()
+			if wrong {
+				kv.Stop()
+				t.Fatalf("trial %d: re-Put key %q was wrongly expired", trial, k)
+			}
+		}
+		kv.Stop()
+	}
+}

--- a/pkg/tinykv/tinykv.go
+++ b/pkg/tinykv/tinykv.go
@@ -364,7 +364,9 @@ func (kv *store[T]) expireFunc() time.Duration {
 		delete(kv.kv, k)
 		toNotify[k] = v
 	}
-	go notifyExpirations(toNotify, kv.onExpire)
+	if len(toNotify) > 0 {
+		go notifyExpirations(toNotify, kv.onExpire)
+	}
 	if interval == 0 && len(kv.heap) > 0 {
 		last := kv.heap[0]
 		interval = time.Until(last.expiresAt)

--- a/pkg/tinykv/tinykv.go
+++ b/pkg/tinykv/tinykv.go
@@ -315,18 +315,27 @@ func (kv *store[T]) expireFunc() time.Duration {
 			expired[last.key] = entry.value
 		}
 	}
-REVAL:
-	for k := range expired {
+	// Re-validate each candidate against the current entry and build the set to
+	// notify in a single pass. A candidate is skipped when its key was removed or
+	// re-Put with a later expiry (a stale timeout was popped from the heap). Every
+	// key that is deleted from the store here is also added to toNotify, so a
+	// deletion can never happen without firing onExpire.
+	//
+	// The previous implementation mutated `expired` in place and used `goto` to
+	// restart the range whenever a candidate was skipped; because survivors were
+	// already deleted from kv.kv before the restart, they read back as absent and
+	// were silently dropped from the notification set — the entry vanished from the
+	// store but onExpire never fired.
+	toNotify := make(map[string]T, len(expired))
+	for k, v := range expired {
 		newVal, ok := kv.kv[k]
-		if !ok ||
-			newVal.timeout == nil ||
-			!newVal.expired() {
-			delete(expired, k)
-			goto REVAL
+		if !ok || newVal.timeout == nil || !newVal.expired() {
+			continue
 		}
 		delete(kv.kv, k)
+		toNotify[k] = v
 	}
-	go notifyExpirations(expired, kv.onExpire)
+	go notifyExpirations(toNotify, kv.onExpire)
 	if interval == 0 && len(kv.heap) > 0 {
 		last := kv.heap[0]
 		interval = time.Until(last.expiresAt)


### PR DESCRIPTION
## Problem

`expireFunc` can delete an expired entry from the store **without ever calling `onExpire`** for it. Since Sablier registers `OnInstanceExpired` as the `onExpire` callback (it stops the instance whose session expired), a dropped notification means **a session silently disappears while its instance keeps running** — an orphan that never scales back to zero.

The bug is in the re-validation pass:

```go
REVAL:
	for k := range expired {
		newVal, ok := kv.kv[k]
		if !ok || newVal.timeout == nil || !newVal.expired() {
			delete(expired, k)
			goto REVAL
		}
		delete(kv.kv, k)   // survivor: removed from store, kept in `expired` to be notified
	}
	go notifyExpirations(expired, kv.onExpire)
```

The loop mutates `expired` in place and restarts via `goto` whenever a candidate is skipped (a key that was removed, or re-`Put` with a later expiry so its stale timeout was popped from the heap). The problem:

1. A genuinely-expired survivor is processed → `delete(kv.kv, k)` removes it from the store, but it stays in `expired` so it will be notified.
2. A later iteration hits a re-`Put` (now not-expired) candidate → `delete(expired, k)` + `goto REVAL` restarts the range.
3. On the restart, the survivor from step 1 is looked up again: `kv.kv[k]` is now **absent** (we deleted it) → `!ok` → it gets `delete(expired, k)` and is **dropped from the notification set**.

Net result: the entry is gone from the store, but `onExpire` never fires. A single re-`Put` key in a batch can drop every survivor processed before it.

This is easy to hit in practice whenever many entries expire around the same instant while others are being renewed — e.g. a fleet of sessions created together, or continuous session renewals via traffic.

## Fix

Re-validate and delete in a single pass, building a fresh `toNotify` set. Every key deleted from the store is added to `toNotify`, so a deletion can never happen without a matching notification. Re-`Put`/removed candidates are simply skipped (left untouched).

```go
toNotify := make(map[string]T, len(expired))
for k, v := range expired {
	newVal, ok := kv.kv[k]
	if !ok || newVal.timeout == nil || !newVal.expired() {
		continue
	}
	delete(kv.kv, k)
	toNotify[k] = v
}
go notifyExpirations(toNotify, kv.onExpire)
```

## Test

Added `TestExpireFuncNotifiesEveryDeletedEntry`, which builds expiry batches mixing genuinely-expired keys with re-`Put` keys and asserts that **every** entry removed from the store fires `onExpire` (and that re-`Put`, not-expired keys are neither expired nor notified).

Against the old code this fails deterministically (thousands of store deletions with no notification across a few hundred trials); with the fix it passes, and the existing `tinykv` tests continue to pass.

## Impact

Found while running Sablier in production (a fleet of on-demand environments): instances whose sessions expired were occasionally left running with no session and never hibernated. This is a plausible root cause for "orphaned" workloads that outlive their session.
