### PR TITLE
feat(api): add ready_on_start query param to dynamic strategy

### DIFF
--- a/internal/api/start_dynamic.go
+++ b/internal/api/start_dynamic.go
@@ -23,6 +23,7 @@ type DynamicRequest struct {
 	Theme            string        `form:"theme"`
 	SessionDuration  time.Duration `form:"session_duration"`
 	RefreshFrequency time.Duration `form:"refresh_frequency"`
+	ReadyOnStart     bool          `form:"ready_on_start"`
 }
 
 func StartDynamic(router *gin.RouterGroup, s *ServeStrategy) {
@@ -74,6 +75,9 @@ func StartDynamic(router *gin.RouterGroup, s *ServeStrategy) {
 		}
 
 		AddSablierHeader(c, sessionState)
+		if request.ReadyOnStart {
+			c.Header(SablierStatusHeader, SablierStatusReady)
+		}
 
 		renderOptions := theme.Options{
 			DisplayName:      request.DisplayName,

--- a/internal/api/start_dynamic_test.go
+++ b/internal/api/start_dynamic_test.go
@@ -27,6 +27,22 @@ func session() *sablier.SessionState {
 	}
 }
 
+func notReadySession() *sablier.SessionState {
+	return &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"test": {
+				Instance: sablier.InstanceInfo{
+					Name:            "test",
+					CurrentReplicas: 0,
+					DesiredReplicas: 1,
+					Status:          sablier.InstanceStatusStarting,
+				},
+				Error: nil,
+			},
+		},
+	}
+}
+
 func TestStartDynamic(t *testing.T) {
 	t.Run("StartDynamicInvalidBind", func(t *testing.T) {
 		app, router, strategy, _ := NewApiTest(t)
@@ -70,6 +86,14 @@ func TestStartDynamic(t *testing.T) {
 		StartDynamic(router, strategy)
 		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(session(), nil)
 		r := PerformRequest(app, "GET", "/api/strategies/dynamic?group=test")
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, SablierStatusReady, r.Header().Get(SablierStatusHeader))
+	})
+	t.Run("StartDynamicReadyOnStartForcesReady", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		StartDynamic(router, strategy)
+		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(notReadySession(), nil)
+		r := PerformRequest(app, "GET", "/api/strategies/dynamic?group=test&ready_on_start=true")
 		assert.Equal(t, http.StatusOK, r.Code)
 		assert.Equal(t, SablierStatusReady, r.Header().Get(SablierStatusHeader))
 	})


### PR DESCRIPTION
## What

Adds `ready_on_start` query parameter to the dynamic strategy. When `true`, Sablier returns `X-Sablier-Session-Status: ready` immediately regardless of instance health — the reverse proxy passes the request through without showing a waiting page.

The per-instance `sablier.ready-on-start` label controls behavior per container. The query param does the same, but at the middleware level — no labels needed.

## Why

Sometimes you want different behavior depending on which service is accessed:

**Home Assistant + Frigate:** When loading the HA dashboard, you want Frigate to start in the background — no need to wait. But when accessing Frigate's own UI directly, you want the waiting screen to confirm it's ready.
**Chat app + LiteLLM proxy:** When users open the chat, LiteLLM starts alongside without blocking. Direct access to LiteLLM UI get the waiting screen.

## Usage

GET /api/strategies/dynamic?group=myapp&ready_on_start=true

Plugin-side config (separate PRs):
```yaml
    frigate-sablier:
      plugin:
        sablier:
          names: frigate
          dynamic:
            displayName: Frigate

    frigate-sablier-force:
      plugin:
        sablier:
          names: frigate
          dynamic:
            displayName: Frigate
            readyOnStart: true
```

#975 #984
