### PR TITLE
fix(kubernetes): honor names-based replica count on instance start

### DIFF
--- a/pkg/provider/kubernetes/instance_start.go
+++ b/pkg/provider/kubernetes/instance_start.go
@@ -16,6 +16,22 @@ func (p *Provider) InstanceDependencies(_ context.Context, _ string) ([]sablier.
 	return nil, nil
 }
 
+// activeReplicas resolves the replica count used when starting an instance.
+// The sablier.active.replicas label on the workload stays authoritative when
+// present. Without it, an explicit count from the names-based API
+// (kind_namespace_name_replicas, e.g. reverse-proxy plugin middlewares) is
+// honored, so `deployment_ns_name_2` scales to 2 as documented instead of
+// silently falling back to the default of 1.
+func activeReplicas(sc sablier.ScaleConfig, labels map[string]string, parsed ParsedName) int32 {
+	if _, hasLabel := labels["sablier.active.replicas"]; hasLabel {
+		return sc.Active.Replicas
+	}
+	if parsed.Replicas > 1 {
+		return parsed.Replicas
+	}
+	return sc.Active.Replicas
+}
+
 func (p *Provider) InstanceStart(ctx context.Context, name string) (err error) {
 	ctx, span := p.tracer.Start(ctx, "kubernetes.instance.start",
 		trace.WithAttributes(attribute.String("instance", name)))
@@ -64,6 +80,7 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) (err error) {
 	}
 
 	sc := sablier.ScaleConfigFromLabels(labels)
+	sc.Active.Replicas = activeReplicas(sc, labels, parsed)
 	if sc.Idle.Replicas >= 1 || sc.Active.Replicas > 1 || sc.Active.CPU != "" || sc.Active.Memory != "" {
 		span.SetAttributes(
 			attribute.String("operation", "scale_mode"),

--- a/pkg/provider/kubernetes/instance_start_replicas_test.go
+++ b/pkg/provider/kubernetes/instance_start_replicas_test.go
@@ -1,0 +1,61 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
+
+func TestActiveReplicas(t *testing.T) {
+	parsedWith := func(replicas int32) ParsedName {
+		return ParsedName{Kind: "deployment", Namespace: "ns", Name: "app", Replicas: replicas}
+	}
+
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		parsed   ParsedName
+		expected int32
+	}{
+		{
+			name:     "no label, names replicas honored",
+			labels:   map[string]string{},
+			parsed:   parsedWith(2),
+			expected: 2,
+		},
+		{
+			name:     "no label, names replicas 1 keeps default",
+			labels:   map[string]string{},
+			parsed:   parsedWith(1),
+			expected: 1,
+		},
+		{
+			name:     "no label, names replicas 0 keeps default",
+			labels:   map[string]string{},
+			parsed:   parsedWith(0),
+			expected: 1,
+		},
+		{
+			name:     "label wins over names replicas",
+			labels:   map[string]string{"sablier.active.replicas": "3"},
+			parsed:   parsedWith(2),
+			expected: 3,
+		},
+		{
+			name:     "explicit label 1 wins over names replicas",
+			labels:   map[string]string{"sablier.active.replicas": "1"},
+			parsed:   parsedWith(5),
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := sablier.ScaleConfigFromLabels(tt.labels)
+			got := activeReplicas(sc, tt.labels, tt.parsed)
+			if got != tt.expected {
+				t.Errorf("activeReplicas() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The names-based API documents `kind_namespace_name_replicas` (README, e2e manifests use e.g. `deployment_default_whoami-deployment_1`), and `ParseName` extracts the trailing count - but `InstanceStart` discards it: the target always comes from `ScaleConfigFromLabels`, which defaults to `Active.Replicas = 1` when the workload has no `sablier.active.replicas` label.

Anyone configuring `deployment_ns_name_2` via a reverse-proxy plugin middleware gets 1 replica on wake, silently. This is the still-open half of #258: that issue was closed by the scale-mode labels (#908), which works for label-managed workloads, but the names path - the primary interface for plugin middleware users, who may not control workload labels (third-party charts) - still ignores its own documented replicas segment. Observed on sablier 1.14.0 / Traefik plugin / AKS: `deployment_<ns>_<name>_2` woke at 1, scaling a running 2-replica deployment down.

## Change

`InstanceStart` resolves the target count via a small helper with explicit precedence:

1. `sablier.active.replicas` label, when present - **stays authoritative** (no behavior change for label users; an explicit label of `1` still wins over a names count)
2. an explicit names count `> 1`
3. the existing default (1)

Includes a table-driven unit test for the precedence (`TestActiveReplicas`). `go build`/`go vet` clean; the package suite needs the k3s testcontainer my environment cannot run - relying on CI.

## Notes

- `_0` and `_1` behave exactly as before (default), so existing setups are unaffected.
- The DeploymentName/StatefulSetName helpers (label-discovered workloads) keep their current behavior; only explicitly-named instances change, and only when the name asks for > 1.