### PR TITLE
feat(strategy): add poke strategy

### DIFF
--- a/docs/content/concepts/strategies.md
+++ b/docs/content/concepts/strategies.md
@@ -52,6 +52,8 @@ This strategy is useful for background services whose startup the caller does no
 
 Instances with the `sablier.ready-on-start=true` label are treated as ready as soon as the start is dispatched, even with the dynamic or blocking strategy. See [Configuration](/configuration/#instance-labels) for details.
 
+To set up the poke strategy on a route, see [Start without waiting](/how-to-guides/loading-strategies/start-without-waiting/).
+
 ```mermaid
 sequenceDiagram
     participant User

--- a/docs/content/concepts/strategies.md
+++ b/docs/content/concepts/strategies.md
@@ -3,7 +3,7 @@ title: Strategies
 weight: 418
 ---
 
-A **strategy** is how the reverse-proxy plugin behaves while Sablier is starting the instances for a session. Sablier offers two: the **dynamic** strategy shows a self-refreshing waiting page, and the **blocking** strategy holds the request open until everything is ready. Which one fits depends on who (or what) is making the request.
+A **strategy** is how the reverse-proxy plugin behaves while Sablier is starting the instances for a session. Sablier offers three: the **dynamic** strategy shows a self-refreshing waiting page, the **blocking** strategy holds the request open until everything is ready, and the **poke** strategy starts instances and lets the request through without waiting. Which one fits depends on who (or what) is making the request.
 
 ## Dynamic strategy
 
@@ -42,6 +42,29 @@ sequenceDiagram
 
 The waiting page is rendered from a [theme](/how-to-guides/loading-strategies/customize-theme/); use a built-in one or provide your own. To set up the dynamic strategy on a route, see [Show a waiting page](/how-to-guides/loading-strategies/show-waiting-page/).
 
+## Poke strategy
+
+The **poke strategy** starts the requested instances and returns the real session status immediately — no waiting page, no blocking. The reverse proxy plugin is free to pass the request through regardless of the status, or show a waiting page, or redirect. It is up to the consumer to decide how to handle the response.
+
+{{< callout type="info" >}}
+This strategy is useful for background services whose startup the caller does not need to wait for. For example, an NVR that records alongside a smart-home dashboard — you want it started, but you don't want the dashboard to stall while the NVR boots.
+{{< /callout >}}
+
+Instances with the `sablier.ready-on-start=true` label are treated as ready as soon as the start is dispatched, even with the dynamic or blocking strategy. See [Configuration](/configuration/#instance-labels) for details.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Proxy
+    participant Sablier
+    participant Provider
+    User->>Proxy: Website Request
+    Proxy->>Sablier: Reverse Proxy Plugin Request Session (poke)
+    Sablier->>Provider: Start Instance (async)
+    Sablier-->>Proxy: Returns the X-Sablier-Session-Status Header
+    Proxy-->>User: Content
+```
+
 ## Blocking strategy
 
 The **blocking strategy** holds the request until your session is ready. Nothing is served to the caller until Sablier reports the instances ready (or the wait times out), at which point the original request is forwarded.
@@ -73,3 +96,4 @@ To set up the blocking strategy on a route, see [Block until ready](/how-to-guid
 
 - Reach for the **dynamic** strategy when a human is browsing directly. A themed waiting page is friendlier than a request that appears to hang, and it survives long start-up times without hitting client timeouts.
 - Reach for the **blocking** strategy when the caller is another program (an API client, a webhook, a health probe) that simply expects to wait for a response and would not know what to do with an HTML waiting page.
+- Reach for the **poke** strategy when you want instances started but don't need them healthy before serving traffic — background workers, sidecar caches, companion processes the caller doesn't depend on.

--- a/docs/content/concepts/strategies.md
+++ b/docs/content/concepts/strategies.md
@@ -50,7 +50,7 @@ The **poke strategy** starts the requested instances and returns the real sessio
 This strategy is useful for background services whose startup the caller does not need to wait for. For example, an NVR that records alongside a smart-home dashboard — you want it started, but you don't want the dashboard to stall while the NVR boots.
 {{< /callout >}}
 
-Instances with the `sablier.ready-on-start=true` label are treated as ready as soon as the start is dispatched, even with the dynamic or blocking strategy. See [Configuration](/configuration/#instance-labels) for details.
+Instances with the `sablier.ready-on-start=true` label are treated as ready as soon as the start is dispatched, even with the dynamic or blocking strategy. See [Configuration](/tutorials/configuration/#instance-labels) for details.
 
 To set up the poke strategy on a route, see [Start without waiting](/how-to-guides/loading-strategies/start-without-waiting/).
 

--- a/docs/content/concepts/strategies.md
+++ b/docs/content/concepts/strategies.md
@@ -50,7 +50,7 @@ The **poke strategy** starts the requested instances and returns the real sessio
 This strategy is useful for background services whose startup the caller does not need to wait for. For example, an NVR that records alongside a smart-home dashboard — you want it started, but you don't want the dashboard to stall while the NVR boots.
 {{< /callout >}}
 
-Instances with the `sablier.ready-on-start=true` label are treated as ready as soon as the start is dispatched, even with the dynamic or blocking strategy. See [Configuration](/tutorials/configuration/#instance-labels) for details.
+Instances with the `sablier.ready-on-start=true` label are treated as ready as soon as the start is dispatched, even with the dynamic or blocking strategy. See the [Label reference](/reference/labels/#label-sablier-ready-on-start) for details.
 
 To set up the poke strategy on a route, see [Start without waiting](/how-to-guides/loading-strategies/start-without-waiting/).
 

--- a/docs/content/how-to-guides/loading-strategies/start-without-waiting.md
+++ b/docs/content/how-to-guides/loading-strategies/start-without-waiting.md
@@ -3,7 +3,7 @@ title: Start without waiting
 weight: 111
 ---
 
-The **poke** strategy starts your instances and lets the request through immediately — no waiting page, no blocking.
+The **poke** strategy starts your instances and immediately lets the request continue. Unlike the `blocking` and `dynamic` strategies, it never waits for an instance to become ready and never displays a waiting page.
 
 ```Caddyfile
 :80 {
@@ -19,24 +19,58 @@ The **poke** strategy starts your instances and lets the request through immedia
 }
 ```
 
-It is the right choice for background services whose startup the caller does not need to wait for — video recorders, cache sidecars, build agents.
+Use this strategy for services that should be started in response to a request but do not need to be available for that request. Typical examples include video recorders, cache sidecars, AI model servers, and build agents.
 
 ```mermaid
 flowchart LR
-    request[Request arrives] --> start[Start dispatched]
-    start --> forward[Request passed through]
-    start -.->|background| ready[Instance starts]
+		request[Request arrives] --> start[Start instance]
+		request --> forward[Request forwarded]
+		start -.->|background| ready[Instance becomes ready]
 ```
 
 ## Select the poke strategy
 
-The strategy is chosen in your reverse-proxy plugin configuration. Each proxy has its own syntax for opting a route into the poke strategy. See [Reverse proxies](/tutorials/reverse-proxies/) for the exact configuration of your plugin.
+Configure the strategy in your reverse proxy plugin. Each supported reverse proxy has its own syntax for enabling the poke strategy on a route. See [Reverse proxies](/tutorials/reverse-proxies/) for configuration examples.
 
 ## How it works
 
-Poke dispatches the instance start but does not wait for it to become healthy. The session status is returned immediately as reported by the provider. The plugin passes the request through regardless.
+When a request arrives, Sablier asks the provider to start the associated instance and immediately returns control to the reverse proxy. It does not wait for the instance to become healthy or ready to receive traffic. The request is always forwarded to the upstream service.
 
-If you need per-container control instead of per-route, use the `sablier.ready-on-start=true` label with the dynamic or blocking strategy. See [Configuration](/tutorials/configuration/#instance-labels).
+This makes `poke` suitable for background startup scenarios where the request itself does not depend on the instance being available.
+
+If you need per-container control instead of per-route behavior, use the `sablier.ready-on-start=true` label with the `dynamic` or `blocking` strategy. See [Configuration](/tutorials/configuration/#instance-labels).
+
+## Start companion services in the background
+
+You can combine multiple Sablier middlewares on the same route. Use a `dynamic` middleware for the service that must be ready before handling the request, and `poke` middlewares for companion services that should start in the background.
+
+### Example: Chat UI with AI services
+
+`Open WebUI` depends on `Ollama`, `LiteLLM`, and `SearXNG`. Users only need to wait for `Open WebUI`, while the supporting services can start in the background.
+
+```mermaid
+flowchart LR
+    subgraph chat[Access openwebui.localhost]
+        ow_req[Request] --> ow_wait[Wait for open-webui]
+        ow_req -.->|background| ollama_bg[Start ollama]
+        ow_req -.->|background| litellm_bg[Start litellm]
+        ow_req -.->|background| searxng_bg[Start searxng]
+        ow_wait --> ow_ready[Chat UI loads]
+    end
+```
+
+Traefik
+```yaml
+http:
+  routers:
+    open-webui:
+      rule: "Host(`open-webui.example.com`)"
+      middlewares:
+        - open-webui-sablier # dynamic
+        - ollama-sablier # poke
+        - litellm-sablier # poke
+        - searxng-sablier # poke
+```
 
 ## Related
 

--- a/docs/content/how-to-guides/loading-strategies/start-without-waiting.md
+++ b/docs/content/how-to-guides/loading-strategies/start-without-waiting.md
@@ -1,0 +1,44 @@
+---
+title: Start without waiting
+weight: 111
+---
+
+The **poke** strategy starts your instances and lets the request through immediately — no waiting page, no blocking.
+
+```Caddyfile
+:80 {
+	route /whoami {
+		sablier http://sablier:10000 {
+			group demo
+			session_duration 1m
+			poke
+		}
+
+		reverse_proxy whoami:80
+	}
+}
+```
+
+It is the right choice for background services whose startup the caller does not need to wait for — video recorders, cache sidecars, build agents.
+
+```mermaid
+flowchart LR
+    request[Request arrives] --> start[Start dispatched]
+    start --> forward[Request passed through]
+    start -.->|background| ready[Instance starts]
+```
+
+## Select the poke strategy
+
+The strategy is chosen in your reverse-proxy plugin configuration. Each proxy has its own syntax for opting a route into the poke strategy. See [Reverse proxies](/tutorials/reverse-proxies/) for the exact configuration of your plugin.
+
+## How it works
+
+Poke dispatches the instance start but does not wait for it to become healthy. The session status is returned immediately as reported by the provider. The plugin passes the request through regardless.
+
+If you need per-container control instead of per-route, use the `sablier.ready-on-start=true` label with the dynamic or blocking strategy. See [Configuration](/tutorials/configuration/#instance-labels).
+
+## Related
+
+- [Strategies](/concepts/strategies/): how the poke strategy works conceptually.
+- [Reverse proxies](/tutorials/reverse-proxies/): the exact plugin syntax for each proxy.

--- a/docs/content/how-to-guides/loading-strategies/start-without-waiting.md
+++ b/docs/content/how-to-guides/loading-strategies/start-without-waiting.md
@@ -59,17 +59,24 @@ flowchart LR
     end
 ```
 
-Traefik
+#### Traefik
+
+If a user accesses `LiteLLM` directly, the waiting page is shown instead — the second router below handles that case.
 ```yaml
 http:
   routers:
     open-webui:
       rule: "Host(`open-webui.example.com`)"
       middlewares:
-        - open-webui-sablier # dynamic
-        - ollama-sablier # poke
-        - litellm-sablier # poke
-        - searxng-sablier # poke
+        - open-webui-dynamic-sablier
+        - ollama-poke-sablier
+        - litellm-poke-sablier
+        - searxng-poke-sablier
+
+    litellm:
+      rule: "Host(`litellm.example.com`)"
+      middlewares:
+        - litellm-dynamic-sablier
 ```
 
 ## Related

--- a/docs/content/how-to-guides/loading-strategies/start-without-waiting.md
+++ b/docs/content/how-to-guides/loading-strategies/start-without-waiting.md
@@ -38,7 +38,7 @@ When a request arrives, Sablier asks the provider to start the associated instan
 
 This makes `poke` suitable for background startup scenarios where the request itself does not depend on the instance being available.
 
-If you need per-container control instead of per-route behavior, use the `sablier.ready-on-start=true` label with the `dynamic` or `blocking` strategy. See [Configuration](/tutorials/configuration/#instance-labels).
+If you need per-container control instead of per-route behavior, use the `sablier.ready-on-start=true` label with the `dynamic` or `blocking` strategy. See the [Label reference](/reference/labels/#label-sablier-ready-on-start).
 
 ## Start companion services in the background
 

--- a/docs/content/tutorials/getting-started.md
+++ b/docs/content/tutorials/getting-started.md
@@ -235,7 +235,7 @@ The waiting page refreshes on its own. When `whoami` reports ready, Sablier relo
 You have now followed a request through the full path: a stopped service, a waiting page, and the running application. This is scale-to-zero from end to end.
 
 {{< callout type="info" >}}
-To hold the request until the service is ready, instead of showing a waiting page, replace the `dynamic` block with a `blocking` block. See [Loading strategies](/how-to-guides/loading-strategies/) for both strategies.
+To hold the request until the service is ready instead of showing a waiting page, replace the `dynamic` block with a `blocking` block. To start instances without waiting at all, use a `poke` block. See [Loading strategies](/how-to-guides/loading-strategies/) for all three.
 {{< /callout >}}
 
 {{% /steps %}}

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -744,7 +744,7 @@
                 }
               }
             },
-            "description": "Group or instance not found"
+            "description": "Group not found"
           },
           "500": {
             "content": {

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -675,6 +675,94 @@
         ]
       }
     },
+    "/api/strategies/poke": {
+      "get": {
+        "description": "Starts the requested instances and immediately returns the session status without waiting for readiness. Provide either `names` or `group`, never both.",
+        "parameters": [
+          {
+            "description": "Instance name(s); repeat for multiple. Mutually exclusive with group.",
+            "in": "query",
+            "name": "names",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Group name. Mutually exclusive with names.",
+            "in": "query",
+            "name": "group",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Session duration as a Go duration (e.g. 5m). Defaults to the server default.",
+            "in": "query",
+            "name": "session_duration",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.SessionResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "X-Sablier-Session-Status": {
+                "description": "ready or not-ready",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rfc7807.Problem"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rfc7807.Problem"
+                }
+              }
+            },
+            "description": "Group or instance not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rfc7807.Problem"
+                }
+              }
+            },
+            "description": "Internal error"
+          }
+        },
+        "summary": "Poke strategy",
+        "tags": [
+          "strategies"
+        ]
+      }
+    },
     "/api/themes": {
       "get": {
         "description": "Lists the waiting-page themes available to the dynamic strategy (built-in and custom). Also served at the legacy path `/api/dynamic/themes`.",

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -742,6 +742,94 @@
         ]
       }
     },
+    "/api/strategies/poke": {
+      "get": {
+        "description": "Starts the requested instances and immediately returns the session status without waiting for readiness. Provide either `names` or `group`, never both.",
+        "parameters": [
+          {
+            "description": "Instance name(s); repeat for multiple. Mutually exclusive with group.",
+            "in": "query",
+            "name": "names",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Group name. Mutually exclusive with names.",
+            "in": "query",
+            "name": "group",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Session duration as a Go duration (e.g. 5m). Defaults to the server default.",
+            "in": "query",
+            "name": "session_duration",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.SessionResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "X-Sablier-Session-Status": {
+                "description": "ready or not-ready",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rfc7807.Problem"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rfc7807.Problem"
+                }
+              }
+            },
+            "description": "Group or instance not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rfc7807.Problem"
+                }
+              }
+            },
+            "description": "Internal error"
+          }
+        },
+        "summary": "Poke strategy",
+        "tags": [
+          "strategies"
+        ]
+      }
+    },
     "/api/themes": {
       "get": {
         "description": "Lists the waiting-page themes available to the dynamic strategy (built-in and custom). Also served at the legacy path `/api/dynamic/themes`.",

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -811,7 +811,7 @@
                 }
               }
             },
-            "description": "Group or instance not found"
+            "description": "Group not found"
           },
           "500": {
             "content": {

--- a/internal/api/start_poke.go
+++ b/internal/api/start_poke.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
+
+type PokeRequest struct {
+	Names           []string      `form:"names"`
+	Group           string        `form:"group"`
+	SessionDuration time.Duration `form:"session_duration"`
+}
+
+// Poke registers the poke strategy endpoint.
+//
+// @Summary      Poke strategy
+// @Description  Starts the requested instances and immediately returns the session status without waiting for readiness. Provide either `names` or `group`, never both.
+// @Tags         strategies
+// @Produce      json
+// @Param        names             query  []string  false  "Instance name(s); repeat for multiple. Mutually exclusive with group."
+// @Param        group             query  string    false  "Group name. Mutually exclusive with names."
+// @Param        session_duration  query  string    false  "Session duration as a Go duration (e.g. 5m). Defaults to the server default."
+// @Success      200  {object}  SessionResponse
+// @Header       200  {string}  X-Sablier-Session-Status  "ready or not-ready"
+// @Failure      400  {object}  rfc7807.Problem  "Validation error"
+// @Failure      404  {object}  rfc7807.Problem  "Group or instance not found"
+// @Failure      500  {object}  rfc7807.Problem  "Internal error"
+// @Router       /api/strategies/poke [get]
+func Poke(router *gin.RouterGroup, s *ServeStrategy) {
+	router.GET("/strategies/poke", func(c *gin.Context) {
+		request := PokeRequest{
+			SessionDuration: s.SessionsConfig.DefaultDuration,
+		}
+
+		if err := c.ShouldBind(&request); err != nil {
+			AbortWithProblemDetail(c, ProblemValidation(err))
+			return
+		}
+
+		if len(request.Names) == 0 && request.Group == "" {
+			AbortWithProblemDetail(c, ProblemValidation(errors.New("'names' or 'group' query parameter must be set")))
+			return
+		}
+
+		if len(request.Names) > 0 && request.Group != "" {
+			AbortWithProblemDetail(c, ProblemValidation(errors.New("'names' and 'group' query parameters are both set, only one must be set")))
+			return
+		}
+
+		recordSessionRequest(s.Metrics, "poke", request.Group)
+
+		var sessionState *sablier.SessionState
+		var err error
+		if len(request.Names) > 0 {
+			sessionState, err = s.Sablier.RequestSession(c.Request.Context(), request.Names, request.SessionDuration)
+		} else {
+			sessionState, err = s.Sablier.RequestSessionGroup(c.Request.Context(), request.Group, request.SessionDuration)
+			if groupNotFoundError, ok := errors.AsType[sablier.ErrGroupNotFound](err); ok {
+				AbortWithProblemDetail(c, ProblemGroupNotFound(groupNotFoundError))
+				return
+			}
+		}
+		if err != nil {
+			AbortWithProblemDetail(c, ProblemError(err))
+			return
+		}
+
+		if sessionState == nil {
+			AbortWithProblemDetail(c, ProblemError(errors.New("session could not be created, please check logs for more details")))
+			return
+		}
+
+		AddSablierHeader(c, sessionState)
+
+		c.JSON(http.StatusOK, map[string]any{"session": sessionState})
+	})
+}

--- a/internal/api/start_poke.go
+++ b/internal/api/start_poke.go
@@ -27,7 +27,7 @@ type PokeRequest struct {
 // @Success      200  {object}  SessionResponse
 // @Header       200  {string}  X-Sablier-Session-Status  "ready or not-ready"
 // @Failure      400  {object}  rfc7807.Problem  "Validation error"
-// @Failure      404  {object}  rfc7807.Problem  "Group or instance not found"
+// @Failure      404  {object}  rfc7807.Problem  "Group not found"
 // @Failure      500  {object}  rfc7807.Problem  "Internal error"
 // @Router       /api/strategies/poke [get]
 func Poke(router *gin.RouterGroup, s *ServeStrategy) {

--- a/internal/api/start_poke.go
+++ b/internal/api/start_poke.go
@@ -15,7 +15,7 @@ type PokeRequest struct {
 	SessionDuration time.Duration `form:"session_duration"`
 }
 
-// Poke registers the poke strategy endpoint.
+// StartPoke registers the poke strategy endpoint.
 //
 // @Summary      Poke strategy
 // @Description  Starts the requested instances and immediately returns the session status without waiting for readiness. Provide either `names` or `group`, never both.
@@ -30,7 +30,7 @@ type PokeRequest struct {
 // @Failure      404  {object}  rfc7807.Problem  "Group not found"
 // @Failure      500  {object}  rfc7807.Problem  "Internal error"
 // @Router       /api/strategies/poke [get]
-func Poke(router *gin.RouterGroup, s *ServeStrategy) {
+func StartPoke(router *gin.RouterGroup, s *ServeStrategy) {
 	router.GET("/strategies/poke", func(c *gin.Context) {
 		request := PokeRequest{
 			SessionDuration: s.SessionsConfig.DefaultDuration,

--- a/internal/api/start_poke_test.go
+++ b/internal/api/start_poke_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"github.com/tniswong/go.rfcx/rfc7807"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+)
+
+func TestPoke(t *testing.T) {
+	t.Run("PokeInvalidBind", func(t *testing.T) {
+		app, router, strategy, _ := NewApiTest(t)
+		Poke(router, strategy)
+		r := PerformRequest(app, "GET", "/api/strategies/poke?session_duration=invalid")
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+	t.Run("PokeWithoutNamesOrGroup", func(t *testing.T) {
+		app, router, strategy, _ := NewApiTest(t)
+		Poke(router, strategy)
+		r := PerformRequest(app, "GET", "/api/strategies/poke")
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+	t.Run("PokeWithNamesAndGroup", func(t *testing.T) {
+		app, router, strategy, _ := NewApiTest(t)
+		Poke(router, strategy)
+		r := PerformRequest(app, "GET", "/api/strategies/poke?names=test&group=test")
+		assert.Equal(t, http.StatusBadRequest, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+	t.Run("PokeByNames", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		Poke(router, strategy)
+		m.EXPECT().RequestSession(gomock.Any(), []string{"test"}, gomock.Any()).Return(&sablier.SessionState{}, nil)
+		r := PerformRequest(app, "GET", "/api/strategies/poke?names=test")
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, SablierStatusReady, r.Header().Get(SablierStatusHeader))
+	})
+	t.Run("PokeByGroup", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		Poke(router, strategy)
+		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(&sablier.SessionState{}, nil)
+		r := PerformRequest(app, "GET", "/api/strategies/poke?group=test")
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, SablierStatusReady, r.Header().Get(SablierStatusHeader))
+	})
+	t.Run("PokeNotReadyReturnsNotReady", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		Poke(router, strategy)
+		notReady := &sablier.SessionState{
+			Instances: map[string]sablier.InstanceInfoWithError{
+				"test": {
+					Instance: sablier.InstanceInfo{Name: "test", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStarting},
+				},
+			},
+		}
+		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(notReady, nil)
+		r := PerformRequest(app, "GET", "/api/strategies/poke?group=test")
+		assert.Equal(t, http.StatusOK, r.Code)
+		assert.Equal(t, SablierStatusNotReady, r.Header().Get(SablierStatusHeader))
+	})
+	t.Run("PokeErrGroupNotFound", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		Poke(router, strategy)
+		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(nil, sablier.ErrGroupNotFound{
+			Group:           "test",
+			AvailableGroups: []string{"test1", "test2"},
+		})
+		r := PerformRequest(app, "GET", "/api/strategies/poke?group=test")
+		assert.Equal(t, http.StatusNotFound, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+	t.Run("PokeError", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		Poke(router, strategy)
+		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(nil, errors.New("unknown error"))
+		r := PerformRequest(app, "GET", "/api/strategies/poke?group=test")
+		assert.Equal(t, http.StatusInternalServerError, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+	t.Run("PokeSessionNil", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		Poke(router, strategy)
+		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(nil, nil)
+		r := PerformRequest(app, "GET", "/api/strategies/poke?group=test")
+		assert.Equal(t, http.StatusInternalServerError, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+}

--- a/internal/api/start_poke_test.go
+++ b/internal/api/start_poke_test.go
@@ -11,47 +11,47 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestPoke(t *testing.T) {
-	t.Run("PokeInvalidBind", func(t *testing.T) {
+func TestStartPoke(t *testing.T) {
+	t.Run("StartPokeInvalidBind", func(t *testing.T) {
 		app, router, strategy, _ := NewApiTest(t)
-		Poke(router, strategy)
+		StartPoke(router, strategy)
 		r := PerformRequest(app, "GET", "/api/strategies/poke?session_duration=invalid")
 		assert.Equal(t, http.StatusBadRequest, r.Code)
 		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
 	})
-	t.Run("PokeWithoutNamesOrGroup", func(t *testing.T) {
+	t.Run("StartPokeWithoutNamesOrGroup", func(t *testing.T) {
 		app, router, strategy, _ := NewApiTest(t)
-		Poke(router, strategy)
+		StartPoke(router, strategy)
 		r := PerformRequest(app, "GET", "/api/strategies/poke")
 		assert.Equal(t, http.StatusBadRequest, r.Code)
 		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
 	})
-	t.Run("PokeWithNamesAndGroup", func(t *testing.T) {
+	t.Run("StartPokeWithNamesAndGroup", func(t *testing.T) {
 		app, router, strategy, _ := NewApiTest(t)
-		Poke(router, strategy)
+		StartPoke(router, strategy)
 		r := PerformRequest(app, "GET", "/api/strategies/poke?names=test&group=test")
 		assert.Equal(t, http.StatusBadRequest, r.Code)
 		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
 	})
-	t.Run("PokeByNames", func(t *testing.T) {
+	t.Run("StartPokeByNames", func(t *testing.T) {
 		app, router, strategy, m := NewApiTest(t)
-		Poke(router, strategy)
+		StartPoke(router, strategy)
 		m.EXPECT().RequestSession(gomock.Any(), []string{"test"}, gomock.Any()).Return(&sablier.SessionState{}, nil)
 		r := PerformRequest(app, "GET", "/api/strategies/poke?names=test")
 		assert.Equal(t, http.StatusOK, r.Code)
 		assert.Equal(t, SablierStatusReady, r.Header().Get(SablierStatusHeader))
 	})
-	t.Run("PokeByGroup", func(t *testing.T) {
+	t.Run("StartPokeByGroup", func(t *testing.T) {
 		app, router, strategy, m := NewApiTest(t)
-		Poke(router, strategy)
+		StartPoke(router, strategy)
 		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(&sablier.SessionState{}, nil)
 		r := PerformRequest(app, "GET", "/api/strategies/poke?group=test")
 		assert.Equal(t, http.StatusOK, r.Code)
 		assert.Equal(t, SablierStatusReady, r.Header().Get(SablierStatusHeader))
 	})
-	t.Run("PokeNotReadyReturnsNotReady", func(t *testing.T) {
+	t.Run("StartPokeNotReadyReturnsNotReady", func(t *testing.T) {
 		app, router, strategy, m := NewApiTest(t)
-		Poke(router, strategy)
+		StartPoke(router, strategy)
 		notReady := &sablier.SessionState{
 			Instances: map[string]sablier.InstanceInfoWithError{
 				"test": {
@@ -64,9 +64,9 @@ func TestPoke(t *testing.T) {
 		assert.Equal(t, http.StatusOK, r.Code)
 		assert.Equal(t, SablierStatusNotReady, r.Header().Get(SablierStatusHeader))
 	})
-	t.Run("PokeErrGroupNotFound", func(t *testing.T) {
+	t.Run("StartPokeErrGroupNotFound", func(t *testing.T) {
 		app, router, strategy, m := NewApiTest(t)
-		Poke(router, strategy)
+		StartPoke(router, strategy)
 		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(nil, sablier.ErrGroupNotFound{
 			Group:           "test",
 			AvailableGroups: []string{"test1", "test2"},
@@ -75,17 +75,17 @@ func TestPoke(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, r.Code)
 		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
 	})
-	t.Run("PokeError", func(t *testing.T) {
+	t.Run("StartPokeError", func(t *testing.T) {
 		app, router, strategy, m := NewApiTest(t)
-		Poke(router, strategy)
+		StartPoke(router, strategy)
 		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(nil, errors.New("unknown error"))
 		r := PerformRequest(app, "GET", "/api/strategies/poke?group=test")
 		assert.Equal(t, http.StatusInternalServerError, r.Code)
 		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
 	})
-	t.Run("PokeSessionNil", func(t *testing.T) {
+	t.Run("StartPokeSessionNil", func(t *testing.T) {
 		app, router, strategy, m := NewApiTest(t)
-		Poke(router, strategy)
+		StartPoke(router, strategy)
 		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(nil, nil)
 		r := PerformRequest(app, "GET", "/api/strategies/poke?group=test")
 		assert.Equal(t, http.StatusInternalServerError, r.Code)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -24,7 +24,7 @@ func registerRoutes(ctx context.Context, router *gin.Engine, serverConf config.S
 	APIv1 := base.Group("/api")
 	api.StartDynamic(APIv1, s)
 	api.StartBlocking(APIv1, s)
-	api.Poke(APIv1, s)
+	api.StartPoke(APIv1, s)
 	api.ListThemes(APIv1, s)
 	api.InstanceEvents(APIv1, s)
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -24,6 +24,7 @@ func registerRoutes(ctx context.Context, router *gin.Engine, serverConf config.S
 	APIv1 := base.Group("/api")
 	api.StartDynamic(APIv1, s)
 	api.StartBlocking(APIv1, s)
+	api.Poke(APIv1, s)
 	api.ListThemes(APIv1, s)
 	api.InstanceEvents(APIv1, s)
 }


### PR DESCRIPTION
## What

Adds the **poke strategy** — a new `GET /api/strategies/poke` endpoint that starts instances and returns the session status immediately without waiting for readiness. The plugin always passes the request through regardless of `X-Sablier-Session-Status`.

Useful when you want instances started but don't need them healthy before serving traffic — background workers, sidecar caches, companion processes the caller doesn't depend on.

## Usage

GET /api/strategies/poke?group=myapp&session_duration=30m

Plugin config examples (separate PRs in each plugin repo):

```yaml
# Traefik
plugin:
  sablier:
    group: myapp
    poke: {}
# Caddy
sablier {
    group mygroup
    poke
}
// Proxy-WASM
{ "group": "mygroup", "poke": {} }
```

Related
- sablier.ready-on-start=true label (already merged) — same behavior at the per-container level
- Companion PRs in plugin repos: sablier-traefik-plugin, sablier-caddy-plugin, sablier-proxywasm-plugin