### PR TITLE
fix(sablier): data race between group registry reads and in-place member removal

### DIFF
--- a/pkg/sablier/group_registry.go
+++ b/pkg/sablier/group_registry.go
@@ -32,7 +32,8 @@ func (r *groupRegistry) Snapshot() map[string][]string {
 
 // Set replaces the entire registry with groups. Returns the previous snapshot
 // and whether the content actually changed; the caller is responsible for
-// any logging. A nil map is treated as empty.
+// any logging. A nil map is treated as empty. The input is deep-copied so the
+// registry never shares backing storage with the caller.
 func (r *groupRegistry) Set(groups map[string][]string) (old map[string][]string, changed bool) {
 	if groups == nil {
 		groups = make(map[string][]string)
@@ -50,16 +51,31 @@ func (r *groupRegistry) Set(groups map[string][]string) (old map[string][]string
 		copy(cp, v)
 		old[k] = cp
 	}
-	r.data = groups
+	data := make(map[string][]string, len(groups))
+	for k, v := range groups {
+		cp := make([]string, len(v))
+		copy(cp, v)
+		data[k] = cp
+	}
+	r.data = data
 	return old, true
 }
 
-// Get returns the instance list for a group and whether the group exists.
+// Get returns a copy of the instance list for a group and whether the group
+// exists. It must return a copy: removeFromGroup compacts member slices in
+// place under the write lock, so handing out the internal slice would race
+// with callers that iterate it after this method returns (RequestSessionGroup
+// does exactly that).
 func (r *groupRegistry) Get(group string) ([]string, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	names, ok := r.data[group]
-	return names, ok
+	if !ok {
+		return nil, false
+	}
+	out := make([]string, len(names))
+	copy(out, names)
+	return out, true
 }
 
 // Keys returns a snapshot of all current group names.

--- a/pkg/sablier/group_registry_test.go
+++ b/pkg/sablier/group_registry_test.go
@@ -1,0 +1,84 @@
+package sablier
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestGroupRegistry_ConcurrentGetAndRemove reproduces the data race between
+// Get returning the internal member slice and removeFromGroup compacting the
+// same backing array in place (members[:0] + append). This is the production
+// interleaving of RequestSessionGroup (which iterates the slice returned by
+// Get after releasing the lock) and GroupWatch handling a removal event.
+// Run with -race: it fails on the unfixed registry.
+func TestGroupRegistry_ConcurrentGetAndRemove(t *testing.T) {
+	t.Parallel()
+
+	r := newGroupRegistry()
+	members := make([]string, 64)
+	for i := range members {
+		members[i] = fmt.Sprintf("instance-%d", i)
+	}
+	seed := map[string][]string{"g": members}
+	r.Set(map[string][]string{"g": append([]string(nil), members...)})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 1000 {
+			names, ok := r.Get("g")
+			if !ok {
+				continue
+			}
+			// Iterate like RequestSessionGroup does after the lock is gone.
+			for _, n := range names {
+				_ = n
+			}
+		}
+	}()
+
+	// Concurrently trigger removeFromGroup's in-place compaction, then restore.
+	for range 1000 {
+		r.Remove("instance-0")
+		r.Set(map[string][]string{"g": append([]string(nil), seed["g"]...)})
+	}
+	<-done
+}
+
+// TestGroupRegistry_GetReturnsCopy pins the ownership contract: mutating the
+// slice returned by Get must not corrupt the registry's internal state.
+func TestGroupRegistry_GetReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	r := newGroupRegistry()
+	r.Set(map[string][]string{"g": {"a", "b"}})
+
+	names, ok := r.Get("g")
+	if !ok {
+		t.Fatal("group not found")
+	}
+	names[0] = "corrupted"
+
+	again, _ := r.Get("g")
+	if again[0] != "a" {
+		t.Fatalf("registry state mutated through Get's return value: %v", again)
+	}
+}
+
+// TestGroupRegistry_SetCopiesInput pins the same contract on the way in:
+// mutating the map passed to Set must not affect the registry.
+func TestGroupRegistry_SetCopiesInput(t *testing.T) {
+	t.Parallel()
+
+	input := map[string][]string{"g": {"a", "b"}}
+	r := newGroupRegistry()
+	r.Set(input)
+
+	input["g"][0] = "corrupted"
+	delete(input, "g")
+
+	names, ok := r.Get("g")
+	if !ok || names[0] != "a" {
+		t.Fatalf("registry state mutated through Set's input: %v (found=%v)", names, ok)
+	}
+}


### PR DESCRIPTION
## Finding

`groupRegistry.Get` returns its **internal member slice**; `removeFromGroup` compacts **the same backing array in place**. Any caller that iterates the returned slice after the read lock is released races with group mutations.

This is not theoretical — it is the production request path:

1. `RequestSessionGroup` ([session_request.go:60](../blob/main/pkg/sablier/session_request.go#L60)) calls `s.groups.Get(group)` and receives the internal slice.
2. The `RLock` is released; the slice is passed to `requestSession`, which iterates it and spawns one goroutine per member name.
3. Concurrently, `GroupWatch` reacts to a container being removed/relabelled and calls `Sync`/`Remove` -> `removeFromGroup`, which rewrites indices of that same array under the write lock: `filtered := members[:0]; filtered = append(filtered, m)`.

`Set` had the matching hole on the way in: it stored the caller-supplied map without copying (`r.data = groups`), so the registry shared backing storage with whatever the provider layer did to that map afterwards.

`Snapshot()` already deep-copies - `Get` and `Set` simply missed the same treatment.

## Discovery

Found during a design review of `pkg/sablier` (registry ownership audit). Reproduced with a minimal test that mirrors the production interleaving (reader iterating `Get`'s result while `Remove`/`Set` run), under `go test -race`:

```
WARNING: DATA RACE
Write at 0x00c00023b208 by goroutine 11:
  ...(*groupRegistry).removeFromGroup()  pkg/sablier/group_registry.go:146
  ...(*groupRegistry).Remove()           pkg/sablier/group_registry.go:109

Previous read at 0x00c00023b208 by goroutine 28:
  ...TestGroupRegistry_ConcurrentGetAndRemove.func1()  (iterating Get's return value)
```

## Impact

* Under the Go memory model this is undefined behavior; with `-race` builds it aborts the process.
* The observable failure without `-race` is worse than a crash: the reader can see a **half-compacted member list** - duplicated or wrong instance names - so a group session can start the wrong containers or miss members, intermittently and unreproducibly. The trigger window is any group membership change (scale down, container removal, relabel) landing during a session request for that group.

## Fix

The registry now owns its storage exclusively:

* `Get` returns a **copy** of the member slice.
* `Set` **deep-copies** its input map.

Both are documented on the methods so the contract survives refactors. Cost is one small allocation per call on paths that are dominated by provider round-trips.

## Tests

* `TestGroupRegistry_ConcurrentGetAndRemove` - fails on the old code under `-race` (trace above), passes now (verified with `-count=5 -race`).
* `TestGroupRegistry_GetReturnsCopy` / `TestGroupRegistry_SetCopiesInput` - pin the copy-out/copy-in contract so it cannot silently regress.

Full `pkg/sablier` suite and `golangci-lint` pass.

## Docs

No user-facing change (internal concurrency fix): no config, label, API, or generated-docs impact.