### PR TITLE
fix(dockerswarm): nil-service panic when the name filter has no exact match

### DIFF
--- a/pkg/provider/dockerswarm/service_inspect.go
+++ b/pkg/provider/dockerswarm/service_inspect.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.InstanceInfo, error) {
-	service, err := p.getServiceByName(name, ctx)
+	service, err := p.getServiceByName(ctx, name)
 	if err != nil {
 		return sablier.InstanceInfo{}, err
 	}
@@ -65,7 +65,7 @@ func (p *Provider) InstanceInspect(ctx context.Context, name string) (sablier.In
 	return info, nil
 }
 
-func (p *Provider) getServiceByName(name string, ctx context.Context) (*swarm.Service, error) {
+func (p *Provider) getServiceByName(ctx context.Context, name string) (*swarm.Service, error) {
 	filters := client.Filters{}
 	filters.Add("name", name)
 
@@ -80,21 +80,18 @@ func (p *Provider) getServiceByName(name string, ctx context.Context) (*swarm.Se
 		return nil, fmt.Errorf("error listing services: %w", err)
 	}
 
-	if len(services.Items) == 0 {
-		return nil, fmt.Errorf("service with name %s was not found", name)
-	}
-
-	var svc *swarm.Service = nil
+	// The "name" filter is a substring match, so the list can be non-empty
+	// while containing no service actually named `name`; only an exact name or
+	// ID match counts.
+	var svc *swarm.Service
 	for _, service := range services.Items {
-		// Exact match
-		if service.Spec.Name == name {
+		if service.Spec.Name == name || service.ID == name {
 			svc = &service
 			break
 		}
-		if service.ID == name {
-			svc = &service
-			break
-		}
+	}
+	if svc == nil {
+		return nil, fmt.Errorf("service with name %s was not found", name)
 	}
 
 	p.l.DebugContext(ctx, "service inspected", slog.String("service", name),

--- a/pkg/provider/dockerswarm/service_inspect_unit_test.go
+++ b/pkg/provider/dockerswarm/service_inspect_unit_test.go
@@ -1,0 +1,76 @@
+package dockerswarm
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
+	"go.opentelemetry.io/otel"
+	"gotest.tools/v3/assert"
+)
+
+// fakeServiceLister implements only ServiceList; every other APIClient method
+// panics through the embedded nil interface, which is fine for these tests.
+type fakeServiceLister struct {
+	client.APIClient
+	services []swarm.Service
+}
+
+func (f fakeServiceLister) ServiceList(_ context.Context, _ client.ServiceListOptions) (client.ServiceListResult, error) {
+	return client.ServiceListResult{Items: f.services}, nil
+}
+
+func newUnitProvider(services ...swarm.Service) *Provider {
+	return &Provider{
+		Client: fakeServiceLister{services: services},
+		l:      slog.New(slog.DiscardHandler),
+		tracer: otel.Tracer("test"),
+	}
+}
+
+// TestInstanceInspect_SubstringMatchOnly reproduces the nil-service panic:
+// Docker's "name" filter is a substring match, so inspecting "demo" while only
+// "demo-app" exists returns a non-empty list with no exact match. Before the
+// fix, getServiceByName returned (nil, nil) and the caller dereferenced the
+// nil service (after the debug log's arguments had already done so).
+func TestInstanceInspect_SubstringMatchOnly(t *testing.T) {
+	t.Parallel()
+
+	p := newUnitProvider(swarm.Service{
+		ID: "abc123",
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{Name: "demo-app"},
+		},
+	})
+
+	_, err := p.InstanceInspect(context.Background(), "demo")
+	assert.ErrorContains(t, err, "was not found")
+}
+
+// TestInstanceInspect_ExactMatchAmongSubstringMatches pins that the exact
+// match still wins when the filter returns several candidates.
+func TestInstanceInspect_ExactMatchAmongSubstringMatches(t *testing.T) {
+	t.Parallel()
+
+	replicas := uint64(1)
+	p := newUnitProvider(
+		swarm.Service{
+			ID:   "aaa",
+			Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "demo-app"}},
+		},
+		swarm.Service{
+			ID: "bbb",
+			Spec: swarm.ServiceSpec{
+				Annotations: swarm.Annotations{Name: "demo"},
+				Mode:        swarm.ServiceMode{Replicated: &swarm.ReplicatedService{Replicas: &replicas}},
+			},
+			ServiceStatus: &swarm.ServiceStatus{DesiredTasks: 1, RunningTasks: 1},
+		},
+	)
+
+	info, err := p.InstanceInspect(context.Background(), "demo")
+	assert.NilError(t, err)
+	assert.Equal(t, "demo", info.Name)
+}

--- a/pkg/provider/dockerswarm/service_scale.go
+++ b/pkg/provider/dockerswarm/service_scale.go
@@ -40,7 +40,7 @@ func parseMemoryBytes(memory string) (int64, error) {
 // of a Swarm service in a single service update call. Invalid or empty cpu/memory values
 // are skipped with a warning rather than failing the call.
 func (p *Provider) ServiceUpdateScale(ctx context.Context, name string, replicas uint64, cpu, memory string) error {
-	service, err := p.getServiceByName(name, ctx)
+	service, err := p.getServiceByName(ctx, name)
 	if err != nil {
 		return fmt.Errorf("cannot get service: %w", err)
 	}

--- a/pkg/provider/dockerswarm/service_start.go
+++ b/pkg/provider/dockerswarm/service_start.go
@@ -27,7 +27,7 @@ func (p *Provider) InstanceStart(ctx context.Context, name string) (err error) {
 		span.End()
 	}()
 
-	service, err := p.getServiceByName(name, ctx)
+	service, err := p.getServiceByName(ctx, name)
 	if err != nil {
 		return fmt.Errorf("cannot get service: %w", err)
 	}

--- a/pkg/provider/dockerswarm/service_stop.go
+++ b/pkg/provider/dockerswarm/service_stop.go
@@ -23,7 +23,7 @@ func (p *Provider) InstanceStop(ctx context.Context, name string) (err error) {
 		span.End()
 	}()
 
-	service, err := p.getServiceByName(name, ctx)
+	service, err := p.getServiceByName(ctx, name)
 	if err != nil {
 		return fmt.Errorf("cannot get service: %w", err)
 	}


### PR DESCRIPTION
## Finding

`getServiceByName` ([service_inspect.go](../blob/main/pkg/provider/dockerswarm/service_inspect.go#L68-L106)) filters services with Docker's `name` filter, which is a **substring** match. It then scans for an exact name/ID match - but when the list is non-empty and nothing matches exactly, `svc` stays `nil` and the function:

1. evaluates `currentReplicas(svc)` / `desiredReplicas(svc)` / `runningReplicas(svc)` as **debug-log arguments** - Go evaluates log arguments regardless of log level, and `currentReplicas` dereferences `service.Spec.Mode.Replicated` on the nil pointer -> **panic**;
2. even without the log, returns **`(nil, nil)`** - a nil service with a nil error - so every caller dereferences nil at e.g. `service.Spec.Mode.Replicated`.

## How to trigger it

Have a Swarm service whose name is a **superset** of a Sablier-managed name: inspect/start/stop `demo` while only `demo-app` exists (a stack prefix, a rename, a typo in a label). This is an ordinary misconfiguration, not an exotic state.

## Blast radius

`getServiceByName` is called from `InstanceInspect`, `InstanceStart`, `InstanceStop`, and the scale path. Worse, the **events goroutine** calls `InstanceInspect` after every service event ([events.go:41,62,70](../blob/main/pkg/provider/dockerswarm/events.go#L41)) - a panic there is not recovered by any HTTP middleware and **kills the whole Sablier process**.

## Discovery

Found during a design review of the provider layer (comparing the five providers' inspect implementations). Reproduced with a unit test against a fake `client.APIClient` returning one service named `demo-app` for an inspect of `demo`:

```
--- FAIL: TestInstanceInspect_SubstringMatchOnly (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference
  dockerswarm.currentReplicas(...)            service_inspect.go:109
  dockerswarm.(*Provider).getServiceByName()  service_inspect.go:101
  dockerswarm.(*Provider).InstanceInspect()   service_inspect.go:15
```

## Fix

* After the exact-match scan, return a proper error when no service matched: `service with name %s was not found`. This also covers the previously separate empty-list branch, so the function now has a single not-found path.
* A comment documents the substring-match trap so the scan is not "simplified" away later.
* Drive-by in the same function: parameters reordered to the conventional `(ctx, name)` (all four callers updated).

## Tests

* `TestInstanceInspect_SubstringMatchOnly` - panics before the fix (trace above), returns the not-found error after.
* `TestInstanceInspect_ExactMatchAmongSubstringMatches` - pins that an exact match among several substring candidates still resolves correctly.

Package tests and `golangci-lint` pass.

## Docs

No user-facing docs impact (internal bug fix; no config, label, or API change).