### PR TITLE
fix(api): dynamic handler loses request cancellation and trace context

### DIFF
--- a/internal/api/context_propagation_test.go
+++ b/internal/api/context_propagation_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+)
+
+type ctxSentinelKey struct{}
+
+// TestStartDynamicPropagatesRequestContext pins that the dynamic handler hands
+// the HTTP request's context to the session layer. Passing the *gin.Context
+// itself instead of c.Request.Context() silently breaks two things (gin's
+// ContextWithFallback is not enabled): Done() returns a nil channel, so
+// client disconnects and server shutdown never cancel the session work, and
+// Value() does not reach the request context, so the otelgin span is
+// invisible downstream and every provider call becomes an orphan root span.
+func TestStartDynamicPropagatesRequestContext(t *testing.T) {
+	t.Run("names path", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		StartDynamic(router, strategy)
+
+		base := context.WithValue(context.Background(), ctxSentinelKey{}, "sentinel")
+		reqCtx, cancel := context.WithCancel(base)
+		cancel() // pre-cancelled: the handler must observe it
+
+		var got context.Context
+		m.EXPECT().RequestSession(gomock.Any(), []string{"test"}, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ []string, _ time.Duration) (*sablier.SessionState, error) {
+				got = ctx
+				return session(), nil
+			})
+
+		req := httptest.NewRequest("GET", "/api/strategies/dynamic?names=test", nil).WithContext(reqCtx)
+		w := httptest.NewRecorder()
+		app.ServeHTTP(w, req)
+
+		assert.Assert(t, got != nil, "session layer was not called")
+		assert.Equal(t, "sentinel", got.Value(ctxSentinelKey{}), "request context values must reach the session layer")
+		assert.ErrorIs(t, got.Err(), context.Canceled, "request cancellation must reach the session layer")
+	})
+
+	t.Run("group path", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		StartDynamic(router, strategy)
+
+		base := context.WithValue(context.Background(), ctxSentinelKey{}, "sentinel")
+		reqCtx, cancel := context.WithCancel(base)
+		cancel()
+
+		var got context.Context
+		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ string, _ time.Duration) (*sablier.SessionState, error) {
+				got = ctx
+				return session(), nil
+			})
+
+		req := httptest.NewRequest("GET", "/api/strategies/dynamic?group=test", nil).WithContext(reqCtx)
+		w := httptest.NewRecorder()
+		app.ServeHTTP(w, req)
+
+		assert.Assert(t, got != nil, "session layer was not called")
+		assert.Equal(t, "sentinel", got.Value(ctxSentinelKey{}), "request context values must reach the session layer")
+		assert.ErrorIs(t, got.Err(), context.Canceled, "request cancellation must reach the session layer")
+	})
+}
+
+// TestStartBlockingPropagatesRequestContext pins the same contract on the
+// blocking handler, which already passed c.Request.Context() and must not
+// regress to the raw gin context.
+func TestStartBlockingPropagatesRequestContext(t *testing.T) {
+	app, router, strategy, m := NewApiTest(t)
+	StartBlocking(router, strategy)
+
+	base := context.WithValue(context.Background(), ctxSentinelKey{}, "sentinel")
+	reqCtx, cancel := context.WithCancel(base)
+	cancel()
+
+	var got context.Context
+	m.EXPECT().RequestReadySession(gomock.Any(), []string{"test"}, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ []string, _, _ time.Duration) (*sablier.SessionState, error) {
+			got = ctx
+			return session(), nil
+		})
+
+	req := httptest.NewRequest("GET", "/api/strategies/blocking?names=test", nil).WithContext(reqCtx)
+	w := httptest.NewRecorder()
+	app.ServeHTTP(w, req)
+
+	assert.Assert(t, got != nil, "session layer was not called")
+	assert.Equal(t, "sentinel", got.Value(ctxSentinelKey{}), "request context values must reach the session layer")
+	assert.ErrorIs(t, got.Err(), context.Canceled, "request cancellation must reach the session layer")
+}

--- a/internal/api/start_dynamic.go
+++ b/internal/api/start_dynamic.go
@@ -71,10 +71,14 @@ func StartDynamic(router *gin.RouterGroup, s *ServeStrategy) {
 
 		var sessionState *sablier.SessionState
 		var err error
+		// c.Request.Context(), never the *gin.Context itself: without gin's
+		// ContextWithFallback, the gin context has a nil Done() channel and its
+		// Value() does not reach the request context, which silently breaks
+		// cancellation and otel trace propagation for everything downstream.
 		if len(request.Names) > 0 {
-			sessionState, err = s.Sablier.RequestSession(c, request.Names, request.SessionDuration)
+			sessionState, err = s.Sablier.RequestSession(c.Request.Context(), request.Names, request.SessionDuration)
 		} else {
-			sessionState, err = s.Sablier.RequestSessionGroup(c, request.Group, request.SessionDuration)
+			sessionState, err = s.Sablier.RequestSessionGroup(c.Request.Context(), request.Group, request.SessionDuration)
 			if groupNotFoundError, ok := errors.AsType[sablier.ErrGroupNotFound](err); ok {
 				AbortWithProblemDetail(c, ProblemGroupNotFound(groupNotFoundError))
 				return


### PR DESCRIPTION
## Finding

The **dynamic** handler passed the `*gin.Context` itself where a `context.Context` is expected:

```go
sessionState, err = s.Sablier.RequestSession(c, request.Names, request.SessionDuration)        // was: c
sessionState, err = s.Sablier.RequestSessionGroup(c, request.Group, request.SessionDuration)   // was: c
```

while the **blocking** handler correctly passed `c.Request.Context()`. Gin only proxies `Done()`/`Err()`/`Value()` through to the underlying request context when `Engine.ContextWithFallback` is enabled - and it is enabled nowhere in this codebase (verified: zero occurrences). Without it:

* `c.Done()` returns a **nil channel** and `c.Err()` returns nil - **cancellation never propagates**. A client that disconnects (or a server shutting down) does not cancel the session-start work started on its behalf.
* `c.Value(...)` stops at gin's own keys and never reaches the request context - so the span installed by `otelgin.Middleware` is **invisible downstream**. Every provider call under a dynamic request is recorded as an **orphan root span**.

The asymmetry is the nasty part: tracing and cancellation work on the blocking path and silently do not on the dynamic path - the highest-traffic, user-facing endpoint. Nobody notices until they need the trace that isn't there.

## Discovery

Found during an API-layer design review (comparing the two strategy handlers side by side). Pinned with a regression test that stores a sentinel value on the request context and pre-cancels it, then captures the `context.Context` the session layer receives:

```
--- FAIL: TestStartDynamicPropagatesRequestContext/names_path
    assertion failed: sentinel (string) != <nil> (<nil>): request context values must reach the session layer
--- FAIL: TestStartDynamicPropagatesRequestContext/group_path
--- PASS: TestStartBlockingPropagatesRequestContext
```

The blocking handler passing, and the dynamic handler failing, on the identical assertion is the whole bug in one screenful.

## Fix

Pass `c.Request.Context()` at both dynamic call sites, with a comment explaining *why* the raw gin context must never be used there (so the next handler copies the right pattern).

## Tests

`TestStartDynamicPropagatesRequestContext` (names + group paths) and `TestStartBlockingPropagatesRequestContext` pin the contract on both handlers: request-context values must be visible to the session layer, and a cancelled request must be observed as cancelled. API package tests and `golangci-lint` pass.

## Docs

No user-facing docs impact (no config, label, or API surface change).