### PR TITLE
fix(api): dynamic handler swallows theme render errors and starts instances before validating the theme

### DIFF
--- a/internal/api/start_dynamic.go
+++ b/internal/api/start_dynamic.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"sort"
@@ -67,6 +66,18 @@ func StartDynamic(router *gin.RouterGroup, s *ServeStrategy) {
 			return
 		}
 
+		// Validate the theme before any instance is started: a mistyped theme
+		// in the plugin configuration must not start workloads on behalf of a
+		// request that can only ever return 404 (and would start them again on
+		// every retry).
+		if !s.Theme.Exists(request.Theme) {
+			AbortWithProblemDetail(c, ProblemThemeNotFound(theme.ErrThemeNotFound{
+				Theme:           request.Theme,
+				AvailableThemes: s.Theme.List(),
+			}))
+			return
+		}
+
 		recordSessionRequest(s.Metrics, "dynamic", request.Group)
 
 		var sessionState *sablier.SessionState
@@ -101,14 +112,17 @@ func StartDynamic(router *gin.RouterGroup, s *ServeStrategy) {
 			InstanceStates:   sessionStateToRenderOptionsInstanceState(sessionState),
 		}
 
+		// Render into a plain buffer: rendering must fully succeed before any
+		// byte reaches the client, so a template that fails halfway (easy to
+		// author in a custom theme) surfaces as a 500 problem instead of a 200
+		// with a truncated page.
 		buf := new(bytes.Buffer)
-		writer := bufio.NewWriter(buf)
-		err = s.Theme.Render(request.Theme, renderOptions, writer)
+		err = s.Theme.Render(request.Theme, renderOptions, buf)
 		if themeNotFound, ok := errors.AsType[theme.ErrThemeNotFound](err); ok {
 			AbortWithProblemDetail(c, ProblemThemeNotFound(themeNotFound))
 			return
 		}
-		if err := writer.Flush(); err != nil {
+		if err != nil {
 			AbortWithProblemDetail(c, ProblemError(err))
 			return
 		}

--- a/internal/api/start_dynamic_test.go
+++ b/internal/api/start_dynamic_test.go
@@ -2,12 +2,16 @@ package api
 
 import (
 	"errors"
+	"net/http"
+	"testing"
+	"testing/fstest"
+
+	"github.com/neilotoole/slogt"
 	"github.com/sablierapp/sablier/pkg/sablier"
+	"github.com/sablierapp/sablier/pkg/theme"
 	"github.com/tniswong/go.rfcx/rfc7807"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
-	"net/http"
-	"testing"
 )
 
 func session() *sablier.SessionState {
@@ -50,11 +54,28 @@ func TestStartDynamic(t *testing.T) {
 		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
 	})
 	t.Run("StartDynamicThemeNotFound", func(t *testing.T) {
-		app, router, strategy, m := NewApiTest(t)
+		app, router, strategy, _ := NewApiTest(t)
 		StartDynamic(router, strategy)
-		m.EXPECT().RequestSessionGroup(gomock.Any(), "test", gomock.Any()).Return(session(), nil)
+		// No session expectation on purpose: an unknown theme must be rejected
+		// BEFORE any instance is started (the request can only ever 404, and
+		// every retry would otherwise start the workloads again).
 		r := PerformRequest(app, "GET", "/api/strategies/dynamic?group=test&theme=invalid")
 		assert.Equal(t, http.StatusNotFound, r.Code)
+		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
+	})
+	t.Run("StartDynamicRenderError", func(t *testing.T) {
+		app, router, strategy, m := NewApiTest(t)
+		// A theme that parses fine but fails at execution time (field access on
+		// a string): easy to author in a custom theme, must surface as a 500
+		// problem instead of a 200 with a broken page.
+		badFS := fstest.MapFS{"bad.html": &fstest.MapFile{Data: []byte(`{{ .DisplayName.Bad }}`)}}
+		th, err := theme.NewWithCustomThemes(badFS, slogt.New(t))
+		assert.NilError(t, err)
+		strategy.Theme = th
+		StartDynamic(router, strategy)
+		m.EXPECT().RequestSession(gomock.Any(), []string{"test"}, gomock.Any()).Return(session(), nil)
+		r := PerformRequest(app, "GET", "/api/strategies/dynamic?names=test&theme=bad")
+		assert.Equal(t, http.StatusInternalServerError, r.Code)
 		assert.Equal(t, rfc7807.JSONMediaType, r.Header().Get("Content-Type"))
 	})
 	t.Run("StartDynamicByNames", func(t *testing.T) {

--- a/pkg/theme/list.go
+++ b/pkg/theme/list.go
@@ -2,6 +2,11 @@ package theme
 
 import "strings"
 
+// Exists reports whether a theme with the given name is loaded.
+func (t *Themes) Exists(name string) bool {
+	return t.themes.Lookup(name+".html") != nil
+}
+
 // List all the loaded themes
 func (t *Themes) List() []string {
 	themes := make([]string, 0)

--- a/pkg/theme/list_test.go
+++ b/pkg/theme/list_test.go
@@ -24,3 +24,18 @@ func TestList(t *testing.T) {
 
 	assert.ElementsMatch(t, []string{"theme1", "theme2", "ghost", "hacker-terminal", "matrix", "shuffle"}, list)
 }
+
+func TestExists(t *testing.T) {
+	themes, err := theme.NewWithCustomThemes(
+		fstest.MapFS{
+			"custom.html": &fstest.MapFile{},
+		}, slogt.New(t))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	assert.True(t, themes.Exists("custom"))
+	assert.True(t, themes.Exists("ghost")) // embedded
+	assert.False(t, themes.Exists("nope"))
+}


### PR DESCRIPTION
## Finding

Two related defects in the dynamic strategy handler ([start_dynamic.go](../blob/main/internal/api/start_dynamic.go#L104-L114)):

**1. Theme render errors are swallowed -> HTTP 200 with a broken page.**

```go
buf := new(bytes.Buffer)
writer := bufio.NewWriter(buf)
err = s.Theme.Render(request.Theme, renderOptions, writer)
if themeNotFound, ok := errors.AsType[theme.ErrThemeNotFound](err); ok { ... }  // only this error is checked
if err := writer.Flush(); err != nil { ... }  // shadows err; Flush on a bytes.Buffer cannot fail
```

Any render error that is *not* `ErrThemeNotFound` is dropped. Custom themes are Go templates: a bad field access (`{{ .DisplayName.Bad }}`) **parses fine and fails at execution time** - exactly this path. The user gets a 200 with a truncated/empty waiting page and no operator signal. The `bufio.Writer` wrapping a `bytes.Buffer` is pointless double-buffering, and its `Flush()` error check is what created the shadowed-error bug.

**2. The theme is validated *after* the containers are started.** `RequestSession` runs at line 75; the theme lookup happens at line 106. A plugin misconfigured with `theme=typo` **starts the workloads, then returns 404** - and starts them again on every retry. Containers running on behalf of requests that can only ever fail.

## Discovery

Found during an API-layer design review. Both pinned by tests against the unfixed handler:

```
--- FAIL: TestStartDynamic/StartDynamicThemeNotFound   (session was requested before the 404)
--- FAIL: TestStartDynamic/StartDynamicRenderError
    assertion failed: 500 (http.StatusInternalServerError int) != 200 (r.Code int)
```

## Fix

* Render directly into the `bytes.Buffer` (no `bufio`), and surface **every** render error: `ErrThemeNotFound` -> 404 problem, anything else -> 500 problem. Rendering must fully succeed before any byte reaches the client.
* Reject unknown themes **before** any instance is started, via a new `Themes.Exists(name)` (a template lookup, same mechanism `Render` uses). Themes cannot be added at runtime (a restart is required to load new ones - documented behavior), so the early check cannot go stale.

## Tests

* `StartDynamicThemeNotFound` now sets **no session expectation**: gomock fails the test if the session layer is called for an unknown theme, pinning the ordering.
* `StartDynamicRenderError` (new): a parse-valid, execute-failing custom theme must produce a 500 problem (was 200).
* `TestExists` (new): pins the `Exists` lookup for custom and embedded themes.

`internal/api` + `pkg/theme` tests and `golangci-lint` pass.

## Docs

No docs change needed: the customize-theme guide already documents that new themes require a restart; error behavior now matches what a reader would expect (a broken theme fails loudly instead of serving a blank page).