### PR TITLE
refactor(sablier): stage 1 of the InstanceInfo split - typed InstanceConfig with one parser and one enabled-semantics

### DIFF
--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -80,6 +80,57 @@
         },
         "type": "object"
       },
+      "sablier.InstanceConfig": {
+        "properties": {
+          "antiAffinity": {
+            "description": "AntiAffinity lists the groups this instance backs off from\n(sablier.anti-affinity).",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "enabled": {
+            "description": "Enabled reports whether the instance opted into Sablier management\n(sablier.enable set to exactly \"true\").",
+            "type": "boolean"
+          },
+          "groups": {
+            "description": "Groups the instance belongs to (sablier.group). Only populated for\nenabled instances; defaults to [\"default\"] when the label is absent.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "readyAfter": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/time.Duration"
+              }
+            ],
+            "description": "ReadyAfter is the settling delay after the instance first reports ready\n(sablier.ready-after). Zero means no extra wait."
+          },
+          "readyOnStart": {
+            "description": "ReadyOnStart marks the instance ready as soon as its start is\ndispatched, skipping the health check (sablier.ready-on-start).",
+            "type": "boolean"
+          },
+          "runningDays": {
+            "description": "RunningDays restricts RunningHours to specific weekdays\n(sablier.running-days). Empty means every day.",
+            "type": "string"
+          },
+          "runningHours": {
+            "description": "RunningHours is the validated daily keep-warm window\n(sablier.running-hours, \"HH:MM-HH:MM\"). It is kept in its validated\nstring form because that is the serializable canonical representation;\nparse it with ParseRunningHours where the window is evaluated.",
+            "type": "string"
+          },
+          "scale": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/sablier.ScaleConfig"
+              }
+            ],
+            "description": "Scale holds the idle/active resource profiles when any non-default\nscale-mode label is present (sablier.idle.* / sablier.active.*)."
+          }
+        },
+        "type": "object"
+      },
       "sablier.InstanceInfo": {
         "properties": {
           "antiAffinity": {
@@ -88,6 +139,14 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "config": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/sablier.InstanceConfig"
+              }
+            ],
+            "description": "Config is the typed, parsed form of the instance's sablier.* labels,\nproduced by InstanceConfigFromLabels at the provider boundary. Prefer it\n(and the accessor methods such as IsEnabled) over the flat fields above,\nwhich are kept for API and store compatibility and will move behind a\ndedicated API DTO in a later stage. Nil on records that predate this\nfield (e.g. sessions persisted by an older version); accessors fall back\nto the flat fields in that case."
           },
           "currentReplicas": {
             "type": "integer"

--- a/pkg/provider/docker/container_inspect_test.go
+++ b/pkg/provider/docker/container_inspect_test.go
@@ -505,6 +505,19 @@ func TestDockerClassicProvider_GetState(t *testing.T) {
 				ID:    name,
 				Image: "sablierapp/mimic:v0.3.3",
 			}
+			// The provider mirrors the parsed label config into Config with the
+			// same values as the flat fields each case already declares, so
+			// derive the expectation instead of repeating it per case.
+			tt.want.Config = &sablier.InstanceConfig{
+				Enabled:      tt.want.Enabled == "true",
+				Groups:       tt.want.Groups,
+				ReadyAfter:   tt.want.ReadyAfter,
+				ReadyOnStart: tt.want.ReadyOnStart,
+				RunningHours: tt.want.RunningHours,
+				RunningDays:  tt.want.RunningDays,
+				AntiAffinity: tt.want.AntiAffinity,
+				Scale:        tt.want.ScaleConfig,
+			}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {
 				t.Errorf("DockerClassicProvider.InstanceInspect() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/provider/dockerswarm/service_inspect_test.go
+++ b/pkg/provider/dockerswarm/service_inspect_test.go
@@ -193,6 +193,19 @@ func TestDockerSwarmProvider_GetState(t *testing.T) {
 			tt.want.Name = name
 			tt.want.Provider = "swarm"
 			tt.want.Swarm = &sablier.SwarmServiceInfo{}
+			// The provider mirrors the parsed label config into Config with the
+			// same values as the flat fields each case already declares, so
+			// derive the expectation instead of repeating it per case.
+			tt.want.Config = &sablier.InstanceConfig{
+				Enabled:      tt.want.Enabled == "true",
+				Groups:       tt.want.Groups,
+				ReadyAfter:   tt.want.ReadyAfter,
+				ReadyOnStart: tt.want.ReadyOnStart,
+				RunningHours: tt.want.RunningHours,
+				RunningDays:  tt.want.RunningDays,
+				AntiAffinity: tt.want.AntiAffinity,
+				Scale:        tt.want.ScaleConfig,
+			}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {
 				t.Errorf("Provider.InstanceInspect() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/provider/kubernetes/deployment_inspect_test.go
+++ b/pkg/provider/kubernetes/deployment_inspect_test.go
@@ -264,6 +264,19 @@ func TestKubernetesProvider_DeploymentInspect(t *testing.T) {
 				Image:     "sablierapp/mimic:v0.3.3",
 				Labels:    labels,
 			}
+			// The provider mirrors the parsed label config into Config with the
+			// same values as the flat fields each case already declares, so
+			// derive the expectation instead of repeating it per case.
+			tt.want.Config = &sablier.InstanceConfig{
+				Enabled:      tt.want.Enabled == "true",
+				Groups:       tt.want.Groups,
+				ReadyAfter:   tt.want.ReadyAfter,
+				ReadyOnStart: tt.want.ReadyOnStart,
+				RunningHours: tt.want.RunningHours,
+				RunningDays:  tt.want.RunningDays,
+				AntiAffinity: tt.want.AntiAffinity,
+				Scale:        tt.want.ScaleConfig,
+			}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {
 				t.Errorf("Provider.InstanceInspect() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/provider/kubernetes/statefulset_inspect_test.go
+++ b/pkg/provider/kubernetes/statefulset_inspect_test.go
@@ -221,6 +221,19 @@ func TestKubernetesProvider_InspectStatefulSet(t *testing.T) {
 				Image:     "sablierapp/mimic:v0.3.3",
 				Labels:    labels,
 			}
+			// The provider mirrors the parsed label config into Config with the
+			// same values as the flat fields each case already declares, so
+			// derive the expectation instead of repeating it per case.
+			tt.want.Config = &sablier.InstanceConfig{
+				Enabled:      tt.want.Enabled == "true",
+				Groups:       tt.want.Groups,
+				ReadyAfter:   tt.want.ReadyAfter,
+				ReadyOnStart: tt.want.ReadyOnStart,
+				RunningHours: tt.want.RunningHours,
+				RunningDays:  tt.want.RunningDays,
+				AntiAffinity: tt.want.AntiAffinity,
+				Scale:        tt.want.ScaleConfig,
+			}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {
 				t.Errorf("DockerSwarmProvider.InstanceInspect() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/provider/podman/container_inspect_test.go
+++ b/pkg/provider/podman/container_inspect_test.go
@@ -308,6 +308,19 @@ func TestPodmanProvider_GetState(t *testing.T) {
 				ID:    name,
 				Image: "docker.io/sablierapp/mimic:v0.3.3",
 			}
+			// The provider mirrors the parsed label config into Config with the
+			// same values as the flat fields each case already declares, so
+			// derive the expectation instead of repeating it per case.
+			tt.want.Config = &sablier.InstanceConfig{
+				Enabled:      tt.want.Enabled == "true",
+				Groups:       tt.want.Groups,
+				ReadyAfter:   tt.want.ReadyAfter,
+				ReadyOnStart: tt.want.ReadyOnStart,
+				RunningHours: tt.want.RunningHours,
+				RunningDays:  tt.want.RunningDays,
+				AntiAffinity: tt.want.AntiAffinity,
+				Scale:        tt.want.ScaleConfig,
+			}
 			got, err := p.InstanceInspect(ctx, name)
 			if !cmp.Equal(err, tt.wantErr) {
 				t.Errorf("PodmanProvider.InstanceInspect() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/sablier/autostop.go
+++ b/pkg/sablier/autostop.go
@@ -100,7 +100,7 @@ func (s *Sablier) WatchAndStopExternallyStarted(ctx context.Context) {
 				continue
 			}
 			// Only act on Sablier-managed instances.
-			if info.Info.Enabled != "true" {
+			if !info.Info.IsEnabled() {
 				continue
 			}
 			if s.isStartedByUs(ctx, info.Info.Name) {

--- a/pkg/sablier/autowarm.go
+++ b/pkg/sablier/autowarm.go
@@ -104,7 +104,7 @@ func (s *Sablier) WatchAndWarmExternallyStarted(ctx context.Context) {
 				continue
 			}
 			// Only act on Sablier-managed instances.
-			if info.Info.Enabled != "true" {
+			if !info.Info.IsEnabled() {
 				continue
 			}
 			if s.isStartedByUs(ctx, info.Info.Name) {

--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -83,6 +83,25 @@ type InstanceInfo struct {
 	// ScaleConfig configures resource-based scale mode for this instance.
 	// When present, Sablier throttles CPU/memory instead of stopping the container.
 	ScaleConfig *ScaleConfig `json:"scaleConfig,omitempty"`
+
+	// Config is the typed, parsed form of the instance's sablier.* labels,
+	// produced by InstanceConfigFromLabels at the provider boundary. Prefer it
+	// (and the accessor methods such as IsEnabled) over the flat fields above,
+	// which are kept for API and store compatibility and will move behind a
+	// dedicated API DTO in a later stage. Nil on records that predate this
+	// field (e.g. sessions persisted by an older version); accessors fall back
+	// to the flat fields in that case.
+	Config *InstanceConfig `json:"config,omitempty"`
+}
+
+// IsEnabled reports whether the instance opted into Sablier management
+// (sablier.enable set to exactly "true"). It is the single source of that
+// semantics; do not compare the flat Enabled string directly.
+func (instance InstanceInfo) IsEnabled() bool {
+	if instance.Config != nil {
+		return instance.Config.Enabled
+	}
+	return instance.Enabled == "true"
 }
 
 // BlkioWeightDevice holds a per-device I/O scheduling weight override.
@@ -161,6 +180,12 @@ type InstanceConfiguration struct {
 	Name    string
 	Groups  []string
 	Enabled string
+}
+
+// IsEnabled reports whether the listed instance opted into Sablier management
+// (sablier.enable set to exactly "true"), mirroring InstanceInfo.IsEnabled.
+func (c InstanceConfiguration) IsEnabled() bool {
+	return c.Enabled == "true"
 }
 
 func (instance InstanceInfo) IsReady() bool {
@@ -366,68 +391,23 @@ func ParseAntiAffinity(label string) []string {
 	return out
 }
 
-// PopulateEnabledAndGroup reads the sablier.enable and sablier.group labels from
-// labels and writes the results into info. Centralising this logic avoids
-// duplicating the same map lookups in every provider's Inspect implementation.
+// PopulateEnabledAndGroup parses the sablier.* labels into info.Config and
+// mirrors the result into the flat legacy fields, which stay byte-identical
+// on the wire (API responses and persisted session records). All parsing
+// lives in InstanceConfigFromLabels; this is only the compatibility adapter
+// providers call from their Inspect implementations.
 func PopulateEnabledAndGroup(info *InstanceInfo, labels map[string]string) {
+	cfg := InstanceConfigFromLabels(labels, slog.Default().With(slog.String("instance", info.Name)))
+	info.Config = &cfg
+
+	// Legacy flat fields. Enabled keeps the raw label value (not the parsed
+	// boolean) because the API has always exposed it verbatim.
 	info.Enabled = labels[LabelEnable]
-	if info.Enabled == "true" {
-		info.Groups = ParseGroups(labels[LabelGroup])
-	}
-	if v := labels[LabelReadyAfter]; v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			info.ReadyAfter = d
-		} else {
-			slog.Warn("invalid sablier.ready-after label value, ignoring",
-				slog.String("instance", info.Name),
-				slog.String("value", v),
-				slog.Any("error", err),
-			)
-		}
-	}
-	if v := labels[LabelRunningHours]; v != "" {
-		if _, err := ParseRunningHours(v); err == nil {
-			info.RunningHours = v
-		} else {
-			slog.Warn("invalid sablier.running-hours label value, ignoring",
-				slog.String("instance", info.Name),
-				slog.String("value", v),
-				slog.Any("error", err),
-			)
-		}
-	}
-	if v := labels[LabelRunningDays]; v != "" {
-		if _, err := ParseRunningDays(v); err == nil {
-			info.RunningDays = v
-		} else {
-			slog.Warn("invalid sablier.running-days label value, ignoring",
-				slog.String("instance", info.Name),
-				slog.String("value", v),
-				slog.Any("error", err),
-			)
-		}
-	}
-	if v := labels[LabelReadyOnStart]; v != "" {
-		b, err := strconv.ParseBool(v)
-		if err != nil {
-			slog.Warn("invalid sablier.ready-on-start label value, ignoring",
-				slog.String("instance", info.Name),
-				slog.String("value", v),
-				slog.Any("error", err),
-			)
-		} else {
-			info.ReadyOnStart = b
-		}
-	}
-	if v := labels[LabelAntiAffinity]; v != "" {
-		info.AntiAffinity = ParseAntiAffinity(v)
-	}
-	// Only expose ScaleConfig in the response when at least one non-default
-	// scale label is present. Detects configuration by checking for values
-	// that differ from the zero-value defaults (Idle.Replicas=0, Active.Replicas=1).
-	sc := ScaleConfigFromLabels(labels)
-	if sc.Idle.Replicas > 0 || sc.Idle.HasResources() ||
-		sc.Active.Replicas > 1 || sc.Active.HasResources() {
-		info.ScaleConfig = &sc
-	}
+	info.Groups = cfg.Groups
+	info.ReadyAfter = cfg.ReadyAfter
+	info.RunningHours = cfg.RunningHours
+	info.RunningDays = cfg.RunningDays
+	info.ReadyOnStart = cfg.ReadyOnStart
+	info.AntiAffinity = cfg.AntiAffinity
+	info.ScaleConfig = cfg.Scale
 }

--- a/pkg/sablier/instance_config.go
+++ b/pkg/sablier/instance_config.go
@@ -1,0 +1,114 @@
+package sablier
+
+import (
+	"log/slog"
+	"strconv"
+	"time"
+)
+
+// InstanceConfig is the typed, parsed form of the sablier.* labels an
+// instance carries. It is produced in one place, InstanceConfigFromLabels, at
+// the provider boundary; nothing else should interpret raw label strings.
+//
+// This is the first stage of splitting InstanceInfo (which today mixes
+// provider-reported state, parsed label configuration, the API wire format
+// and the persisted session record): the configuration now has one typed
+// home, while InstanceInfo keeps its flat legacy fields byte-identical on the
+// wire for API and store compatibility.
+type InstanceConfig struct {
+	// Enabled reports whether the instance opted into Sablier management
+	// (sablier.enable set to exactly "true").
+	Enabled bool `json:"enabled,omitempty"`
+	// Groups the instance belongs to (sablier.group). Only populated for
+	// enabled instances; defaults to ["default"] when the label is absent.
+	Groups []string `json:"groups,omitempty"`
+	// ReadyAfter is the settling delay after the instance first reports ready
+	// (sablier.ready-after). Zero means no extra wait.
+	ReadyAfter time.Duration `json:"readyAfter,omitempty"`
+	// ReadyOnStart marks the instance ready as soon as its start is
+	// dispatched, skipping the health check (sablier.ready-on-start).
+	ReadyOnStart bool `json:"readyOnStart,omitempty"`
+	// RunningHours is the validated daily keep-warm window
+	// (sablier.running-hours, "HH:MM-HH:MM"). It is kept in its validated
+	// string form because that is the serializable canonical representation;
+	// parse it with ParseRunningHours where the window is evaluated.
+	RunningHours string `json:"runningHours,omitempty"`
+	// RunningDays restricts RunningHours to specific weekdays
+	// (sablier.running-days). Empty means every day.
+	RunningDays string `json:"runningDays,omitempty"`
+	// AntiAffinity lists the groups this instance backs off from
+	// (sablier.anti-affinity).
+	AntiAffinity []string `json:"antiAffinity,omitempty"`
+	// Scale holds the idle/active resource profiles when any non-default
+	// scale-mode label is present (sablier.idle.* / sablier.active.*).
+	Scale *ScaleConfig `json:"scale,omitempty"`
+}
+
+// InstanceConfigFromLabels parses every sablier.* label into a typed
+// InstanceConfig. Invalid values are logged through l and ignored, keeping
+// the previous per-label warn-and-skip behavior. A nil logger falls back to
+// slog.Default().
+func InstanceConfigFromLabels(labels map[string]string, l *slog.Logger) InstanceConfig {
+	if l == nil {
+		l = slog.Default()
+	}
+
+	var cfg InstanceConfig
+	cfg.Enabled = labels[LabelEnable] == "true"
+	if cfg.Enabled {
+		cfg.Groups = ParseGroups(labels[LabelGroup])
+	}
+	if v := labels[LabelReadyAfter]; v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.ReadyAfter = d
+		} else {
+			l.Warn("invalid sablier.ready-after label value, ignoring",
+				slog.String("value", v),
+				slog.Any("error", err),
+			)
+		}
+	}
+	if v := labels[LabelRunningHours]; v != "" {
+		if _, err := ParseRunningHours(v); err == nil {
+			cfg.RunningHours = v
+		} else {
+			l.Warn("invalid sablier.running-hours label value, ignoring",
+				slog.String("value", v),
+				slog.Any("error", err),
+			)
+		}
+	}
+	if v := labels[LabelRunningDays]; v != "" {
+		if _, err := ParseRunningDays(v); err == nil {
+			cfg.RunningDays = v
+		} else {
+			l.Warn("invalid sablier.running-days label value, ignoring",
+				slog.String("value", v),
+				slog.Any("error", err),
+			)
+		}
+	}
+	if v := labels[LabelReadyOnStart]; v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			l.Warn("invalid sablier.ready-on-start label value, ignoring",
+				slog.String("value", v),
+				slog.Any("error", err),
+			)
+		} else {
+			cfg.ReadyOnStart = b
+		}
+	}
+	if v := labels[LabelAntiAffinity]; v != "" {
+		cfg.AntiAffinity = ParseAntiAffinity(v)
+	}
+	// Only expose Scale when at least one non-default scale label is present,
+	// detected by values that differ from the zero-value defaults
+	// (Idle.Replicas=0, Active.Replicas=1).
+	sc := ScaleConfigFromLabels(labels)
+	if sc.Idle.Replicas > 0 || sc.Idle.HasResources() ||
+		sc.Active.Replicas > 1 || sc.Active.HasResources() {
+		cfg.Scale = &sc
+	}
+	return cfg
+}

--- a/pkg/sablier/instance_config_test.go
+++ b/pkg/sablier/instance_config_test.go
@@ -1,0 +1,139 @@
+package sablier
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestInstanceConfigFromLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   InstanceConfig
+	}{
+		{
+			name:   "no labels",
+			labels: map[string]string{},
+			want:   InstanceConfig{},
+		},
+		{
+			name:   "enabled with default group",
+			labels: map[string]string{LabelEnable: "true"},
+			want:   InstanceConfig{Enabled: true, Groups: []string{"default"}},
+		},
+		{
+			name:   "enable accepts only the exact string true",
+			labels: map[string]string{LabelEnable: "1"},
+			want:   InstanceConfig{},
+		},
+		{
+			name:   "groups are not parsed for disabled instances",
+			labels: map[string]string{LabelEnable: "false", LabelGroup: "team-a"},
+			want:   InstanceConfig{},
+		},
+		{
+			name: "full configuration",
+			labels: map[string]string{
+				LabelEnable:       "true",
+				LabelGroup:        "team-a,team-b",
+				LabelReadyAfter:   "30s",
+				LabelReadyOnStart: "true",
+				LabelRunningHours: "09:00-18:00",
+				LabelRunningDays:  "Mon,Tue",
+				LabelAntiAffinity: "streaming",
+			},
+			want: InstanceConfig{
+				Enabled:      true,
+				Groups:       []string{"team-a", "team-b"},
+				ReadyAfter:   30 * time.Second,
+				ReadyOnStart: true,
+				RunningHours: "09:00-18:00",
+				RunningDays:  "Mon,Tue",
+				AntiAffinity: []string{"streaming"},
+			},
+		},
+		{
+			name: "invalid values are ignored, valid ones kept",
+			labels: map[string]string{
+				LabelEnable:       "true",
+				LabelReadyAfter:   "soon",
+				LabelReadyOnStart: "yes-please",
+				LabelRunningHours: "9am-6pm",
+				LabelRunningDays:  "Someday",
+			},
+			want: InstanceConfig{Enabled: true, Groups: []string{"default"}},
+		},
+		{
+			name: "scale config only when a non-default scale label is present",
+			labels: map[string]string{
+				LabelEnable:       "true",
+				LabelIdleReplicas: "1",
+			},
+			want: InstanceConfig{
+				Enabled: true,
+				Groups:  []string{"default"},
+				Scale:   &ScaleConfig{Idle: ResourceProfile{Replicas: 1}, Active: ResourceProfile{Replicas: 1}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := InstanceConfigFromLabels(tt.labels, nil)
+			assert.DeepEqual(t, tt.want, got)
+		})
+	}
+}
+
+func TestInstanceInfoIsEnabled(t *testing.T) {
+	t.Run("parsed config wins", func(t *testing.T) {
+		info := InstanceInfo{Enabled: "false", Config: &InstanceConfig{Enabled: true}}
+		assert.Assert(t, info.IsEnabled())
+	})
+	t.Run("falls back to the flat field on old records", func(t *testing.T) {
+		// A session record persisted by a version that predates Config.
+		old := `{"name":"web","enabled":"true","status":"ready","currentReplicas":1,"desiredReplicas":1}`
+		var info InstanceInfo
+		assert.NilError(t, json.Unmarshal([]byte(old), &info))
+		assert.Assert(t, info.Config == nil)
+		assert.Assert(t, info.IsEnabled())
+	})
+	t.Run("disabled without config", func(t *testing.T) {
+		assert.Assert(t, !InstanceInfo{Enabled: "1"}.IsEnabled())
+		assert.Assert(t, !InstanceInfo{}.IsEnabled())
+	})
+	t.Run("list entries share the semantics", func(t *testing.T) {
+		assert.Assert(t, InstanceConfiguration{Enabled: "true"}.IsEnabled())
+		assert.Assert(t, !InstanceConfiguration{Enabled: "1"}.IsEnabled())
+	})
+}
+
+// TestPopulateEnabledAndGroup_WireCompat pins the compatibility contract of
+// the first InstanceInfo split stage: the flat legacy fields keep their exact
+// names and raw values on the wire, and the typed config is strictly
+// additive under the "config" key.
+func TestPopulateEnabledAndGroup_WireCompat(t *testing.T) {
+	info := InstanceInfo{Name: "web"}
+	PopulateEnabledAndGroup(&info, map[string]string{
+		LabelEnable:       "true",
+		LabelGroup:        "team-a",
+		LabelRunningHours: "09:00-18:00",
+	})
+
+	raw, err := json.Marshal(info)
+	assert.NilError(t, err)
+	var m map[string]any
+	assert.NilError(t, json.Unmarshal(raw, &m))
+
+	// Legacy fields: identical names, raw string semantics preserved.
+	assert.Equal(t, "true", m["enabled"], "legacy enabled must stay the raw label string")
+	assert.DeepEqual(t, []any{"team-a"}, m["groups"])
+	assert.Equal(t, "09:00-18:00", m["runningHours"])
+
+	// Typed config: additive, under its own key, with the parsed boolean.
+	cfg, ok := m["config"].(map[string]any)
+	assert.Assert(t, ok, "config must be serialized additively")
+	assert.Equal(t, true, cfg["enabled"])
+}

--- a/pkg/sablier/instance_expired.go
+++ b/pkg/sablier/instance_expired.go
@@ -38,7 +38,7 @@ func onInstanceExpired(ctx context.Context, provider Provider, recorder metrics.
 					logger.WarnContext(ctx, "instance expired could not be inspected before stop", slog.String("instance", key), slog.Any("error", err))
 					return
 				}
-				if info.Enabled != "true" {
+				if !info.IsEnabled() {
 					logger.WarnContext(ctx, "instance expired but is not managed by sablier, skipping stop", slog.String("instance", key))
 					return
 				}

--- a/pkg/sablier/instance_request.go
+++ b/pkg/sablier/instance_request.go
@@ -103,7 +103,7 @@ func (s *Sablier) requestStart(ctx context.Context, name string, rejectUnlabeled
 		s.l.DebugContext(ctx, "pre-start inspect failed, using bare info", slog.String("instance", name), slog.Any("error", err))
 		info = InstanceInfo{Name: name, CurrentReplicas: 0, DesiredReplicas: 1}
 	}
-	if rejectUnlabeled && info.Enabled != "true" {
+	if rejectUnlabeled && !info.IsEnabled() {
 		return InstanceInfo{}, ErrInstanceNotManaged{Name: name}
 	}
 	info.Status = InstanceStatusStarting

--- a/pkg/sablier/running_hours_watch.go
+++ b/pkg/sablier/running_hours_watch.go
@@ -37,7 +37,7 @@ func (s *Sablier) reconcileRunningHours(ctx context.Context) {
 
 	now := time.Now()
 	for _, configured := range instances {
-		if configured.Enabled != "true" {
+		if !configured.IsEnabled() {
 			continue
 		}
 


### PR DESCRIPTION
## Finding

`InstanceInfo` ([instance.go](../blob/main/pkg/sablier/instance.go#L40-L86)) is **four things at once**:

1. **Provider-reported state** - `Status`, `CurrentReplicas`, `DesiredReplicas` (plus `ReadyAt`, whose own comment admits it "is set internally by Sablier and is never populated by a provider").
2. **Parsed-label configuration bag** - `Enabled` is a *string* compared against `"true"` in **six** scattered places (autostop, autowarm, expiration, request handling, running-hours watcher, and the parser itself); `RunningHours`/`RunningDays` are raw strings; `ReadyAfter`, `ReadyOnStart`, `AntiAffinity`, `ScaleConfig` ride along.
3. **The API wire format** - marshalled directly into responses and the SSE stream; every field is OpenAPI schema surface that reverse-proxy plugins can parse.
4. **The persisted session record** - the whole struct is JSON-serialized into the store, freezing stale label config into sessions.

Every feature adds a field here and touches all four concerns at once; nobody can tell which fields a provider must set, which Sablier owns, and which are configuration. Label parsing also warned through the **global** `slog`, bypassing the configured handler.

## Approach: staged, wire-compatible

The full split has two compatibility cliffs - the wire format (plugins) and the persisted records (upgrades with live state) - so it lands in stages. **This PR is stage 1, scoped to the configuration concern, and changes zero existing bytes on the wire.**

## What this stage does

* **One parser.** All `sablier.*` label interpretation now lives in `InstanceConfigFromLabels`, producing a typed `InstanceConfig` (`Enabled bool`, real `time.Duration`, validated window strings, `Scale *ScaleConfig`). It takes a logger (restoring per-instance context on warnings) instead of the global `slog`.
* **One semantics.** The six `Enabled == "true"` string comparisons collapse into `IsEnabled()` accessors on `InstanceInfo` and `InstanceConfiguration`. The `InstanceInfo` accessor prefers the parsed config and **falls back to the flat field** for session records persisted by older versions.
* **Compatibility preserved.** `PopulateEnabledAndGroup` (the function all five providers call) becomes a thin adapter: it stores the typed config under a new **additive** `config` key and mirrors it into the flat legacy fields byte-identically - `enabled` stays the raw label string the API has always exposed.

## Evidence it is behavior-preserving

* Every pre-existing `PopulateEnabledAndGroup` test (ready-after, groups, running-hours, anti-affinity, scale labels, blkio labels) **passes unchanged** - they assert the flat fields.
* A new `TestPopulateEnabledAndGroup_WireCompat` pins the contract: legacy keys keep their exact names and raw values, `config` is strictly additive.
* A new fallback test unmarshals a pre-`config` session record and asserts `IsEnabled()` still answers correctly.
* Full parser table test for `InstanceConfigFromLabels` (enable exact-match semantics, group gating, invalid-value warn-and-ignore, scale-presence condition).

`openapi.json` regenerated (gains the additive `sablier.InstanceConfig` schema); `make check-generate`, full test suite and `golangci-lint` pass.

## Next stages (separate PRs)

2. **API DTO in `internal/api`** so the wire format stops being the domain struct (pairs with the OpenAPI drift finding).
3. **Versioned session record** so the store stops persisting label configuration, and the flat config fields can then be dropped from `InstanceInfo`.
4. Provider contract cleanup (`ReadyAt` and friends move off the provider-facing type).

## Docs

No documentation impact beyond the regenerated OpenAPI spec: no labels, config options, or behavior changed.