### PR TITLE
refactor(api): session responses use explicit DTOs; published OpenAPI schema finally matches the wire

### DIFF
--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -1,10 +1,35 @@
 {
   "components": {
     "schemas": {
+      "api.InstanceEntryResponse": {
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "instance": {
+            "$ref": "#/components/schemas/sablier.InstanceInfo"
+          }
+        },
+        "type": "object"
+      },
       "api.SessionResponse": {
         "properties": {
           "session": {
-            "$ref": "#/components/schemas/sablier.SessionState"
+            "$ref": "#/components/schemas/api.SessionStateResponse"
+          }
+        },
+        "type": "object"
+      },
+      "api.SessionStateResponse": {
+        "properties": {
+          "instances": {
+            "items": {
+              "$ref": "#/components/schemas/api.InstanceEntryResponse"
+            },
+            "type": "array"
+          },
+          "status": {
+            "type": "string"
           }
         },
         "type": "object"
@@ -163,15 +188,6 @@
         },
         "type": "object"
       },
-      "sablier.InstanceInfoWithError": {
-        "properties": {
-          "error": {},
-          "instance": {
-            "$ref": "#/components/schemas/sablier.InstanceInfo"
-          }
-        },
-        "type": "object"
-      },
       "sablier.InstanceStatus": {
         "enum": [
           "completed",
@@ -292,17 +308,6 @@
           },
           "idle": {
             "$ref": "#/components/schemas/sablier.ResourceProfile"
-          }
-        },
-        "type": "object"
-      },
-      "sablier.SessionState": {
-        "properties": {
-          "instances": {
-            "additionalProperties": {
-              "$ref": "#/components/schemas/sablier.InstanceInfoWithError"
-            },
-            "type": "object"
           }
         },
         "type": "object"

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -1,10 +1,55 @@
 package api
 
-import "github.com/sablierapp/sablier/pkg/sablier"
+import (
+	"sort"
 
-// SessionResponse is the JSON body returned by the blocking strategy endpoint.
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
+
+// SessionResponse is the wire contract of the blocking strategy endpoint. It
+// is built explicitly from the domain session by NewSessionResponse, so the
+// handler returns exactly the type its OpenAPI annotation declares and the
+// generated schema matches the bytes on the wire (the previous ad-hoc
+// map+custom-marshaler pair had drifted: the published schema said `instances`
+// was a map and omitted `status`, while the wire carried an array plus
+// `status`).
 type SessionResponse struct {
-	Session *sablier.SessionState `json:"session"`
+	Session SessionStateResponse `json:"session"`
+}
+
+// SessionStateResponse mirrors the historical wire shape of a session: an
+// array of instance entries plus the aggregate session status ("ready" or
+// "not-ready"). Entries are sorted by instance name; the order was previously
+// map-iteration random and was never part of the contract.
+type SessionStateResponse struct {
+	Instances []InstanceEntryResponse `json:"instances"`
+	Status    string                  `json:"status"`
+}
+
+// InstanceEntryResponse is one instance of the session, with the error that
+// prevented it from starting, if any.
+type InstanceEntryResponse struct {
+	Instance sablier.InstanceInfo `json:"instance"`
+	Error    string               `json:"error,omitempty"`
+}
+
+// NewSessionResponse maps a domain session to its wire representation.
+func NewSessionResponse(s *sablier.SessionState) SessionResponse {
+	instances := make([]InstanceEntryResponse, 0, len(s.Instances))
+	for _, v := range s.Instances {
+		entry := InstanceEntryResponse{Instance: v.Instance}
+		if v.Error != nil {
+			entry.Error = v.Error.Error()
+		}
+		instances = append(instances, entry)
+	}
+	sort.Slice(instances, func(i, j int) bool {
+		return instances[i].Instance.Name < instances[j].Instance.Name
+	})
+	return SessionResponse{Session: SessionStateResponse{
+		Instances: instances,
+		Status:    s.Status(),
+	}}
 }
 
 // ThemesResponse is the JSON body returned by the themes endpoint.

--- a/internal/api/responses_test.go
+++ b/internal/api/responses_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+	"gotest.tools/v3/assert"
+)
+
+func TestNewSessionResponse(t *testing.T) {
+	t.Run("sorted instances with status and error string", func(t *testing.T) {
+		s := &sablier.SessionState{
+			Instances: map[string]sablier.InstanceInfoWithError{
+				"b": {Instance: sablier.InstanceInfo{Name: "b", Status: sablier.InstanceStatusReady}},
+				"a": {Instance: sablier.InstanceInfo{Name: "a"}, Error: errors.New("provider unavailable")},
+			},
+		}
+
+		resp := NewSessionResponse(s)
+
+		assert.Equal(t, "not-ready", resp.Session.Status)
+		assert.Equal(t, 2, len(resp.Session.Instances))
+		assert.Equal(t, "a", resp.Session.Instances[0].Instance.Name)
+		assert.Equal(t, "provider unavailable", resp.Session.Instances[0].Error)
+		assert.Equal(t, "b", resp.Session.Instances[1].Instance.Name)
+		assert.Equal(t, "", resp.Session.Instances[1].Error)
+	})
+
+	t.Run("empty session serializes an empty array, not null", func(t *testing.T) {
+		resp := NewSessionResponse(&sablier.SessionState{})
+		raw, err := json.Marshal(resp)
+		assert.NilError(t, err)
+		assert.Assert(t, string(raw) != "" && !containsSub(string(raw), `"instances":null`), "instances must be [] on the wire: %s", raw)
+	})
+}
+
+// TestSessionResponseWireShape pins the historical wire contract of the
+// blocking endpoint, previously produced by an ad-hoc map plus a custom
+// SessionState marshaler: an object under "session" holding an ARRAY of
+// {instance, error} entries and a "status" string. The generated OpenAPI
+// schema is derived from these DTO types, so schema and wire can no longer
+// drift apart.
+func TestSessionResponseWireShape(t *testing.T) {
+	s := &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"web": {Instance: sablier.InstanceInfo{Name: "web", Status: sablier.InstanceStatusReady, CurrentReplicas: 1, DesiredReplicas: 1}},
+		},
+	}
+
+	raw, err := json.Marshal(NewSessionResponse(s))
+	assert.NilError(t, err)
+
+	var m map[string]any
+	assert.NilError(t, json.Unmarshal(raw, &m))
+
+	session, ok := m["session"].(map[string]any)
+	assert.Assert(t, ok, "top-level session object expected")
+	assert.Equal(t, "ready", session["status"])
+
+	instances, ok := session["instances"].([]any)
+	assert.Assert(t, ok, "instances must be an array on the wire")
+	entry := instances[0].(map[string]any)
+	instance := entry["instance"].(map[string]any)
+	assert.Equal(t, "web", instance["name"])
+	_, hasError := entry["error"]
+	assert.Assert(t, !hasError, "error must be omitted when empty")
+}
+
+func containsSub(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/start_blocking.go
+++ b/internal/api/start_blocking.go
@@ -93,6 +93,6 @@ func StartBlocking(router *gin.RouterGroup, s *ServeStrategy) {
 
 		AddSablierHeader(c, sessionState)
 
-		c.JSON(http.StatusOK, map[string]any{"session": sessionState})
+		c.JSON(http.StatusOK, NewSessionResponse(sessionState))
 	})
 }

--- a/internal/api/theme_list.go
+++ b/internal/api/theme_list.go
@@ -16,9 +16,7 @@ import (
 // @Router       /api/dynamic/themes [get]
 func ListThemes(router *gin.RouterGroup, s *ServeStrategy) {
 	handler := func(c *gin.Context) {
-		c.JSON(http.StatusOK, map[string]any{
-			"themes": s.Theme.List(),
-		})
+		c.JSON(http.StatusOK, ThemesResponse{Themes: s.Theme.List()})
 	}
 
 	router.GET("/themes", handler)

--- a/pkg/sablier/session.go
+++ b/pkg/sablier/session.go
@@ -1,7 +1,6 @@
 package sablier
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -60,23 +59,3 @@ func (s *SessionState) Status() string {
 	return "not-ready"
 }
 
-func (s *SessionState) MarshalJSON() ([]byte, error) {
-	type instanceJSON struct {
-		Instance InstanceInfo `json:"instance"`
-		Error    string       `json:"error,omitempty"`
-	}
-
-	instances := make([]instanceJSON, 0, len(s.Instances))
-	for _, v := range s.Instances {
-		item := instanceJSON{Instance: v.Instance}
-		if v.Error != nil {
-			item.Error = v.Error.Error()
-		}
-		instances = append(instances, item)
-	}
-
-	return json.Marshal(map[string]any{
-		"instances": instances,
-		"status":    s.Status(),
-	})
-}

--- a/pkg/sablier/session_test.go
+++ b/pkg/sablier/session_test.go
@@ -91,30 +91,6 @@ func TestSessionState_Status(t *testing.T) {
 	assert.Equal(t, notReady.Status(), "not-ready")
 }
 
-func TestSessionState_MarshalJSON(t *testing.T) {
-	s := &sablier.SessionState{
-		Instances: map[string]sablier.InstanceInfoWithError{
-			"a": {Instance: sablier.InstanceInfo{Name: "a", Status: sablier.InstanceStatusReady}},
-		},
-	}
-
-	b, err := s.MarshalJSON()
-	assert.NilError(t, err)
-	assert.Assert(t, contains(string(b), `"status":"ready"`))
-}
-
-func TestSessionState_MarshalJSON_ErrorField(t *testing.T) {
-	s := &sablier.SessionState{
-		Instances: map[string]sablier.InstanceInfoWithError{
-			"a": {Instance: sablier.InstanceInfo{Name: "a"}, Error: errors.New("provider unavailable")},
-		},
-	}
-
-	b, err := s.MarshalJSON()
-	assert.NilError(t, err)
-	assert.Assert(t, contains(string(b), `"error":"provider unavailable"`))
-}
-
 func contains(s, sub string) bool {
 	return len(sub) == 0 || (len(s) >= len(sub) && (indexOf(s, sub) >= 0))
 }


### PR DESCRIPTION
## Finding

Stage 2 of the `InstanceInfo`/session split (stage 1: #1023). This one targets the **wire-format facet**: the API contract was the domain struct, and the published contract was already wrong.

The blocking endpoint returned an ad-hoc map with the domain object inside:

```go
c.JSON(http.StatusOK, map[string]any{"session": sessionState})
```

whose bytes were shaped by a custom `SessionState.MarshalJSON` - but **swag generates the OpenAPI schema from struct tags, not custom marshalers**. The two have disagreed since day one:

| | published schema said | the wire actually carried |
|---|---|---|
| `instances` | a **map** of name -> entry | an **array** of `{instance, error}` entries |
| `status` | *(absent)* | `"ready"` / `"not-ready"` |
| `error` | an empty **object** | a **string** |

Anyone building a reverse-proxy plugin against the published `openapi.json` parsed the wrong shape. `SessionResponse`/`ThemesResponse` existed *only* to feed annotations; handlers returned ad-hoc maps, so nothing could keep them in sync. And every future field on the domain struct silently became API surface.

## Discovery

Found during the API-layer design review by diffing `SessionState.MarshalJSON`'s output against the `sablier.SessionState` schema in the committed `openapi.json`.

## Fix

* `NewSessionResponse` maps the domain session into explicit DTOs (`SessionResponse` -> `SessionStateResponse` -> `InstanceEntryResponse`), and the handler **returns the annotated type**. The themes endpoint likewise returns the real `ThemesResponse`. Schema and wire are now generated from the same types - they cannot drift again.
* `SessionState.MarshalJSON` is **deleted**: the domain type no longer carries wire concerns. Its tests move to the API package against the DTO.
* `openapi.json` regenerated: it now tells the truth (array + `status` + string `error`). This changes the *published spec*, not the wire - the direction that fixes consumers.

## Wire compatibility

Byte-shape unchanged, with one deliberate improvement: instance entries are now **sorted by name** instead of map-iteration random. Ordering was never part of the contract and non-determinism was only ever a nuisance.

The inner `instance` object intentionally still serializes the domain `InstanceInfo` - trimming it to "the stable fields plugins need" is a breaking change that belongs with the API-versioning work, and stage 3 (versioned session record) is the prerequisite for dropping the flat fields.

## Tests

* `TestNewSessionResponse` - sorted entries, error-string mapping, status aggregation, empty-session-as-`[]`.
* `TestSessionResponseWireShape` - pins array + `status` + omitted-empty-`error`, so the historical contract is enforced by test rather than by accident.
* Migrated the two former `MarshalJSON` tests; full API + core suites and `golangci-lint` pass; `make check-generate` green.

## Docs

`openapi.json` is the only doc artifact affected (regenerated; now accurate). No labels/config/behavior change.