### PR TITLE
feat(kubernetes): add delegated scaling via activate/deactivate intent webhooks

### DIFF
--- a/docs/content/how-to-guides/scaling-resources/delegated-scaling.md
+++ b/docs/content/how-to-guides/scaling-resources/delegated-scaling.md
@@ -1,0 +1,190 @@
+---
+title: Delegated scaling (KEDA)
+description: Let an external scaler own the replica count and drive it from Sablier's activate/deactivate webhooks.
+weight: 126
+compatibility:
+  docker: unsupported
+  swarm: unsupported
+  kubernetes: supported
+  podman: unsupported
+  proxmox: impossible
+---
+
+{{< compatibility >}}
+
+This guide shows you how to hand the replica count to an **external scaler** — typically a [KEDA](https://keda.sh) `ScaledObject` — while Sablier keeps deciding *when* a workload should be up. Instead of writing `spec.replicas` itself, Sablier emits `activate` and `deactivate` **intent webhooks** that your scaler acts on.
+
+```yaml
+# Deployment (Kubernetes)
+metadata:
+  labels:
+    sablier.enable: "true"
+  annotations:
+    sablier.group: "myapp"
+    sablier.delegate-scaling: "true"
+```
+
+## Why delegated scaling exists
+
+KEDA's `ScaledObject` continuously reconciles a workload's replica count from its triggers, and it enforces `minReplicaCount` as a floor. When Sablier and KEDA both write `spec.replicas`, they fight:
+
+1. A session expires, so Sablier scales the Deployment to **zero**.
+2. KEDA's next reconcile sees the replica count below `minReplicaCount` and restores it to **one**.
+3. That scale-from-zero is observed as a `started` event, so Sablier believes the workload is up — and it stays **latched at one replica forever**, never returning to zero.
+
+Sablier writing replicas directly is fundamentally incompatible with any controller that also owns the replica count. Delegated scaling resolves this by making Sablier **stop writing replicas** for the labelled workload. It emits its intent as a webhook, and the scaler — which already owns the replica count — pauses or resumes its own reconciliation in response.
+
+> This is the KEDA/HPA scale-to-zero coexistence problem discussed in [sablier#130](https://github.com/sablierapp/sablier/issues/130).
+
+```mermaid
+flowchart LR
+    req["Session requested"] -->|activate webhook| scaler["External scaler<br/>(KEDA ScaledObject)"]
+    exp["Session expired"] -->|deactivate webhook| scaler
+    scaler -->|owns spec.replicas| wl["Workload"]
+```
+
+## The label
+
+| Label | Format | Default | Example |
+|-------|--------|---------|---------|
+| `sablier.delegate-scaling` | Boolean | `false` | `"true"` |
+
+When `sablier.delegate-scaling=true`:
+
+- Sablier **never** calls the provider's start/stop (it never writes `spec.replicas`).
+- A session request emits an `activate` intent instead of starting the workload.
+- A session expiry (and the unregistered-instance scan) emits a `deactivate` intent instead of scaling to zero.
+- The workload is **exempt** from the externally-started stopper (`provider.auto-stop-externally-started`), because the scaler legitimately owns its replica count while active.
+
+Readiness is still observed the normal way: on subsequent requests Sablier inspects the workload and reports it ready once the scaler has brought it up.
+
+{{< callout type="info" >}}
+On Kubernetes, `sablier.enable` must be a **label** (discovery uses a label selector). `sablier.delegate-scaling` may be set as either a label or an annotation; an annotation wins when both are present.
+{{< /callout >}}
+
+## Intent webhooks
+
+Delegated scaling introduces two new webhook event types, delivered with the same [payload format](/how-to-guides/webhooks/#payload-format) as the lifecycle events:
+
+```json
+{
+  "event": "activate",
+  "instance": { "name": "myapp" },
+  "timestamp": "2025-01-15T10:30:00Z"
+}
+```
+
+```json
+{
+  "event": "deactivate",
+  "instance": { "name": "myapp" },
+  "timestamp": "2025-01-15T10:45:00Z"
+}
+```
+
+### Explicit subscription is required
+
+Unlike the lifecycle events (`started`/`stopped`), where an endpoint with no `events` filter receives **all** of them, intent events require an **explicit subscription**. An endpoint receives `activate`/`deactivate` **only** if its `events` filter lists them:
+
+```yaml
+# sablier.yaml
+webhooks:
+  endpoints:
+    # This endpoint drives the scaler — it opts in explicitly.
+    - url: http://keda-adapter.default.svc/scale
+      events:
+        - activate
+        - deactivate
+
+    # This existing endpoint has no filter. It keeps receiving started/stopped
+    # and receives ZERO intent events — no new traffic.
+    - url: https://uptime.example.com/api/push/xxxx
+```
+
+This makes delegated scaling **safe to enable incrementally**: turning the label on for a workload sends no intent traffic anywhere until an endpoint deliberately subscribes.
+
+### Ordering and retries
+
+Intent delivery is **load-bearing** — a reordered `deactivate`→`activate`, or a silently dropped delivery, would leave the scaler in the wrong state. So intent events are delivered on a separate watch with stronger guarantees than the best-effort lifecycle path:
+
+- Events are delivered **strictly in order**, one at a time — the receiver observes them in the exact order Sablier emitted them.
+- Each delivery is retried up to **5 attempts** with a linear backoff before Sablier gives up and moves on to the next event.
+
+This contrasts with lifecycle (`started`/`stopped`) delivery, which is fire-and-forget with no retry (see [Delivery semantics](/how-to-guides/webhooks/#delivery-semantics)).
+
+## KEDA walkthrough
+
+The receiver's job is to translate an `activate`/`deactivate` into pausing or unpausing the `ScaledObject`, which KEDA does through the `autoscaling.keda.sh/paused` annotation. Pausing at the current replica count keeps the workload up; pausing at zero (or letting normal reconciliation resume) idles it.
+
+### 1. Label the workload
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+  labels:
+    app: myapp
+    sablier.enable: "true"
+  annotations:
+    sablier.group: "myapp"
+    sablier.delegate-scaling: "true"
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+        - name: myapp
+          image: myapp:latest
+```
+
+### 2. Let KEDA own the replica count
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: myapp
+spec:
+  scaleTargetRef:
+    name: myapp
+  minReplicaCount: 0
+  maxReplicaCount: 3
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "70"
+```
+
+### 3. Point Sablier's intent webhook at your adapter
+
+```yaml
+# sablier.yaml
+webhooks:
+  endpoints:
+    - url: http://keda-adapter.default.svc/scale
+      events:
+        - activate
+        - deactivate
+```
+
+### 4. Translate intents into pause/unpause
+
+Your adapter receives the intent payload and patches the `ScaledObject`. On `activate`, remove the paused annotation (or set it to keep the workload up) so KEDA resumes normal autoscaling; on `deactivate`, allow it to fall back to `minReplicaCount: 0`.
+
+```bash
+# activate: resume KEDA autoscaling (workload can scale up)
+kubectl annotate scaledobject myapp autoscaling.keda.sh/paused-
+
+# deactivate: pause at zero replicas (workload stays idle)
+kubectl annotate --overwrite scaledobject myapp autoscaling.keda.sh/paused-replicas=0
+```
+
+Because Sablier never touches `spec.replicas`, KEDA remains the single writer of the replica count and the scale-to-zero race disappears.

--- a/docs/content/how-to-guides/webhooks.md
+++ b/docs/content/how-to-guides/webhooks.md
@@ -33,9 +33,22 @@ Common uses:
 |-------|----------|---------|-------------|
 | `url` | Yes | None | Full HTTP(S) URL to POST events to. |
 | `headers` | No | `{}` | Key/value map of HTTP request headers (e.g. `Authorization`). |
-| `events` | No | all | Event types that trigger this endpoint. Accepted values: `started`, `stopped`. Omit or leave empty to receive **all** events. |
+| `events` | No | all | Event types that trigger this endpoint. Accepted values: `started`, `stopped` (lifecycle) and `activate`, `deactivate` (intent). Omit or leave empty to receive **all lifecycle** events. |
 
 Multiple endpoints are supported. Each endpoint is evaluated independently so you can send different event types to different targets.
+
+### Event types
+
+| Event | Kind | Fired when |
+|-------|------|-----------|
+| `started` | Lifecycle | Sablier observes a managed instance scale up. |
+| `stopped` | Lifecycle | Sablier observes a managed instance scale to zero. |
+| `activate` | Intent | Sablier wants a [delegated-scaling](/how-to-guides/scaling-resources/delegated-scaling/) instance brought up (an external scaler owns the replica count). |
+| `deactivate` | Intent | Sablier wants a delegated-scaling instance idled. |
+
+**Lifecycle** events (`started`/`stopped`) are observations of an actual scale transition. An endpoint with an empty `events` filter receives all of them.
+
+**Intent** events (`activate`/`deactivate`) are emitted only for workloads labelled `sablier.delegate-scaling=true`. They require an **explicit subscription**: an endpoint receives them **only** if its `events` filter lists them — there is no empty-means-all fallback, so existing unfiltered endpoints see zero intent traffic. See [Delegated scaling](/how-to-guides/scaling-resources/delegated-scaling/).
 
 ### CLI / environment variables
 
@@ -63,7 +76,7 @@ Every delivery is an HTTP `POST` with `Content-Type: application/json`. The body
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `event` | `string` | Normalized event type: `"started"` or `"stopped"`. |
+| `event` | `string` | Normalized event type: `"started"` or `"stopped"` (lifecycle), or `"activate"` / `"deactivate"` (intent). |
 | `instance.name` | `string` | Name of the container / service / workload as known to Sablier. |
 | `timestamp` | RFC 3339 UTC | Time at which Sablier processed the event. |
 
@@ -71,11 +84,23 @@ The payload is intentionally minimal and **provider-agnostic**. The same structu
 
 ## Delivery semantics
 
-- Webhooks are delivered **asynchronously** (fire-and-forget). They do not block the event loop.
+Delivery guarantees differ by event kind.
+
+**Lifecycle events** (`started`/`stopped`) are best-effort:
+
+- Delivered **asynchronously** (fire-and-forget). They do not block the event loop.
 - Each endpoint is called in its own goroutine.
 - HTTP errors (status 400 or above) and network errors are **logged** but do **not** affect Sablier's behavior.
 - The HTTP client uses a **10-second timeout** per request.
-- There is no built-in retry. If a delivery fails, the event is lost. Use an intermediary queue (e.g., a message broker) in front of your endpoint if at-least-once delivery is required.
+- There is **no retry**. If a delivery fails, the event is lost. Use an intermediary queue (e.g., a message broker) in front of your endpoint if at-least-once delivery is required.
+
+**Intent events** (`activate`/`deactivate`) are delivered with stronger guarantees, because a reordered or dropped delivery would leave the external scaler in the wrong state:
+
+- Delivered **strictly in order**, one event at a time — the receiver observes them in the exact order Sablier emitted them.
+- Each delivery is retried up to **5 attempts** with a linear backoff before Sablier gives up and moves on.
+- The same 10-second per-request timeout applies.
+
+See [Delegated scaling](/how-to-guides/scaling-resources/delegated-scaling/) for the full picture.
 
 ## Example: Uptime Kuma integration
 

--- a/docs/content/reference/labels.md
+++ b/docs/content/reference/labels.md
@@ -63,6 +63,7 @@ sablier-group-my-group  # one tag per group
 | [`sablier.running-hours`](#label-sablier-running-hours) | A daily keep-warm window in local time. |
 | [`sablier.running-days`](#label-sablier-running-days) | Restricts the `sablier.running-hours` window to specific weekdays. |
 | [`sablier.anti-affinity`](#label-sablier-anti-affinity) | Lists the group names this instance backs off from; it is forced idle while any listed group has an active session. |
+| [`sablier.delegate-scaling`](#label-sablier-delegate-scaling) | Opts the instance into delegated scaling: Sablier never writes the replica count and instead emits "activate"/"deactivate" intent webhooks for an external scaler (e.g. a KEDA ScaledObject) to act on. |
 | [`sablier.idle.replicas`](#label-sablier-idle-replicas) | The replica count when idle. |
 | [`sablier.idle.cpu`](#label-sablier-idle-cpu) | The CPU limit applied when the session expires. |
 | [`sablier.idle.memory`](#label-sablier-idle-memory) | The memory limit applied when the session expires. |
@@ -169,6 +170,20 @@ Kubernetes must set a multi-value list as an **annotation**. Not supported on Pr
 {{< /callout >}}
 
 [Learn more](/how-to-guides/anti-affinity/)
+
+### `sablier.delegate-scaling` {#label-sablier-delegate-scaling}
+
+Opts the instance into delegated scaling: Sablier never writes the replica count and instead emits "activate"/"deactivate" intent webhooks for an external scaler (e.g. a KEDA ScaledObject) to act on.
+
+{{< badge "boolean" >}} {{< badge content="Next release" >}}
+
+Example: `"true"`
+
+{{< callout type="info" >}}
+Kubernetes only.
+{{< /callout >}}
+
+[Learn more](/how-to-guides/scaling-resources/delegated-scaling/)
 
 ### `sablier.idle.replicas` {#label-sablier-idle-replicas}
 

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -114,6 +114,10 @@
             },
             "type": "array"
           },
+          "delegateScaling": {
+            "description": "DelegateScaling opts the instance into delegated scaling\n(sablier.delegate-scaling): Sablier never writes the replica count and\ninstead emits activate/deactivate intent webhooks for an external scaler\n(e.g. a KEDA ScaledObject) to act on.",
+            "type": "boolean"
+          },
           "enabled": {
             "description": "Enabled reports whether the instance opted into Sablier management\n(sablier.enable set to exactly \"true\").",
             "type": "boolean"

--- a/pkg/provider/kubernetes/cnpgcluster_list.go
+++ b/pkg/provider/kubernetes/cnpgcluster_list.go
@@ -58,9 +58,10 @@ func (p *Provider) clusterToInstance(u *unstructured.Unstructured) sablier.Insta
 	parsed := ClusterName(u.GetNamespace(), u.GetName(), ParseOptions{Delimiter: p.delimiter})
 
 	return sablier.InstanceConfiguration{
-		Name:    parsed.Original,
-		Groups:  groups,
-		Enabled: enabled,
+		Name:      parsed.Original,
+		Groups:    groups,
+		Enabled:   enabled,
+		Delegated: delegatedScaling(config),
 	}
 }
 

--- a/pkg/provider/kubernetes/deployment_list.go
+++ b/pkg/provider/kubernetes/deployment_list.go
@@ -42,9 +42,10 @@ func (p *Provider) deploymentToInstance(d *v1.Deployment) sablier.InstanceConfig
 	parsed := DeploymentName(d, ParseOptions{Delimiter: p.delimiter})
 
 	return sablier.InstanceConfiguration{
-		Name:    parsed.Original,
-		Groups:  groups,
-		Enabled: enabled,
+		Name:      parsed.Original,
+		Groups:    groups,
+		Enabled:   enabled,
+		Delegated: delegatedScaling(config),
 	}
 }
 

--- a/pkg/provider/kubernetes/deployment_list_test.go
+++ b/pkg/provider/kubernetes/deployment_list_test.go
@@ -1,0 +1,65 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestDeploymentToInstance_Delegated verifies that sablier.delegate-scaling is
+// read from the merged label/annotation config onto InstanceConfiguration.Delegated,
+// so the list path carries it without an extra inspect.
+func TestDeploymentToInstance_Delegated(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      map[string]string
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:   "absent means not delegated",
+			labels: map[string]string{"sablier.enable": "true"},
+			want:   false,
+		},
+		{
+			name:   "set via label",
+			labels: map[string]string{"sablier.enable": "true", "sablier.delegate-scaling": "true"},
+			want:   true,
+		},
+		{
+			name:        "set via annotation",
+			labels:      map[string]string{"sablier.enable": "true"},
+			annotations: map[string]string{"sablier.delegate-scaling": "true"},
+			want:        true,
+		},
+		{
+			name:        "annotation overrides label",
+			labels:      map[string]string{"sablier.enable": "true", "sablier.delegate-scaling": "false"},
+			annotations: map[string]string{"sablier.delegate-scaling": "true"},
+			want:        true,
+		},
+		{
+			name:   "invalid value is treated as false",
+			labels: map[string]string{"sablier.enable": "true", "sablier.delegate-scaling": "maybe"},
+			want:   false,
+		},
+	}
+
+	p := &Provider{delimiter: "_"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &v1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "app",
+					Namespace:   "ns",
+					Labels:      tt.labels,
+					Annotations: tt.annotations,
+				},
+			}
+			got := p.deploymentToInstance(d)
+			assert.Equal(t, got.Delegated, tt.want)
+		})
+	}
+}

--- a/pkg/provider/kubernetes/sablier_config.go
+++ b/pkg/provider/kubernetes/sablier_config.go
@@ -1,6 +1,11 @@
 package kubernetes
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
 
 // sablierConfigPrefix is the common prefix for all Sablier configuration keys.
 const sablierConfigPrefix = "sablier."
@@ -36,3 +41,10 @@ func sablierConfig(labels, annotations map[string]string) map[string]string {
 	return merged
 }
 
+// delegatedScaling reports whether the merged Sablier config opts the workload
+// into delegated scaling (sablier.delegate-scaling). Invalid values are treated
+// as false, mirroring the warn-and-skip parsing in InstanceConfigFromLabels.
+func delegatedScaling(config map[string]string) bool {
+	b, _ := strconv.ParseBool(config[sablier.LabelDelegateScaling])
+	return b
+}

--- a/pkg/provider/kubernetes/statefulset_list.go
+++ b/pkg/provider/kubernetes/statefulset_list.go
@@ -42,9 +42,10 @@ func (p *Provider) statefulSetToInstance(ss *v1.StatefulSet) sablier.InstanceCon
 	parsed := StatefulSetName(ss, ParseOptions{Delimiter: p.delimiter})
 
 	return sablier.InstanceConfiguration{
-		Name:    parsed.Original,
-		Groups:  groups,
-		Enabled: enabled,
+		Name:      parsed.Original,
+		Groups:    groups,
+		Enabled:   enabled,
+		Delegated: delegatedScaling(config),
 	}
 }
 

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -18,6 +18,17 @@ const (
 	InstanceEventUpdated InstanceEventType = "updated"
 	// InstanceEventRemoved fires when an instance is permanently deleted from the provider.
 	InstanceEventRemoved InstanceEventType = "removed"
+
+	// InstanceEventActivate is an intent event: Sablier wants the instance brought
+	// up. Unlike InstanceEventStarted (an observation of an actual scale-from-zero),
+	// this expresses intent and is emitted only for delegated-scaling instances, whose
+	// replica count is owned by an external scaler (e.g. a KEDA ScaledObject) rather
+	// than written by Sablier directly.
+	InstanceEventActivate InstanceEventType = "activate"
+	// InstanceEventDeactivate is an intent event: Sablier wants the instance idled to
+	// zero. It is the deactivate counterpart to InstanceEventActivate and, like it, is
+	// emitted only for delegated-scaling instances.
+	InstanceEventDeactivate InstanceEventType = "deactivate"
 )
 
 // InstanceEventsOptions controls which events InstanceEvents streams.

--- a/pkg/sablier/autostop.go
+++ b/pkg/sablier/autostop.go
@@ -23,11 +23,11 @@ func (s *Sablier) StopAllUnregisteredInstances(ctx context.Context) error {
 		return err
 	}
 
-	unregistered := make([]string, 0)
+	unregistered := make([]InstanceConfiguration, 0)
 	for _, instance := range instances {
 		_, err = s.sessions.Get(ctx, instance.Name)
 		if errors.Is(err, store.ErrKeyNotFound) {
-			unregistered = append(unregistered, instance.Name)
+			unregistered = append(unregistered, instance)
 		}
 	}
 
@@ -35,22 +35,25 @@ func (s *Sablier) StopAllUnregisteredInstances(ctx context.Context) error {
 
 	waitGroup := errgroup.Group{}
 
-	for _, name := range unregistered {
-		waitGroup.Go(s.stopFunc(ctx, name))
+	for _, instance := range unregistered {
+		waitGroup.Go(s.stopFunc(ctx, instance))
 	}
 
 	return waitGroup.Wait()
 }
 
-func (s *Sablier) stopFunc(ctx context.Context, name string) func() error {
+func (s *Sablier) stopFunc(ctx context.Context, instance InstanceConfiguration) func() error {
 	return func() error {
-		err := s.provider.InstanceStop(ctx, name)
-		if err != nil {
-			s.l.ErrorContext(ctx, "failed to stop instance", slog.String("instance", name), slog.Any("error", err))
+		// Route through s.stop so delegated instances are deactivated via an intent
+		// event (the Delegated flag comes from the list, no extra inspect needed)
+		// rather than scaled to zero directly.
+		info := InstanceInfo{Name: instance.Name, Config: &InstanceConfig{DelegateScaling: instance.Delegated}}
+		if err := s.stop(ctx, instance.Name, info); err != nil {
+			s.l.ErrorContext(ctx, "failed to stop instance", slog.String("instance", instance.Name), slog.Any("error", err))
 			return err
 		}
-		s.metrics.RecordInstanceStop(name, "unregistered")
-		s.l.InfoContext(ctx, "stopped unregistered instance", slog.String("instance", name), slog.String("reason", "instance is enabled but not started by Sablier"))
+		s.metrics.RecordInstanceStop(instance.Name, "unregistered")
+		s.l.InfoContext(ctx, "stopped unregistered instance", slog.String("instance", instance.Name), slog.String("reason", "instance is enabled but not started by Sablier"))
 		return nil
 	}
 }
@@ -101,6 +104,13 @@ func (s *Sablier) WatchAndStopExternallyStarted(ctx context.Context) {
 			}
 			// Only act on Sablier-managed instances.
 			if !info.Info.IsEnabled() {
+				continue
+			}
+			// Delegated instances are scaled by an external scaler (e.g. KEDA),
+			// which legitimately owns their replica count while active. Never
+			// force-stop them here, or we would fight that scaler.
+			if info.Info.IsDelegated() {
+				s.l.DebugContext(ctx, "externally started instance is delegated, leaving to external scaler", slog.String("instance", info.Info.Name))
 				continue
 			}
 			if s.isStartedByUs(ctx, info.Info.Name) {

--- a/pkg/sablier/autostop_test.go
+++ b/pkg/sablier/autostop_test.go
@@ -267,3 +267,31 @@ func TestWatchAndStopExternallyStarted_EventStreamClosed(t *testing.T) {
 		t.Fatal("timed out waiting for reconciliation after stream closure")
 	}
 }
+
+// TestStopAllUnregisteredInstances_Delegated emits a deactivate intent for an
+// unregistered delegated instance instead of scaling it to zero directly (the
+// absence of an InstanceStop EXPECT makes gomock fail if it is called).
+func TestStopAllUnregisteredInstances_Delegated(t *testing.T) {
+	manager, sessions, provider, rec := setupSablierWithMetrics(t)
+	ctx := t.Context()
+
+	provider.EXPECT().InstanceList(ctx, gomock.Any()).Return([]sablier.InstanceConfiguration{
+		{Name: "app", Enabled: "true", Delegated: true},
+	}, nil)
+	sessions.EXPECT().Get(ctx, "app").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+
+	stream := manager.IntentEvents(ctx)
+
+	err := manager.StopAllUnregisteredInstances(ctx)
+	assert.NilError(t, err)
+
+	select {
+	case ev := <-stream.Events:
+		assert.Equal(t, string(ev.Type), "deactivate")
+		assert.Equal(t, ev.Info.Name, "app")
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a deactivate intent event")
+	}
+
+	assert.Assert(t, containsCall(rec.snapshot(), "stop:app/unregistered"))
+}

--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -104,6 +104,14 @@ func (instance InstanceInfo) IsEnabled() bool {
 	return instance.Enabled == "true"
 }
 
+// IsDelegated reports whether the instance uses delegated scaling
+// (sablier.delegate-scaling=true): Sablier emits activate/deactivate intent
+// webhooks instead of writing the replica count, leaving the actual scaling to
+// an external scaler.
+func (instance InstanceInfo) IsDelegated() bool {
+	return instance.Config != nil && instance.Config.DelegateScaling
+}
+
 // BlkioWeightDevice holds a per-device I/O scheduling weight override.
 type BlkioWeightDevice struct {
 	Path   string `json:"path"`
@@ -180,6 +188,9 @@ type InstanceConfiguration struct {
 	Name    string
 	Groups  []string
 	Enabled string
+	// Delegated mirrors sablier.delegate-scaling on the list path so autostop can
+	// route through an intent event without an extra inspect. See InstanceInfo.IsDelegated.
+	Delegated bool
 }
 
 // IsEnabled reports whether the listed instance opted into Sablier management

--- a/pkg/sablier/instance_config.go
+++ b/pkg/sablier/instance_config.go
@@ -39,6 +39,11 @@ type InstanceConfig struct {
 	// AntiAffinity lists the groups this instance backs off from
 	// (sablier.anti-affinity).
 	AntiAffinity []string `json:"antiAffinity,omitempty"`
+	// DelegateScaling opts the instance into delegated scaling
+	// (sablier.delegate-scaling): Sablier never writes the replica count and
+	// instead emits activate/deactivate intent webhooks for an external scaler
+	// (e.g. a KEDA ScaledObject) to act on.
+	DelegateScaling bool `json:"delegateScaling,omitempty"`
 	// Scale holds the idle/active resource profiles when any non-default
 	// scale-mode label is present (sablier.idle.* / sablier.active.*).
 	Scale *ScaleConfig `json:"scale,omitempty"`
@@ -101,6 +106,17 @@ func InstanceConfigFromLabels(labels map[string]string, l *slog.Logger) Instance
 	}
 	if v := labels[LabelAntiAffinity]; v != "" {
 		cfg.AntiAffinity = ParseAntiAffinity(v)
+	}
+	if v := labels[LabelDelegateScaling]; v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			l.Warn("invalid sablier.delegate-scaling label value, ignoring",
+				slog.String("value", v),
+				slog.Any("error", err),
+			)
+		} else {
+			cfg.DelegateScaling = b
+		}
 	}
 	// Only expose Scale when at least one non-default scale label is present,
 	// detected by values that differ from the zero-value defaults

--- a/pkg/sablier/instance_config_test.go
+++ b/pkg/sablier/instance_config_test.go
@@ -37,32 +37,45 @@ func TestInstanceConfigFromLabels(t *testing.T) {
 		{
 			name: "full configuration",
 			labels: map[string]string{
-				LabelEnable:       "true",
-				LabelGroup:        "team-a,team-b",
-				LabelReadyAfter:   "30s",
-				LabelReadyOnStart: "true",
-				LabelRunningHours: "09:00-18:00",
-				LabelRunningDays:  "Mon,Tue",
-				LabelAntiAffinity: "streaming",
+				LabelEnable:          "true",
+				LabelGroup:           "team-a,team-b",
+				LabelReadyAfter:      "30s",
+				LabelReadyOnStart:    "true",
+				LabelRunningHours:    "09:00-18:00",
+				LabelRunningDays:     "Mon,Tue",
+				LabelAntiAffinity:    "streaming",
+				LabelDelegateScaling: "true",
 			},
 			want: InstanceConfig{
-				Enabled:      true,
-				Groups:       []string{"team-a", "team-b"},
-				ReadyAfter:   30 * time.Second,
-				ReadyOnStart: true,
-				RunningHours: "09:00-18:00",
-				RunningDays:  "Mon,Tue",
-				AntiAffinity: []string{"streaming"},
+				Enabled:         true,
+				Groups:          []string{"team-a", "team-b"},
+				ReadyAfter:      30 * time.Second,
+				ReadyOnStart:    true,
+				RunningHours:    "09:00-18:00",
+				RunningDays:     "Mon,Tue",
+				AntiAffinity:    []string{"streaming"},
+				DelegateScaling: true,
 			},
+		},
+		{
+			name:   "delegate-scaling parses a boolean",
+			labels: map[string]string{LabelEnable: "true", LabelDelegateScaling: "true"},
+			want:   InstanceConfig{Enabled: true, Groups: []string{"default"}, DelegateScaling: true},
+		},
+		{
+			name:   "delegate-scaling false leaves scaling to Sablier",
+			labels: map[string]string{LabelEnable: "true", LabelDelegateScaling: "false"},
+			want:   InstanceConfig{Enabled: true, Groups: []string{"default"}},
 		},
 		{
 			name: "invalid values are ignored, valid ones kept",
 			labels: map[string]string{
-				LabelEnable:       "true",
-				LabelReadyAfter:   "soon",
-				LabelReadyOnStart: "yes-please",
-				LabelRunningHours: "9am-6pm",
-				LabelRunningDays:  "Someday",
+				LabelEnable:          "true",
+				LabelReadyAfter:      "soon",
+				LabelReadyOnStart:    "yes-please",
+				LabelRunningHours:    "9am-6pm",
+				LabelRunningDays:     "Someday",
+				LabelDelegateScaling: "maybe",
 			},
 			want: InstanceConfig{Enabled: true, Groups: []string{"default"}},
 		},
@@ -107,6 +120,16 @@ func TestInstanceInfoIsEnabled(t *testing.T) {
 	t.Run("list entries share the semantics", func(t *testing.T) {
 		assert.Assert(t, InstanceConfiguration{Enabled: "true"}.IsEnabled())
 		assert.Assert(t, !InstanceConfiguration{Enabled: "1"}.IsEnabled())
+	})
+}
+
+func TestInstanceInfoIsDelegated(t *testing.T) {
+	t.Run("parsed config drives the flag", func(t *testing.T) {
+		assert.Assert(t, InstanceInfo{Config: &InstanceConfig{DelegateScaling: true}}.IsDelegated())
+		assert.Assert(t, !InstanceInfo{Config: &InstanceConfig{DelegateScaling: false}}.IsDelegated())
+	})
+	t.Run("nil config is never delegated", func(t *testing.T) {
+		assert.Assert(t, !InstanceInfo{}.IsDelegated())
 	})
 }
 

--- a/pkg/sablier/instance_expired.go
+++ b/pkg/sablier/instance_expired.go
@@ -3,53 +3,52 @@ package sablier
 import (
 	"context"
 	"log/slog"
-
-	"github.com/sablierapp/sablier/pkg/metrics"
 )
 
-// OnInstanceExpired returns a store-expiration callback that stops the
-// instance via the provider and records the corresponding metrics.
+// OnInstanceExpired returns a store-expiration callback that idles the expired
+// instance and records the corresponding metrics.
 //
-// recorder may be metrics.Noop{} when metrics are disabled — call sites
-// must always pass a non-nil recorder.
-func OnInstanceExpired(ctx context.Context, provider Provider, recorder metrics.Recorder, logger *slog.Logger) func(string) {
-	return onInstanceExpired(ctx, provider, recorder, logger, false)
-}
-
+// A single InstanceInspect serves both the optional enabled-verification and the
+// delegated-scaling detection that selects how the instance is stopped: a
+// delegated instance is deactivated via an intent webhook (an external scaler
+// owns its replica count) while every other instance is scaled to zero through
+// the provider. The expired session may also have been the last one keeping a
+// group active, so an anti-affinity reconcile runs afterwards to restore any
+// instance held idle because of it.
 func (s *Sablier) OnInstanceExpired(ctx context.Context) func(string) {
-	base := onInstanceExpired(ctx, s.provider, s.metrics, s.l, s.verifyEnabledOnExpiration)
-	return func(key string) {
-		base(key)
+	return func(_key string) {
+		go func(key string) {
+			s.l.InfoContext(ctx, "instance expired", slog.String("instance", key))
+
+			// A single inspect serves both the optional enabled-verification and the
+			// delegated-scaling detection that selects how the instance is stopped.
+			info, err := s.provider.InstanceInspect(ctx, key)
+			if err != nil {
+				if s.verifyEnabledOnExpiration {
+					s.l.WarnContext(ctx, "instance expired could not be inspected before stop", slog.String("instance", key), slog.Any("error", err))
+					return
+				}
+				// Best-effort: without verification we still stop, via a bare
+				// (non-delegated) provider stop.
+				s.l.WarnContext(ctx, "instance expired could not be inspected, stopping via provider", slog.String("instance", key), slog.Any("error", err))
+				info = InstanceInfo{Name: key}
+			} else if s.verifyEnabledOnExpiration && !info.IsEnabled() {
+				s.l.WarnContext(ctx, "instance expired but is not managed by sablier, skipping stop", slog.String("instance", key))
+				return
+			}
+
+			if err := s.stop(ctx, key, info); err != nil {
+				s.l.ErrorContext(ctx, "instance expired could not be stopped", slog.String("instance", key), slog.Any("error", err))
+			}
+			s.metrics.RecordInstanceStop(key, "expired")
+			s.metrics.RecordInactiveInstance(key)
+			s.metrics.DiscardReadyWait(key)
+		}(_key)
+
 		// The expired session may have been the last one keeping a group active;
 		// restore any instance we forced idle because of an anti-affinity to it.
 		// The store key is already gone by the time this callback runs, so the
 		// reconcile sees the group as inactive.
 		s.triggerAntiAffinityReconcile(ctx)
-	}
-}
-
-func onInstanceExpired(ctx context.Context, provider Provider, recorder metrics.Recorder, logger *slog.Logger, verifyEnabled bool) func(string) {
-	return func(_key string) {
-		go func(key string) {
-			logger.InfoContext(ctx, "instance expired", slog.String("instance", key))
-			if verifyEnabled {
-				info, err := provider.InstanceInspect(ctx, key)
-				if err != nil {
-					logger.WarnContext(ctx, "instance expired could not be inspected before stop", slog.String("instance", key), slog.Any("error", err))
-					return
-				}
-				if !info.IsEnabled() {
-					logger.WarnContext(ctx, "instance expired but is not managed by sablier, skipping stop", slog.String("instance", key))
-					return
-				}
-			}
-			err := provider.InstanceStop(ctx, key)
-			if err != nil {
-				logger.ErrorContext(ctx, "instance expired could not be stopped from provider", slog.String("instance", key), slog.Any("error", err))
-			}
-			recorder.RecordInstanceStop(key, "expired")
-			recorder.RecordInactiveInstance(key)
-			recorder.DiscardReadyWait(key)
-		}(_key)
 	}
 }

--- a/pkg/sablier/instance_expired_test.go
+++ b/pkg/sablier/instance_expired_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/neilotoole/slogt"
 	"github.com/sablierapp/sablier/pkg/metrics"
 	"github.com/sablierapp/sablier/pkg/sablier"
 	"go.uber.org/mock/gomock"
@@ -14,17 +13,17 @@ import (
 )
 
 func TestOnInstanceExpired_StopsAndRecordsMetrics(t *testing.T) {
-	_, _, p, rec := setupSablierWithMetrics(t)
+	manager, _, p, rec := setupSablierWithMetrics(t)
 	ctx := t.Context()
 
+	p.EXPECT().InstanceInspect(gomock.Any(), "i1").Return(sablier.InstanceInfo{Name: "i1"}, nil)
 	stopped := make(chan struct{}, 1)
 	p.EXPECT().InstanceStop(gomock.Any(), "i1").DoAndReturn(func(_ any, _ string) error {
 		stopped <- struct{}{}
 		return nil
 	})
 
-	cb := sablier.OnInstanceExpired(ctx, p, rec, slogt.New(t))
-	cb("i1")
+	manager.OnInstanceExpired(ctx)("i1")
 
 	select {
 	case <-stopped:
@@ -41,17 +40,17 @@ func TestOnInstanceExpired_StopsAndRecordsMetrics(t *testing.T) {
 }
 
 func TestOnInstanceExpired_ProviderStopErrorStillRecordsMetrics(t *testing.T) {
-	_, _, p, rec := setupSablierWithMetrics(t)
+	manager, _, p, rec := setupSablierWithMetrics(t)
 	ctx := t.Context()
 
+	p.EXPECT().InstanceInspect(gomock.Any(), "i2").Return(sablier.InstanceInfo{Name: "i2"}, nil)
 	stopped := make(chan struct{}, 1)
 	p.EXPECT().InstanceStop(gomock.Any(), "i2").DoAndReturn(func(_ any, _ string) error {
 		stopped <- struct{}{}
 		return errors.New("cannot stop")
 	})
 
-	cb := sablier.OnInstanceExpired(ctx, p, rec, slogt.New(t))
-	cb("i2")
+	manager.OnInstanceExpired(ctx)("i2")
 
 	select {
 	case <-stopped:
@@ -122,4 +121,34 @@ func assertNoExpirationMetrics(t *testing.T, rec metrics.Recorder) {
 
 func containsCall(calls []string, want string) bool {
 	return slices.Contains(calls, want)
+}
+
+// TestSablierOnInstanceExpired_Delegated emits a deactivate intent and does not
+// call the provider's InstanceStop (the absence of an EXPECT makes gomock fail
+// if it is called).
+func TestSablierOnInstanceExpired_Delegated(t *testing.T) {
+	manager, _, provider, rec := setupSablierWithMetrics(t)
+	ctx := t.Context()
+
+	provider.EXPECT().InstanceInspect(gomock.Any(), "app").Return(sablier.InstanceInfo{
+		Name: "app", Enabled: "true", Config: &sablier.InstanceConfig{Enabled: true, DelegateScaling: true},
+	}, nil)
+
+	stream := manager.IntentEvents(ctx)
+	manager.OnInstanceExpired(ctx)("app")
+
+	select {
+	case ev := <-stream.Events:
+		assert.Equal(t, string(ev.Type), "deactivate")
+		assert.Equal(t, ev.Info.Name, "app")
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a deactivate intent event")
+	}
+
+	assert.Assert(t, checkWithTimeout(20*time.Millisecond, 2*time.Second, func() bool {
+		calls := rec.snapshot()
+		return containsCall(calls, "stop:app/expired") &&
+			containsCall(calls, "active-:app") &&
+			containsCall(calls, "ready_discard:app")
+	}), "expected expiration metrics")
 }

--- a/pkg/sablier/instance_request.go
+++ b/pkg/sablier/instance_request.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/store"
 )
 
@@ -107,6 +108,19 @@ func (s *Sablier) requestStart(ctx context.Context, name string, rejectUnlabeled
 		return InstanceInfo{}, ErrInstanceNotManaged{Name: name}
 	}
 	info.Status = InstanceStatusStarting
+
+	// Delegated scaling: an external scaler (e.g. a KEDA ScaledObject) owns the
+	// replica count, so Sablier must not start the workload itself. Record the
+	// same ready-wait/active metrics the non-delegated path records at this point,
+	// emit an activate intent, and return — there is no async provider call to
+	// track, so we skip the pendingStart bookkeeping. Readiness is observed via
+	// InstanceInspect on subsequent requests, exactly as for any other instance.
+	if info.IsDelegated() {
+		s.metrics.RecordReadyWaitBegin(name)
+		s.metrics.RecordActiveInstance(name)
+		s.emitIntent(ctx, name, provider.InstanceEventActivate)
+		return info, nil
+	}
 
 	// Second critical section: register the pending entry. Re-check in case
 	// another goroutine raced past the first unlock and registered first.

--- a/pkg/sablier/instance_request_test.go
+++ b/pkg/sablier/instance_request_test.go
@@ -742,3 +742,39 @@ func TestInstanceRequest_ReadyAfter_GracePeriodRespectedByPolling(t *testing.T) 
 	assert.NilError(t, err)
 	assert.Assert(t, session.IsReady())
 }
+
+// TestInstanceRequest_Delegated_EmitsActivateNoStart verifies that requesting a
+// delegated instance emits an activate intent and never calls the provider's
+// InstanceStart (the absence of an EXPECT makes gomock fail if it is called).
+func TestInstanceRequest_Delegated_EmitsActivateNoStart(t *testing.T) {
+	manager, sessions, provider, rec := setupSablierWithMetrics(t)
+	ctx := t.Context()
+
+	info := sablier.InstanceInfo{
+		Name: "deployment_ns_app_1", Enabled: "true",
+		Config:          &sablier.InstanceConfig{Enabled: true, DelegateScaling: true},
+		CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+	}
+	starting := info
+	starting.Status = sablier.InstanceStatusStarting
+
+	sessions.EXPECT().Get(ctx, info.Name).Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+	provider.EXPECT().InstanceInspect(gomock.Any(), info.Name).Return(info, nil)
+	sessions.EXPECT().Put(ctx, starting, time.Minute).Return(nil)
+
+	stream := manager.IntentEvents(ctx)
+
+	got, err := manager.InstanceRequest(ctx, info.Name, time.Minute)
+	assert.NilError(t, err)
+	assert.Equal(t, got.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
+
+	select {
+	case ev := <-stream.Events:
+		assert.Equal(t, string(ev.Type), "activate")
+		assert.Equal(t, ev.Info.Name, info.Name)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected an activate intent event")
+	}
+
+	assert.Assert(t, containsCall(rec.snapshot(), "active+:"+info.Name))
+}

--- a/pkg/sablier/labels.go
+++ b/pkg/sablier/labels.go
@@ -84,6 +84,17 @@ const (
 	// since: NEXT_RELEASE
 	LabelAntiAffinity = "sablier.anti-affinity"
 
+	// LabelDelegateScaling opts the instance into delegated scaling: Sablier never
+	// writes the replica count and instead emits "activate"/"deactivate" intent
+	// webhooks for an external scaler (e.g. a KEDA ScaledObject) to act on.
+	//
+	// type: boolean
+	// example: "true"
+	// feature: /how-to-guides/scaling-resources/delegated-scaling/
+	// providers: Kubernetes only.
+	// since: NEXT_RELEASE
+	LabelDelegateScaling = "sablier.delegate-scaling"
+
 	// LabelIdleReplicas is the replica count when idle. `0` stops the workload;
 	// `1` or more keeps it running with optional resource throttling.
 	//

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -11,7 +11,13 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/sablierapp/sablier/pkg/metrics"
+	"github.com/sablierapp/sablier/pkg/provider"
 )
+
+// intentEventsBuffer sizes the internal channel that carries delegated-scaling
+// intent events to the webhook dispatcher. It is drained continuously by
+// WatchOrdered, so it only ever buffers a transient burst.
+const intentEventsBuffer = 256
 
 type Sablier struct {
 	provider Provider
@@ -67,6 +73,10 @@ type Sablier struct {
 	// verifyEnabledOnExpiration re-checks sablier.enable before stopping expired instances.
 	verifyEnabledOnExpiration bool
 
+	// intentEvents carries delegated-scaling intent events (activate/deactivate)
+	// from the orchestration layer to the webhook dispatcher. See emitIntent.
+	intentEvents chan InstanceEvent
+
 	metrics metrics.Recorder
 	tracer  trace.Tracer
 
@@ -82,6 +92,7 @@ func New(logger *slog.Logger, store Store, provider Provider) *Sablier {
 		suppressed:                    map[string]struct{}{},
 		pendingStarts:                 map[string]*pendingStart{},
 		depStarts:                     map[string]*depStart{},
+		intentEvents:                  make(chan InstanceEvent, intentEventsBuffer),
 		l:                             logger,
 		metrics:                       metrics.Noop{},
 		tracer:                        otel.Tracer("github.com/sablierapp/sablier"),
@@ -182,4 +193,36 @@ func (s *Sablier) RemoveInstanceFromAllGroups(instance string) []string {
 
 func (s *Sablier) RemoveInstance(ctx context.Context, name string) error {
 	return s.sessions.Delete(ctx, name)
+}
+
+// IntentEvents returns the stream of delegated-scaling intent events
+// (activate/deactivate). It is meant to be consumed by a single watcher (the
+// webhook dispatcher's ordered watch); the stream has no error channel.
+func (s *Sablier) IntentEvents(_ context.Context) InstanceEventStream {
+	return InstanceEventStream{Events: s.intentEvents}
+}
+
+// emitIntent publishes a delegated-scaling intent event for the named instance.
+// It blocks only until the event is buffered or ctx is cancelled.
+func (s *Sablier) emitIntent(ctx context.Context, name string, eventType provider.InstanceEventType) {
+	event := InstanceEvent{Type: eventType, Info: InstanceInfo{Name: name}}
+	select {
+	case s.intentEvents <- event:
+	case <-ctx.Done():
+		s.l.WarnContext(ctx, "dropped scaling intent event, context cancelled",
+			slog.String("instance", name),
+			slog.String("event", string(eventType)),
+		)
+	}
+}
+
+// stop idles the named instance. For delegated-scaling instances it emits a
+// deactivate intent (an external scaler owns the replica count); otherwise it
+// scales the instance to zero via the provider.
+func (s *Sablier) stop(ctx context.Context, name string, info InstanceInfo) error {
+	if info.IsDelegated() {
+		s.emitIntent(ctx, name, provider.InstanceEventDeactivate)
+		return nil
+	}
+	return s.provider.InstanceStop(ctx, name)
 }

--- a/pkg/sabliercmd/start.go
+++ b/pkg/sabliercmd/start.go
@@ -149,6 +149,10 @@ func Start(ctx context.Context, conf config.Config) error {
 			},
 		})
 		go d.Watch(ctx, stream)
+		// Delegated-scaling intent events (activate/deactivate) are delivered on a
+		// separate ordered, retrying watch so a deactivate→activate cannot be
+		// reordered and a dropped delivery does not strand the external scaler.
+		go d.WatchOrdered(ctx, s.IntentEvents(ctx))
 		for i, ep := range conf.Webhooks.Endpoints {
 			events := ep.Events
 			if len(events) == 0 {

--- a/pkg/webhook/dispatcher.go
+++ b/pkg/webhook/dispatcher.go
@@ -3,6 +3,18 @@
 // bridge: regardless of whether the underlying runtime is Docker, Kubernetes,
 // Docker Swarm, Podman, or Proxmox LXC, every consumer receives the same JSON
 // payload structure.
+//
+// Two kinds of events are delivered on separate watches:
+//
+//   - Lifecycle events ("started"/"stopped") are observations of an actual
+//     scale transition. They are delivered best-effort and fan out per endpoint
+//     (Watch/dispatch); an endpoint with no events filter receives all of them.
+//   - Intent events ("activate"/"deactivate") are emitted only for
+//     delegated-scaling instances, whose replica count is owned by an external
+//     scaler. They are delivered strictly in order with bounded retries
+//     (WatchOrdered/dispatchOrdered) and require an explicit subscription: an
+//     endpoint receives them only if its events filter lists them, so existing
+//     unfiltered endpoints see no new traffic.
 package webhook
 
 import (
@@ -27,7 +39,8 @@ import (
 // Payload is the normalized JSON body posted to every webhook endpoint.
 // The same structure is used regardless of the underlying provider.
 type Payload struct {
-	// Event is the normalized event type: "started" or "stopped".
+	// Event is the normalized event type. Lifecycle events are "started" or
+	// "stopped"; delegated-scaling intent events are "activate" or "deactivate".
 	Event string `json:"event"`
 	// Instance holds provider-agnostic instance identifiers.
 	Instance InstancePayload `json:"instance"`
@@ -68,9 +81,9 @@ func NewDispatcher(endpoints []config.WebhookEndpoint, logger *slog.Logger) *Dis
 	}
 }
 
-// Watch consumes events from stream and delivers webhooks for "started" and
-// "stopped" transitions. It returns when ctx is cancelled, the event channel
-// is closed, or a terminal error is received from the stream.
+// Watch consumes events from stream and delivers webhooks for the lifecycle
+// "started" and "stopped" transitions only. It returns when ctx is cancelled,
+// the event channel is closed, or a terminal error is received from the stream.
 //
 // Watch waits for all in-flight HTTP deliveries to complete before returning,
 // so the caller can rely on no goroutines escaping after Watch exits.
@@ -108,6 +121,94 @@ func (d *Dispatcher) Watch(ctx context.Context, stream sablier.InstanceEventStre
 	}
 }
 
+// orderedDeliveryAttempts bounds how many times WatchOrdered retries a single
+// delivery before giving up and moving on to the next event.
+const orderedDeliveryAttempts = 5
+
+// orderedRetryBaseDelay is the base backoff between ordered-delivery retries; it
+// grows linearly with the attempt number.
+const orderedRetryBaseDelay = 200 * time.Millisecond
+
+// WatchOrdered consumes events from stream and delivers them strictly in order,
+// one event at a time, retrying each delivery with bounded backoff. It is the
+// counterpart to Watch for intent events (activate/deactivate) where delivery is
+// load-bearing: a reordered deactivate→activate or a silently dropped delivery
+// would leave the external scaler in the wrong state.
+//
+// Unlike Watch it does not fan out per endpoint concurrently — all of an event's
+// endpoints are delivered (with retries) before the next event is read, so the
+// receiver observes events in the exact order Sablier emitted them.
+//
+// Call WatchOrdered in a dedicated goroutine.
+func (d *Dispatcher) WatchOrdered(ctx context.Context, stream sablier.InstanceEventStream) {
+	eventsC := stream.Events
+	errC := stream.Err
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.l.InfoContext(ctx, "ordered webhook dispatcher stopped", slog.Any("reason", ctx.Err()))
+			return
+		case event, ok := <-eventsC:
+			if !ok {
+				d.l.WarnContext(ctx, "ordered webhook event stream closed")
+				return
+			}
+			d.dispatchOrdered(ctx, event)
+		case err, ok := <-errC:
+			if !ok {
+				return
+			}
+			d.l.ErrorContext(ctx, "ordered webhook event stream error", slog.Any("error", err))
+			return
+		}
+	}
+}
+
+// dispatchOrdered delivers a single event to every endpoint that should fire,
+// sequentially and with bounded retries, before returning.
+func (d *Dispatcher) dispatchOrdered(ctx context.Context, event sablier.InstanceEvent) {
+	payload := Payload{
+		Event:     string(event.Type),
+		Instance:  InstancePayload{Name: event.Info.Name},
+		Timestamp: time.Now().UTC(),
+	}
+	for _, ep := range d.endpoints {
+		// Intent events require an EXPLICIT subscription. Unlike shouldFire there
+		// is no empty-means-all fallback: an endpoint with no events filter never
+		// receives activate/deactivate, so existing unfiltered endpoints (e.g. an
+		// uptime monitor watching started/stopped) see zero new traffic.
+		if !slices.Contains(ep.Events, string(event.Type)) {
+			continue
+		}
+		d.sendWithRetry(ctx, ep, payload)
+	}
+}
+
+// sendWithRetry calls send up to orderedDeliveryAttempts times, backing off
+// between attempts, until send reports success or the context is cancelled.
+func (d *Dispatcher) sendWithRetry(ctx context.Context, ep config.WebhookEndpoint, payload Payload) {
+	for attempt := 1; attempt <= orderedDeliveryAttempts; attempt++ {
+		if err := d.send(ctx, ep, payload); err == nil {
+			return
+		}
+		if attempt == orderedDeliveryAttempts {
+			d.l.ErrorContext(ctx, "webhook: giving up after retries",
+				slog.String("url", ep.URL),
+				slog.String("event", payload.Event),
+				slog.String("instance", payload.Instance.Name),
+				slog.Int("attempts", attempt),
+			)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Duration(attempt) * orderedRetryBaseDelay):
+		}
+	}
+}
+
 // dispatch builds the payload and spawns a goroutine per endpoint that should fire.
 // Each goroutine is tracked in wg so Watch can wait for them to drain.
 func (d *Dispatcher) dispatch(ctx context.Context, wg *sync.WaitGroup, event sablier.InstanceEvent) {
@@ -121,7 +222,9 @@ func (d *Dispatcher) dispatch(ctx context.Context, wg *sync.WaitGroup, event sab
 			continue
 		}
 		wg.Go(func() {
-			d.send(ctx, ep, payload)
+			// Best-effort delivery: send logs its own failures, and this path
+			// intentionally does not retry, so the returned error is ignored.
+			_ = d.send(ctx, ep, payload)
 		})
 	}
 }
@@ -134,19 +237,20 @@ func (d *Dispatcher) shouldFire(ep config.WebhookEndpoint, eventType string) boo
 	return slices.Contains(ep.Events, eventType)
 }
 
-// send performs the HTTP POST. Errors are logged but never returned; webhook
-// delivery is best-effort and must not block the event loop.
-func (d *Dispatcher) send(ctx context.Context, ep config.WebhookEndpoint, payload Payload) {
+// send performs the HTTP POST. It returns nil on success and an error on
+// failure. Callers on the best-effort path (Watch/dispatch) ignore the return;
+// the ordered path (WatchOrdered/sendWithRetry) uses it to drive retries.
+func (d *Dispatcher) send(ctx context.Context, ep config.WebhookEndpoint, payload Payload) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		d.l.ErrorContext(ctx, "webhook: failed to marshal payload", slog.String("url", ep.URL), slog.Any("error", err))
-		return
+		return err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ep.URL, bytes.NewReader(body))
 	if err != nil {
 		d.l.ErrorContext(ctx, "webhook: failed to build request", slog.String("url", ep.URL), slog.Any("error", err))
-		return
+		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", d.userAgent)
@@ -157,7 +261,7 @@ func (d *Dispatcher) send(ctx context.Context, ep config.WebhookEndpoint, payloa
 	resp, err := d.client.Do(req)
 	if err != nil {
 		d.l.ErrorContext(ctx, "webhook: delivery failed", slog.String("url", ep.URL), slog.Any("error", err))
-		return
+		return err
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -168,7 +272,7 @@ func (d *Dispatcher) send(ctx context.Context, ep config.WebhookEndpoint, payloa
 			slog.String("event", payload.Event),
 			slog.String("instance", payload.Instance.Name),
 		)
-		return
+		return fmt.Errorf("webhook %s returned status %d", ep.URL, resp.StatusCode)
 	}
 	d.l.InfoContext(ctx, "webhook: delivered",
 		slog.String("url", ep.URL),
@@ -176,6 +280,7 @@ func (d *Dispatcher) send(ctx context.Context, ep config.WebhookEndpoint, payloa
 		slog.String("event", payload.Event),
 		slog.String("instance", payload.Instance.Name),
 	)
+	return nil
 }
 
 // validateEndpoints checks each endpoint for a non-empty URL.

--- a/pkg/webhook/dispatcher_test.go
+++ b/pkg/webhook/dispatcher_test.go
@@ -85,6 +85,113 @@ func startWatch(t *testing.T, d *webhook.Dispatcher, ctx context.Context, cancel
 	})
 }
 
+// startWatchOrdered launches d.WatchOrdered in a goroutine, with cleanup.
+func startWatchOrdered(t *testing.T, d *webhook.Dispatcher, ctx context.Context, cancel context.CancelFunc, stream sablier.InstanceEventStream) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		d.WatchOrdered(ctx, stream)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+}
+
+func TestDispatcher_WatchOrdered_DeliversIntentEventsInOrder(t *testing.T) {
+	c := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(c.handler))
+	defer srv.Close()
+
+	// Intent events require an explicit subscription.
+	d := webhook.NewDispatcher([]config.WebhookEndpoint{{URL: srv.URL, Events: []string{"activate", "deactivate"}}}, slogt.New(t))
+
+	eventsC, _, stream := makeStream()
+	ctx, cancel := context.WithCancel(t.Context())
+	startWatchOrdered(t, d, ctx, cancel, stream)
+
+	// A deactivate followed by an activate must arrive in that exact order.
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventDeactivate, Info: sablier.InstanceInfo{Name: "app"}}
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventActivate, Info: sablier.InstanceInfo{Name: "app"}}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && c.count() < 2 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	assert.Equal(t, 2, c.count())
+	assert.Equal(t, "deactivate", c.received[0].Event)
+	assert.Equal(t, "activate", c.received[1].Event)
+}
+
+func TestDispatcher_WatchOrdered_RetriesThenSucceeds(t *testing.T) {
+	var mu sync.Mutex
+	attempts := 0
+	done := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		attempts++
+		n := attempts
+		mu.Unlock()
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}))
+	defer srv.Close()
+
+	// Intent events require an explicit subscription.
+	d := webhook.NewDispatcher([]config.WebhookEndpoint{{URL: srv.URL, Events: []string{"activate"}}}, slogt.New(t))
+
+	eventsC, _, stream := makeStream()
+	ctx, cancel := context.WithCancel(t.Context())
+	startWatchOrdered(t, d, ctx, cancel, stream)
+
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventActivate, Info: sablier.InstanceInfo{Name: "app"}}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected eventual successful delivery after retries")
+	}
+	mu.Lock()
+	got := attempts
+	mu.Unlock()
+	assert.Assert(t, got >= 3, "expected at least 3 attempts, got %d", got)
+}
+
+// TestDispatcher_WatchOrdered_UnfilteredEndpointReceivesNoIntentEvents proves the
+// headline invariant: an endpoint with an empty events filter (which fires for
+// every lifecycle event) receives zero intent events. Intent delivery requires an
+// explicit subscription, so existing unfiltered endpoints see no new traffic.
+func TestDispatcher_WatchOrdered_UnfilteredEndpointReceivesNoIntentEvents(t *testing.T) {
+	c := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(c.handler))
+	defer srv.Close()
+
+	// No Events filter => empty-means-all for lifecycle events, but never intent.
+	d := webhook.NewDispatcher([]config.WebhookEndpoint{{URL: srv.URL}}, slogt.New(t))
+
+	eventsC, _, stream := makeStream()
+	ctx, cancel := context.WithCancel(t.Context())
+	startWatchOrdered(t, d, ctx, cancel, stream)
+
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventActivate, Info: sablier.InstanceInfo{Name: "app"}}
+	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventDeactivate, Info: sablier.InstanceInfo{Name: "app"}}
+
+	// Give the dispatcher time to (not) deliver.
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, 0, c.count(), "unfiltered endpoint must not receive intent events")
+}
+
 func TestDispatcher_FiresOnStartedEvent(t *testing.T) {
 	c := &capture{}
 	srv := httptest.NewServer(http.HandlerFunc(c.handler))


### PR DESCRIPTION
Closes #1034

## What

Adds an opt-in **delegated scaling** mode for Kubernetes workloads. A workload labelled `sablier.delegate-scaling=true` has its replica count owned by an external scaler (e.g. a KEDA `ScaledObject`); Sablier stops writing `spec.replicas` and instead emits `activate`/`deactivate` **intent webhooks** the scaler acts on.

## Why

When Sablier writes `spec.replicas` and a controller such as KEDA also owns it, they race: Sablier scales to zero, KEDA's `minReplicaCount` enforcement restores one replica, that scale-up is observed as a `started` event, and the workload is latched at one replica forever. Delegating the replica count to the scaler and communicating intent over webhooks removes the race. See #130 for the scale-to-zero precedent.

## Changes (file-by-file)

- `pkg/sablier/labels.go` — new CI-gated label constant `LabelDelegateScaling` (`sablier.delegate-scaling`), Kubernetes-only, `since: NEXT_RELEASE`.
- `pkg/sablier/instance_config.go` — parse `DelegateScaling bool` in `InstanceConfigFromLabels` with the standard `strconv.ParseBool` warn-and-skip.
- `pkg/sablier/instance.go` — `InstanceInfo.IsDelegated()` accessor; `Delegated` field on `InstanceConfiguration` (list-path carrier, avoids an extra inspect).
- `pkg/sablier/sablier.go` — internal buffered `intentEvents` channel; `IntentEvents(ctx)`, non-blocking `emitIntent(...)`, and a delegated-aware `stop(...)` (deactivate intent vs `provider.InstanceStop`).
- `pkg/sablier/instance_request.go` — delegated requests record the ready-wait / active metrics, emit an `activate` intent, and return without the start/pendingStart bookkeeping.
- `pkg/sablier/instance_expired.go` — rewrote `(*Sablier).OnInstanceExpired` to a single `InstanceInspect` serving both enable-verification and delegated detection, routing the stop through `stop(...)` and keeping the anti-affinity reconcile. Removed the now-dead package-level `OnInstanceExpired`/`onInstanceExpired`.
- `pkg/sablier/autostop.go` — `StopAllUnregisteredInstances` carries `InstanceConfiguration` (preserving `Delegated`) and routes through `stop(...)`; `WatchAndStopExternallyStarted` skips delegated instances (the scaler owns them).
- `pkg/provider/types.go` — new `InstanceEventActivate` / `InstanceEventDeactivate` intent event types.
- `pkg/provider/kubernetes/{sablier_config,deployment_list,statefulset_list,cnpgcluster_list}.go` — set `Delegated` from the merged `sablier.*` label/annotation config. Other providers untouched.
- `pkg/webhook/dispatcher.go` — `WatchOrdered`/`dispatchOrdered`/`sendWithRetry` deliver intent events strictly in order with a bounded 5-attempt retry; `send` now returns an error to drive retries (best-effort path ignores it). `dispatchOrdered` requires an **explicit** subscription (no empty-means-all). Doc comments updated.
- `pkg/sabliercmd/start.go` — wires a second, ordered watch (`go d.WatchOrdered(ctx, s.IntentEvents(ctx))`) inside the webhooks-enabled block.
- Docs — new guide `how-to-guides/scaling-resources/delegated-scaling.md`, `webhooks.md` updated (event table, explicit-subscription rule, delivery semantics), regenerated `reference/labels.md` and `static/openapi.json`.

## Invariants

**Default off.** Without the `sablier.delegate-scaling` label *and* without an endpoint that explicitly subscribes to `activate`/`deactivate`, behavior and webhook traffic are **byte-identical** to today:

- No label → no instance is delegated → the request/expiry/autostop paths behave exactly as before (`emitIntent` is never called).
- Intent events require explicit subscription → existing unfiltered endpoints receive zero new deliveries; lifecycle `started`/`stopped` delivery is unchanged.

## Testing

- `pkg/sablier`:
  - `TestInstanceConfigFromLabels` (delegate-scaling table entries: true/false/invalid)
  - `TestInstanceInfoIsDelegated`
  - `TestInstanceRequest_Delegated_EmitsActivateNoStart`
  - `TestSablierOnInstanceExpired_Delegated`
  - `TestOnInstanceExpired_StopsAndRecordsMetrics` / `TestOnInstanceExpired_ProviderStopErrorStillRecordsMetrics` (ported from the removed package-level function to the method)
  - `TestStopAllUnregisteredInstances_Delegated`
- `pkg/webhook`:
  - `TestDispatcher_WatchOrdered_DeliversIntentEventsInOrder`
  - `TestDispatcher_WatchOrdered_RetriesThenSucceeds`
  - `TestDispatcher_WatchOrdered_UnfilteredEndpointReceivesNoIntentEvents` (the explicit-subscription invariant)
- `pkg/provider/kubernetes`:
  - `TestDeploymentToInstance_Delegated` (label, annotation, override, invalid)

`make fmt`, `go build ./...`, `go test -race ./pkg/sablier/... ./pkg/webhook/...`, `make lint`, and `make check-generate` all pass.

## Docs

- New: `how-to-guides/scaling-resources/delegated-scaling.md` (the KEDA race, the label, intent payloads, ordering + bounded-retry semantics, explicit subscription, and a KEDA ScaledObject pause/unpause walkthrough with manifests). Compatibility matrix: Kubernetes only.
- Updated: `how-to-guides/webhooks.md` (event-types table, explicit-subscription rule, per-kind delivery semantics).
- Regenerated: `reference/labels.md`, `static/openapi.json`.

> Rebase note: open PR #1026 (store schema v2) also touches `InstanceConfig` persistence. This PR adds a single additive `DelegateScaling` field to `InstanceConfig`; if #1026 merges first, expect a trivial rebase there.

## Note on authorship

This PR was co-authored with Claude (Anthropic's AI). My own Go experience is limited: the problem, the design and the validation come from our production Kubernetes/KEDA environment, where an earlier version of this feature has been running, but most of the Go implementation was written by Claude Code under my direction and review. Please don't hesitate to flag anything non-idiomatic — happy to iterate on feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
