### PR TITLE
fix(dockerswarm): honor the running-only filter in InstanceList

### DIFF
--- a/pkg/provider/dockerswarm/service_list.go
+++ b/pkg/provider/dockerswarm/service_list.go
@@ -11,12 +11,12 @@ import (
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
-func (p *Provider) InstanceList(ctx context.Context, _ provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
+func (p *Provider) InstanceList(ctx context.Context, opts provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
 	filters := client.Filters{}
 	filters.Add("label", fmt.Sprintf("%s=true", sablier.LabelEnable))
 	filters.Add("mode", "replicated")
 
-	p.l.DebugContext(ctx, "listing services", slog.Group("options", slog.Bool("status", true), slog.Any("filters", filters)))
+	p.l.DebugContext(ctx, "listing services", slog.Group("options", slog.Bool("all", opts.All), slog.Bool("status", true), slog.Any("filters", filters)))
 	services, err := p.Client.ServiceList(ctx, client.ServiceListOptions{
 		Status:  true,
 		Filters: filters,
@@ -29,6 +29,12 @@ func (p *Provider) InstanceList(ctx context.Context, _ provider.InstanceListOpti
 
 	instances := make([]sablier.InstanceConfiguration, 0, len(services.Items))
 	for _, s := range services.Items {
+		// A service scaled to zero has no running tasks and is not a running
+		// instance: mirror the docker provider, which only lists running
+		// containers unless All is requested.
+		if !opts.All && (s.ServiceStatus == nil || s.ServiceStatus.RunningTasks == 0) {
+			continue
+		}
 		instance := p.serviceToInstance(s)
 		instances = append(instances, instance)
 	}

--- a/pkg/provider/dockerswarm/service_list_test.go
+++ b/pkg/provider/dockerswarm/service_list_test.go
@@ -130,3 +130,58 @@ func TestDockerClassicProvider_GetGroups(t *testing.T) {
 
 	assert.DeepEqual(t, got, want)
 }
+
+func TestDockerSwarmProvider_InstanceList_OnlyRunning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	ctx := t.Context()
+	dind := sharedDinD
+	p, err := dockerswarm.New(ctx, dind.client, slogt.New(t))
+	assert.NilError(t, err)
+
+	running, err := dind.CreateMimic(ctx, MimicOptions{
+		Labels: map[string]string{
+			"sablier.enable": "true",
+		},
+	})
+	assert.NilError(t, err)
+
+	runningResult, err := dind.client.ServiceInspect(ctx, running.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	runningService := runningResult.Service
+	t.Cleanup(func() {
+		_, _ = sharedDinD.client.ServiceRemove(context.Background(), runningService.ID, client.ServiceRemoveOptions{})
+	})
+
+	var zero uint64
+	scaledToZero, err := dind.CreateMimic(ctx, MimicOptions{
+		Replicas: &zero,
+		Labels: map[string]string{
+			"sablier.enable": "true",
+		},
+	})
+	assert.NilError(t, err)
+
+	scaledResult, err := dind.client.ServiceInspect(ctx, scaledToZero.ID, client.ServiceInspectOptions{})
+	assert.NilError(t, err)
+	scaledService := scaledResult.Service
+	t.Cleanup(func() {
+		_, _ = sharedDinD.client.ServiceRemove(context.Background(), scaledService.ID, client.ServiceRemoveOptions{})
+	})
+
+	err = WaitForServiceRunning(ctx, dind.client, runningService.Spec.Name, 1)
+	assert.NilError(t, err)
+
+	// All includes the scaled-to-zero service
+	got, err := p.InstanceList(ctx, provider.InstanceListOptions{All: true})
+	assert.NilError(t, err)
+	assert.Equal(t, len(got), 2)
+
+	// Only running excludes the scaled-to-zero service
+	got, err = p.InstanceList(ctx, provider.InstanceListOptions{All: false})
+	assert.NilError(t, err)
+	assert.Equal(t, len(got), 1)
+	assert.Equal(t, got[0].Name, runningService.Spec.Name)
+}

--- a/pkg/provider/dockerswarm/testcontainers_test.go
+++ b/pkg/provider/dockerswarm/testcontainers_test.go
@@ -30,6 +30,7 @@ type MimicOptions struct {
 	Healthcheck   *container.HealthConfig
 	RestartPolicy *swarm.RestartPolicy
 	Labels        map[string]string
+	Replicas      *uint64
 }
 
 func (d *dindContainer) CreateMimic(ctx context.Context, opts MimicOptions) (client.ServiceCreateResult, error) {
@@ -38,6 +39,9 @@ func (d *dindContainer) CreateMimic(ctx context.Context, opts MimicOptions) (cli
 	}
 
 	var replicas uint64 = 1
+	if opts.Replicas != nil {
+		replicas = *opts.Replicas
+	}
 	return d.client.ServiceCreate(ctx, client.ServiceCreateOptions{
 		Spec: swarm.ServiceSpec{
 			Mode: swarm.ServiceMode{


### PR DESCRIPTION
## Problem

The Docker Swarm provider ignores `InstanceListOptions` and returns every `sablier.enable=true` replicated service, including services already scaled to zero:

```go
func (p *Provider) InstanceList(ctx context.Context, _ provider.InstanceListOptions) (...)
```

`StopAllUnregisteredInstances` explicitly asks for running instances only (`All: false`). With `provider.auto-stop-externally-started: true` the 30s reconciliation scan therefore treats every sleeping (scaled-to-zero, sessionless) service as an externally started instance and "stops" it again on every tick. For each sleeping environment this produces, every 30 seconds, forever:

- one `INF stopped unregistered instance ... reason="instance is enabled but not started by Sablier"` log line per service (~26k lines/day for a 9-service stack), and
- one no-op `ServiceUpdate` per service, bumping the service spec version and generating docker events churn.

Sample from a real deployment (every 30s, all services already at 0/0):

```
1:41PM INF sablier/autostop.go:53 stopped unregistered instance instance=feature-x_queue-all reason="instance is enabled but not started by Sablier"
1:41PM INF sablier/autostop.go:53 stopped unregistered instance instance=feature-x_queue    reason="instance is enabled but not started by Sablier"
... (9 lines per stack, repeated every scan)
```

## Fix

Mirror the docker provider semantics (`ContainerList` with `All: options.All`): when `All` is `false`, skip services that have no running tasks. `ServiceStatus` is already populated since the listing passes `Status: true`.

## Testing

- Added `TestDockerSwarmProvider_InstanceList_OnlyRunning`: a running service and a scaled-to-zero service, `All: true` returns both, `All: false` returns only the running one (needed a `Replicas` knob on the `MimicOptions` test helper, defaulting to the previous hardcoded 1).
- `go test ./pkg/provider/dockerswarm/` (full testcontainers suite) and `go test ./pkg/sablier/ -short` pass.

A possible follow-up (not in this PR to keep it focused): `ServiceUpdateScale` could skip the `ServiceUpdate` call entirely when the current spec already matches the requested replicas/resources, making stops idempotent at the API level too.