### PR TITLE
feat(session): best-effort instances via the `optional:` name prefix

### DIFF
--- a/docs/content/how-to-guides/readiness/optional-instances.md
+++ b/docs/content/how-to-guides/readiness/optional-instances.md
@@ -1,0 +1,54 @@
+---
+title: Mark instances as optional (best-effort)
+description: Start an instance with the session without letting its readiness or failures block the session.
+weight: 137
+compatibility:
+  docker: supported
+  swarm: supported
+  kubernetes: supported
+  podman: supported
+  proxmox: supported
+---
+
+{{< compatibility >}}
+
+This guide shows you how to mark an instance as **optional** (best-effort) by prefixing its name with `optional:` in a `names` request:
+
+```yaml
+# Traefik middleware example
+http:
+  middlewares:
+    my-sablier:
+      plugin:
+        sablier:
+          sablierUrl: http://sablier:10000
+          names: whoami,optional:whoami-helper
+          dynamic:
+            displayName: My Stack
+```
+
+An optional instance behaves exactly like any other session member — it is started on demand, its session is refreshed by traffic, and it scales back down when the session expires — with one difference: **its readiness and errors never gate the session**. The waiting page clears (and a blocking request returns) as soon as all non-optional instances are ready, even if an optional instance is still starting, unhealthy, or failed to start entirely.
+
+Use this to split a stack into important instances that visitors must wait for and auxiliary ones (workers, reporting, developer tooling) that should come up alongside them but must never block the stack when they are broken.
+
+## How it works
+
+The `optional:` marker travels inside the instance name, so every reverse proxy plugin forwards it unchanged — no plugin upgrade is needed. Sablier strips the prefix when the session is requested; providers, sessions and metrics all see the clean instance name. No workload name can collide with the marker because Docker, Swarm, Podman and Kubernetes names cannot contain a colon.
+
+The prefix works the same in a direct API call:
+
+```text
+GET /api/strategies/dynamic?names=whoami&names=optional:whoami-helper&session_duration=5m
+```
+
+## Notes
+
+- A session whose members are **all** optional is immediately ready.
+- Optional instances still appear on the waiting page details while it is shown, but they are not listed as a blocking reason in timeout errors.
+- Optionality is per request: the same instance can be required in one middleware and optional in another.
+- For group-based sessions, instances are discovered via labels and cannot be marked optional yet; use `names` for split behaviour.
+
+## Related
+
+- [Mark ready on start](/how-to-guides/readiness/ready-on-start/) — skip the health check but still require a successful start.
+- [Settling delay](/how-to-guides/readiness/ready-after/) — the opposite direction: require extra readiness time.

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -8,6 +8,9 @@
           },
           "instance": {
             "$ref": "#/components/schemas/sablier.InstanceInfo"
+          },
+          "optional": {
+            "type": "boolean"
           }
         },
         "type": "object"
@@ -528,7 +531,7 @@
         "description": "Holds the request until the requested instances are ready, or until the timeout elapses. Provide either `names` (one or more) or `group`, never both.",
         "parameters": [
           {
-            "description": "Instance name(s); repeat for multiple. Mutually exclusive with group.",
+            "description": "Instance name(s); repeat for multiple. Mutually exclusive with group. Prefix a name with 'optional:' to mark it best-effort: it is started with the session but its readiness and errors never gate it.",
             "in": "query",
             "name": "names",
             "schema": {
@@ -634,7 +637,7 @@
         "description": "Returns a themed HTML waiting page reflecting the session status; the page self-refreshes until the instances are ready. Provide either `names` or `group`.",
         "parameters": [
           {
-            "description": "Instance name(s). Mutually exclusive with group.",
+            "description": "Instance name(s). Mutually exclusive with group. Prefix a name with 'optional:' to mark it best-effort: it is started with the session but its readiness and errors never gate it.",
             "in": "query",
             "name": "names",
             "schema": {

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -27,17 +27,20 @@ type SessionStateResponse struct {
 }
 
 // InstanceEntryResponse is one instance of the session, with the error that
-// prevented it from starting, if any.
+// prevented it from starting, if any. Optional marks a best-effort instance
+// (requested with the "optional:" name prefix) whose readiness and error do
+// not gate the session status.
 type InstanceEntryResponse struct {
 	Instance sablier.InstanceInfo `json:"instance"`
 	Error    string               `json:"error,omitempty"`
+	Optional bool                 `json:"optional,omitempty"`
 }
 
 // NewSessionResponse maps a domain session to its wire representation.
 func NewSessionResponse(s *sablier.SessionState) SessionResponse {
 	instances := make([]InstanceEntryResponse, 0, len(s.Instances))
 	for _, v := range s.Instances {
-		entry := InstanceEntryResponse{Instance: v.Instance}
+		entry := InstanceEntryResponse{Instance: v.Instance, Optional: v.Optional}
 		if v.Error != nil {
 			entry.Error = v.Error.Error()
 		}

--- a/internal/api/start_blocking.go
+++ b/internal/api/start_blocking.go
@@ -23,7 +23,7 @@ type BlockingRequest struct {
 // @Description  Holds the request until the requested instances are ready, or until the timeout elapses. Provide either `names` (one or more) or `group`, never both.
 // @Tags         strategies
 // @Produce      json
-// @Param        names             query  []string  false  "Instance name(s); repeat for multiple. Mutually exclusive with group."
+// @Param        names             query  []string  false  "Instance name(s); repeat for multiple. Mutually exclusive with group. Prefix a name with 'optional:' to mark it best-effort: it is started with the session but its readiness and errors never gate it."
 // @Param        group             query  string    false  "Group name. Mutually exclusive with names."
 // @Param        session_duration  query  string    false  "Session duration as a Go duration (e.g. 5m). Defaults to the server default."
 // @Param        timeout           query  string    false  "Maximum time to wait as a Go duration (e.g. 1m)."

--- a/internal/api/start_dynamic.go
+++ b/internal/api/start_dynamic.go
@@ -30,7 +30,7 @@ type DynamicRequest struct {
 // @Description  Returns a themed HTML waiting page reflecting the session status; the page self-refreshes until the instances are ready. Provide either `names` or `group`.
 // @Tags         strategies
 // @Produce      html
-// @Param        names              query  []string  false  "Instance name(s). Mutually exclusive with group."
+// @Param        names              query  []string  false  "Instance name(s). Mutually exclusive with group. Prefix a name with 'optional:' to mark it best-effort: it is started with the session but its readiness and errors never gate it."
 // @Param        group              query  string    false  "Group name. Mutually exclusive with names."
 // @Param        session_duration   query  string    false  "Session duration as a Go duration (e.g. 5m)."
 // @Param        refresh_frequency  query  string    false  "Waiting-page refresh interval as a Go duration (e.g. 5s)."

--- a/pkg/sablier/session.go
+++ b/pkg/sablier/session.go
@@ -10,12 +10,18 @@ type SessionState struct {
 	Instances map[string]InstanceInfoWithError `json:"instances"`
 }
 
+// IsReady reports whether every gating instance is ready and error-free.
+// Optional (best-effort) instances never gate: a session whose only pending
+// or failing members are optional is ready.
 func (s *SessionState) IsReady() bool {
 	if s.Instances == nil {
 		s.Instances = map[string]InstanceInfoWithError{}
 	}
 
 	for _, v := range s.Instances {
+		if v.Optional {
+			continue
+		}
 		if v.Error != nil || !v.Instance.IsReady() {
 			return false
 		}
@@ -25,11 +31,16 @@ func (s *SessionState) IsReady() bool {
 }
 
 // NotReadyInstances returns the instances that are not ready yet (or errored),
-// sorted by name for stable output. Ready instances are omitted. It is used to
-// explain why a session did not become ready within a blocking timeout.
+// sorted by name for stable output. Ready instances are omitted, as are
+// optional instances: they never gate the session, so they cannot be the
+// reason it did not become ready. It is used to explain why a session did not
+// become ready within a blocking timeout.
 func (s *SessionState) NotReadyInstances() []InstanceInfoWithError {
 	var out []InstanceInfoWithError
 	for _, v := range s.Instances {
+		if v.Optional {
+			continue
+		}
 		if v.Error != nil || !v.Instance.IsReady() {
 			out = append(out, v)
 		}
@@ -40,10 +51,15 @@ func (s *SessionState) NotReadyInstances() []InstanceInfoWithError {
 	return out
 }
 
-// InstanceErrors returns a joined error if any instance has a non-nil error.
+// InstanceErrors returns a joined error if any gating instance has a non-nil
+// error. Errors of optional instances are ignored by design: best-effort
+// members must not fail a blocking request.
 func (s *SessionState) InstanceErrors() error {
 	var errs []error
 	for name, v := range s.Instances {
+		if v.Optional {
+			continue
+		}
 		if v.Error != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", name, v.Error))
 		}

--- a/pkg/sablier/session_request.go
+++ b/pkg/sablier/session_request.go
@@ -4,14 +4,27 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 )
 
+// OptionalPrefix marks a requested instance name as best-effort. An optional
+// instance is started and kept alive with the session exactly like any other
+// member, but its readiness and errors never gate the session: a slow or
+// failing optional instance cannot hold back the waiting page or fail a
+// blocking request. The marker travels inside the name itself so reverse-proxy
+// plugins forward it without changes; no workload name can collide with it
+// because Docker, Swarm, Podman and Kubernetes names cannot contain a colon.
+const OptionalPrefix = "optional:"
+
 type InstanceInfoWithError struct {
 	Instance InstanceInfo `json:"instance"`
 	Error    error        `json:"error"`
+	// Optional marks a best-effort instance, requested with the "optional:"
+	// name prefix. Its readiness and errors are ignored by SessionState.
+	Optional bool `json:"optional,omitempty"`
 }
 
 func (s *Sablier) RequestSession(ctx context.Context, names []string, duration time.Duration) (sessionState *SessionState, err error) {
@@ -34,7 +47,8 @@ func (s *Sablier) requestSession(ctx context.Context, names []string, duration t
 	wg.Add(len(names))
 
 	for i := range names {
-		go func(name string) {
+		name, optional := strings.CutPrefix(names[i], OptionalPrefix)
+		go func(name string, optional bool) {
 			defer wg.Done()
 			state, err := s.instanceRequest(ctx, name, duration, rejectUnlabeled)
 			mx.Lock()
@@ -42,8 +56,9 @@ func (s *Sablier) requestSession(ctx context.Context, names []string, duration t
 			sessionState.Instances[name] = InstanceInfoWithError{
 				Instance: state,
 				Error:    err,
+				Optional: optional,
 			}
-		}(names[i])
+		}(name, optional)
 	}
 
 	wg.Wait()

--- a/pkg/sablier/session_request_test.go
+++ b/pkg/sablier/session_request_test.go
@@ -153,6 +153,48 @@ func TestRequestSession_RejectsUnlabeledInstances(t *testing.T) {
 	assert.Equal(t, notManaged.Name, "nginx")
 }
 
+// The "optional:" prefix is stripped before the name reaches the store and
+// the provider, the session entry is keyed by the clean name, and the entry
+// carries the Optional flag so it never gates readiness.
+func TestRequestSession_OptionalPrefix(t *testing.T) {
+	manager, sessions, provider := setupSablier(t)
+	ctx := t.Context()
+	startCalled := make(chan struct{})
+
+	stoppedInfo := sablier.InstanceInfo{
+		Name:            "nginx",
+		CurrentReplicas: 0,
+		DesiredReplicas: 1,
+		Status:          sablier.InstanceStatusStopped,
+	}
+	notReady := stoppedInfo
+	notReady.Status = sablier.InstanceStatusStarting
+
+	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+	provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil)
+	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ any, _ string) error {
+		close(startCalled)
+		return nil
+	})
+	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
+
+	session, err := manager.RequestSession(ctx, []string{sablier.OptionalPrefix + "nginx"}, time.Minute)
+	assert.NilError(t, err)
+
+	entry, ok := session.Instances["nginx"]
+	assert.Assert(t, ok, "session entry must be keyed by the clean name")
+	assert.Assert(t, entry.Optional)
+	// The instance is only starting, but as the sole (optional) member it
+	// cannot gate the session.
+	assert.Assert(t, session.IsReady())
+
+	select {
+	case <-startCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("InstanceStart was never called asynchronously")
+	}
+}
+
 func TestRequestSessionGroup_DoesNotRejectUnlabeledInstances(t *testing.T) {
 	manager, sessions, provider := setupSablier(t)
 	manager.WithRejectUnlabeledRequests(true)

--- a/pkg/sablier/session_test.go
+++ b/pkg/sablier/session_test.go
@@ -75,6 +75,71 @@ func TestSessionState_InstanceErrors(t *testing.T) {
 	assert.Assert(t, contains(err.Error(), "a: first") || contains(err.Error(), "b: second"))
 }
 
+// Optional (best-effort) instances never gate a session: their errors and
+// readiness are ignored by IsReady, InstanceErrors and NotReadyInstances.
+func TestSessionState_OptionalInstancesDoNotGate(t *testing.T) {
+	s := &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"gold": {
+				Instance: sablier.InstanceInfo{Name: "gold", Status: sablier.InstanceStatusReady},
+			},
+			"silver-starting": {
+				Instance: sablier.InstanceInfo{Name: "silver-starting", Status: sablier.InstanceStatusStarting},
+				Optional: true,
+			},
+			"silver-error": {
+				Instance: sablier.InstanceInfo{Name: "silver-error", Status: sablier.InstanceStatusError},
+				Error:    errors.New("boom"),
+				Optional: true,
+			},
+		},
+	}
+
+	assert.Assert(t, s.IsReady())
+	assert.NilError(t, s.InstanceErrors())
+	assert.Equal(t, len(s.NotReadyInstances()), 0)
+}
+
+func TestSessionState_RequiredInstanceStillGatesAlongsideOptional(t *testing.T) {
+	s := &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"gold": {
+				Instance: sablier.InstanceInfo{Name: "gold", Status: sablier.InstanceStatusStarting},
+			},
+			"silver": {
+				Instance: sablier.InstanceInfo{Name: "silver", Status: sablier.InstanceStatusReady},
+				Optional: true,
+			},
+		},
+	}
+
+	assert.Assert(t, !s.IsReady())
+	notReady := s.NotReadyInstances()
+	assert.Equal(t, len(notReady), 1)
+	assert.Equal(t, notReady[0].Instance.Name, "gold")
+}
+
+func TestSessionState_InstanceErrors_SkipsOptional(t *testing.T) {
+	s := &sablier.SessionState{
+		Instances: map[string]sablier.InstanceInfoWithError{
+			"gold": {
+				Instance: sablier.InstanceInfo{Name: "gold", Status: sablier.InstanceStatusReady},
+				Error:    errors.New("gold failed"),
+			},
+			"silver": {
+				Instance: sablier.InstanceInfo{Name: "silver", Status: sablier.InstanceStatusReady},
+				Error:    errors.New("silver failed"),
+				Optional: true,
+			},
+		},
+	}
+
+	err := s.InstanceErrors()
+	assert.Assert(t, err != nil)
+	assert.Assert(t, contains(err.Error(), "gold failed"))
+	assert.Assert(t, !contains(err.Error(), "silver failed"))
+}
+
 func TestSessionState_Status(t *testing.T) {
 	ready := &sablier.SessionState{
 		Instances: map[string]sablier.InstanceInfoWithError{


### PR DESCRIPTION
## Description

Prefixing a requested instance name with `optional:` marks it as **best-effort**: the instance is started and kept alive with the session exactly like any other member, but its readiness and errors never gate the session. The waiting page clears (and a blocking request returns) as soon as all non-optional instances are ready — even if an optional instance is still starting, unhealthy, or failed to start entirely.

```yaml
names: whoami,optional:whoami-helper
```

## Motivation

We run Sablier (Kubernetes provider, Traefik plugin, `names`-based middlewares) to scale entire dev environments (~80 deployments each) to zero. A single crashlooping auxiliary deployment (reporting worker, devtools API, …) currently holds the whole environment on the waiting page forever. `sablier.ready-on-start` helps for slow health checks but requires labeling every workload's chart, doesn't cover third-party charts, and still gates on start errors.

This feature lets a `names`-based setup split a stack into important instances visitors must wait for and auxiliary ones that wake and hibernate together with the stack but can never hold it hostage when broken.

## Design notes

- **The marker travels inside the name**, so every existing reverse-proxy plugin forwards it unchanged — no plugin change, no plugin upgrade needed by users.
- **Collision-free**: Docker, Swarm, Podman and Kubernetes names cannot contain a colon.
- **Stripped early**: the prefix is removed at session-request time (`RequestSession`), so providers, the session store, metrics and the waiting page all see the clean name.
- Optionality is **per request**, carried in `InstanceInfoWithError.Optional`; `SessionState.IsReady()`, `InstanceErrors()` and `NotReadyInstances()` skip optional entries. A session whose members are all optional is immediately ready.
- Optional instances still appear in session/API responses (new `optional` field on the instance entry) so the waiting page details remain complete.
- Group-based sessions are unchanged; a `sablier.best-effort` label for label-discovered groups would be the natural follow-up if this direction is accepted — happy to do that in a separate PR.

## Changes

- `pkg/sablier/session_request.go` — `OptionalPrefix` constant, prefix stripping, `Optional` flag on `InstanceInfoWithError`
- `pkg/sablier/session.go` — optional entries skipped in `IsReady`, `NotReadyInstances`, `InstanceErrors`
- `internal/api` — `optional` field on `InstanceEntryResponse`, `names` param docs for both strategies
- `docs/content/how-to-guides/readiness/optional-instances.md` — new how-to guide
- `docs/static/openapi.json` — regenerated (`make openapi`)

## Tests

- `TestSessionState_OptionalInstancesDoNotGate`, `TestSessionState_RequiredInstanceStillGatesAlongsideOptional`, `TestSessionState_InstanceErrors_SkipsOptional`
- `TestRequestSession_OptionalPrefix` — verifies the prefix is stripped before store/provider calls, the entry is keyed by the clean name, and carries the flag

`go build ./...`, `go vet` and the `pkg/sablier` + `internal/api` suites pass locally.