### PR TITLE
docs: add Discord link to the website navigation bar

### DIFF
--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -51,6 +51,11 @@ menu:
       url: "https://github.com/sablierapp/sablier"
       params:
         icon: github
+    - name: Discord
+      weight: 7
+      url: "https://discord.gg/WXYp59KeK9"
+      params:
+        icon: discord
   sidebar:
     - identifier: more
       name: More


### PR DESCRIPTION
## What

Adds a Discord icon link to the navbar on [sablierapp.dev](https://sablierapp.dev), next to the existing GitHub icon.

## Why

The Discord server is currently only advertised in the README. Visitors who land on the docs site — the majority of people evaluating Sablier — have no visible path to the community. This is the first step toward making it easier for users to reach us (and for us to reach them).

## Notes

- Uses the `discord` icon that Hextra v0.12.3 already ships in `data/icons.yaml`, so no new assets are needed.
- Renders as an icon-only link with `target="_blank"` and an `sr-only` "Discord" label, identical to the GitHub entry.
- Icon-only menu items are skipped in the mobile hamburger sidebar by the theme — same existing behaviour as the GitHub icon.

Verified with a local `hugo` build (90 pages, exit 0).