### PR TITLE
docs: share giscus comment threads across doc versions

### DIFF
--- a/docs/layouts/_partials/components/giscus.html
+++ b/docs/layouts/_partials/components/giscus.html
@@ -1,0 +1,114 @@
+{{- /* Overrides Hextra's components/giscus.html to make comment threads shared
+  across documentation versions.
+
+  build.sh publishes every version under its own baseURL (/, /next/, /vX.Y/), so
+  the same page has several pathnames. Hextra's default `data-mapping=pathname`
+  turns each of them into a separate GitHub discussion — /v1.15/tutorials/x/ and
+  /v1.16/tutorials/x/ and /tutorials/x/ would all get their own thread, and a
+  reader on the latest docs never sees a question asked on the previous minor.
+
+  Instead we strip the version prefix (the baseURL path) off the page's
+  RelPermalink and pass the remainder as an explicit `data-term` with
+  `data-mapping=specific`, so every version of a page resolves to one thread.
+
+  Everything below the term computation is unchanged from Hextra v0.12.3 except
+  the data-mapping/data-term entries; re-sync it when bumping the theme. */ -}}
+
+{{- $lang := site.Language.Lang | default `en` -}}
+{{- if hasPrefix $lang "zh" -}}
+  {{- /* See: https://github.com/giscus/giscus/tree/main/locales */}}
+  {{- $lang = partial "utils/hugo-compat/language-locale.html" site.Language | default `zh-CN` -}}
+{{- end -}}
+
+{{- /* Version-independent discussion term, e.g. "tutorials/reverse-proxies/".
+  Derived from the baseURL path rather than a hardcoded version pattern so it
+  keeps working whatever prefix scheme build.sh uses. The home page trims to the
+  empty string, which giscus would reject, hence the "index" fallback. */ -}}
+{{- $basePath := (urls.Parse site.BaseURL).Path | default "/" -}}
+{{- $term := strings.TrimPrefix "/" (strings.TrimPrefix $basePath .RelPermalink) -}}
+{{- $term = $term | default "index" -}}
+
+{{- with site.Params.comments.giscus -}}
+<script>
+  function getGiscusTheme() {
+    const giscusTheme = '{{ .theme }}';
+    if (giscusTheme === 'light' || giscusTheme === 'dark') {
+      return giscusTheme;
+    }
+
+    const hugoTheme = localStorage.getItem("color-theme");
+    if (hugoTheme === 'light' || hugoTheme === 'dark') {
+      return hugoTheme;
+    }
+
+    if (hugoTheme === 'system') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    const defaultTheme = '{{ site.Params.theme.default }}';
+    if (defaultTheme === 'light' || defaultTheme === 'dark') {
+      return defaultTheme;
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  function setGiscusTheme() {
+    const iframe = document.querySelector('iframe.giscus-frame');
+    if (!iframe) return;
+
+    const msg = {
+      giscus: {
+        setConfig: {
+          theme: getGiscusTheme(),
+        },
+      },
+    }
+
+    iframe.contentWindow.postMessage(msg, 'https://giscus.app');
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const giscusAttributes = {
+      "src": "https://giscus.app/client.js",
+      "data-repo": "{{ .repo }}",
+      "data-repo-id": "{{ .repoId }}",
+      "data-category": "{{ .category }}",
+      "data-category-id": "{{ .categoryId }}",
+      "data-mapping": "specific",
+      "data-term": {{ $term }},
+      "data-strict": "{{ (string .strict) | default 0 }}",
+      "data-reactions-enabled": "{{ (string .reactionsEnabled) |  default 1 }}",
+      "data-emit-metadata": "{{ (string .emitMetadata) | default 0 }}",
+      "data-input-position": "{{ .inputPosition | default `top` }}",
+      "data-theme": getGiscusTheme(),
+      "data-lang": "{{ .lang | default $lang }}",
+      "crossorigin": "anonymous",
+      "async": "",
+    };
+
+    // Dynamically create script tag
+    const giscusScript = document.createElement("script");
+    Object.entries(giscusAttributes).forEach(([key, value]) => giscusScript.setAttribute(key, value));
+    // Random hash id to avoid conflicts with titles inside pages.
+    document.getElementById('giscus-hextra-bb112b9f807c37c1752e5da6a1652a29').appendChild(giscusScript);
+
+    // Listen for system theme changes
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", setGiscusTheme);
+
+    // Update giscus theme when theme switcher is clicked.
+    const themeToggleOptions = document.querySelectorAll(".hextra-theme-toggle-options [data-item]");
+    if (themeToggleOptions) {
+      themeToggleOptions.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+          setTimeout(setGiscusTheme, 0);
+        });
+      });
+    }
+  });
+</script>
+
+<div id="giscus-hextra-bb112b9f807c37c1752e5da6a1652a29"></div>
+{{- else -}}
+  {{ warnf "giscus is not configured" }}
+{{- end -}}


### PR DESCRIPTION
## Problem

[Discussion #1014](https://github.com/sablierapp/sablier/discussions/1014) is titled `v1.15/tutorials/reverse-proxies/` — the version prefix is baked into the giscus term.

`docs/build.sh` publishes every version under its own baseURL (`/`, `/next/`, `/vX.Y/`), so the same page has several pathnames. Hextra''s default `data-mapping=pathname` turns each one into a separate GitHub discussion:

| URL | discussion term (before) |
|---|---|
| `/tutorials/reverse-proxies/` | `tutorials/reverse-proxies/` |
| `/v1.15/tutorials/reverse-proxies/` | `v1.15/tutorials/reverse-proxies/` |
| `/v1.16/tutorials/reverse-proxies/` | `v1.16/tutorials/reverse-proxies/` |
| `/next/tutorials/reverse-proxies/` | `next/tutorials/reverse-proxies/` |

So a question asked on v1.15 is invisible to a reader on the latest docs, and the fragmentation grows by one thread per page with every release.

## Fix

Hextra''s `components/giscus.html` only emits `data-mapping` — there is no `data-term` hook — so this overrides the partial (the repo already overrides `navbar-title.html` and `favicons.html`).

The term is now the page''s `RelPermalink` with the baseURL path stripped, passed as an explicit `data-term` with `data-mapping=specific`:

```go-html-template
{{- $basePath := (urls.Parse site.BaseURL).Path | default "/" -}}
{{- $term := strings.TrimPrefix "/" (strings.TrimPrefix $basePath .RelPermalink) -}}
{{- $term = $term | default "index" -}}
```

Deriving the prefix from the baseURL rather than matching a `v[0-9]+\.[0-9]+` pattern means it keeps working whatever prefix scheme `build.sh` uses later.

## Verification

Built the site at all three baseURL shapes and compared the emitted terms:

```
g-root   data-mapping": "specific", data-term": "tutorials/reverse-proxies/",
g-v115   data-mapping": "specific", data-term": "tutorials/reverse-proxies/",
g-next   data-mapping": "specific", data-term": "tutorials/reverse-proxies/",
```

Across all 64 comment-enabled pages in each build: `0` empty terms, `0` version-prefixed terms, and the term sets are identical between builds (`Compare-Object` diff = 0 for root-vs-v1.15 and root-vs-next).

## Follow-up (not in this PR)

Discussion #1014 keeps its old title and will be orphaned — the page will open a fresh thread on the next comment. Renaming it to `tutorials/reverse-proxies/` in the GitHub UI reattaches its existing comment. It is the only giscus discussion so far, so that is a one-line manual fix.

## Note for theme upgrades

The partial is a fork of Hextra v0.12.3''s, with only the `data-mapping`/`data-term` entries changed. The header comment says so — re-sync it when bumping the theme.