### PR TITLE
docs(themes): correct the themes endpoint path and response shape

### DIFF
--- a/docs/content/how-to-guides/loading-strategies/customize-theme.md
+++ b/docs/content/how-to-guides/loading-strategies/customize-theme.md
@@ -153,22 +153,36 @@ curl 'http://localhost:10000/api/strategies/dynamic?session_duration=1m&names=ng
 
 ## See the available themes from the API
 
+The themes endpoint is served at `/api/themes` (the legacy path `/api/dynamic/themes` still
+works). It returns every loaded theme, embedded and custom alike, in a single sorted list.
+
 ```bash
-curl 'http://localhost:10000/api/strategies/dynamic/themes'
+curl 'http://localhost:10000/api/themes'
 ```
+
+With the layout shown in [How to load your custom theme](#how-to-load-your-custom-theme):
+
 ```json
 {
-  "custom": [
-    "custom"
-  ],
-  "embedded": [
+  "themes": [
+    "custom1",
+    "custom2",
     "ghost",
     "hacker-terminal",
     "matrix",
-    "shuffle"
+    "shuffle",
+    "special/secret"
   ]
 }
 ```
+
+{{< callout type="info" >}}
+The Sablier image is built `FROM scratch` and contains only the Sablier binary, so there is no
+shell and no `curl` inside the container. Call the endpoint from another container on the same
+network, or from the host through the published port.
+{{< /callout >}}
+
+See the [API reference](/reference/api/) for the full `themes` endpoint documentation.
 
 ## Design your theme in the browser
 

--- a/docs/content/how-to-guides/loading-strategies/customize-theme.md
+++ b/docs/content/how-to-guides/loading-strategies/customize-theme.md
@@ -176,12 +176,6 @@ With the layout shown in [How to load your custom theme](#how-to-load-your-custo
 }
 ```
 
-{{< callout type="info" >}}
-The Sablier image is built `FROM scratch` and contains only the Sablier binary, so there is no
-shell and no `curl` inside the container. Call the endpoint from another container on the same
-network, or from the host through the published port.
-{{< /callout >}}
-
 See the [API reference](/reference/api/) for the full `themes` endpoint documentation.
 
 ## Design your theme in the browser


### PR DESCRIPTION
Part 1 of 3 for #1081 — the documentation half.

`how-to-guides/loading-strategies/customize-theme.md` documented a themes endpoint that has never existed and a response body the handler has never returned, which is what sent the reporter down a long debugging path.

| Documented | Actual |
|---|---|
| `GET /api/strategies/dynamic/themes` | `GET /api/themes`, with `GET /api/dynamic/themes` kept as a legacy alias ([`internal/api/theme_list.go`](https://github.com/sablierapp/sablier/blob/main/internal/api/theme_list.go#L22-L23)) |
| `{"custom": [...], "embedded": [...]}` | `{"themes": [...]}` ([`api.ThemesResponse`](https://github.com/sablierapp/sablier/blob/main/internal/api/responses.go#L58-L61)) |

Also in this PR:

- The sample response now matches the directory tree documented a few lines above it. It previously listed a single `custom` theme against a tree containing three, which is what made the reporter doubt how theme naming works at all.
- A pointer to the full API reference.

### Note on `special/secret`

The sample response lists the nested theme as `special/secret`, matching the tree and the naming rule stated in *How to load your custom theme*. The code does **not** currently behave that way — it registers nested themes under their base name. That is fixed separately in the third PR of this series; this one leaves the naming documentation untouched.

## Test plan

- [x] Endpoint paths and response shape verified against `internal/api/theme_list.go` and `internal/api/responses.go`
- [x] The `/reference/api/` link target exists
- [x] No fragment on the API reference link, so `htmltest` does not try to resolve an anchor inside the Scalar single-page app

🤖 Generated with [Claude Code](https://claude.com/claude-code)