### PR TITLE
feat(theme): default the custom themes path to /etc/sablier/themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,9 @@ logging:
   level: info
 strategy:
   dynamic:
-    # Custom themes folder, will load all .html files recursively (default empty)
-    custom-themes-path:
+    # Custom themes folder, will load all .html files recursively.
+    # A missing folder is not an error, only the built-in themes are served then.
+    custom-themes-path: /etc/sablier/themes
     # Show instances details by default in waiting UI
     show-details-by-default: true
     # Default theme used for dynamic strategy (default "hacker-terminal")

--- a/docs/content/how-to-guides/loading-strategies/customize-theme.md
+++ b/docs/content/how-to-guides/loading-strategies/customize-theme.md
@@ -36,9 +36,12 @@ You can also extend the themes by providing your own, which will be rendered as 
 
 ## Custom themes locations
 
-You can use the `--strategy.dynamic.custom-themes-path` argument to define the location where Sablier should search for themes at startup.
+`--strategy.dynamic.custom-themes-path` defaults to `/etc/sablier/themes`, so the volume mount
+shown at the top of this page is all you need: no extra argument is required. Set the argument
+only when you want Sablier to look somewhere else.
 
-By default, the docker image looks for themes located inside the `/etc/sablier/themes` folder. The volume mount shown at the top of this page makes your themes available at that path.
+If the folder does not exist, Sablier serves the embedded themes and says so at `debug` level,
+so leaving the default in place costs nothing when you have no custom themes.
 
 Sablier will recursively search for themes with the `.html` extension.
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -636,7 +636,7 @@ SABLIER_STORAGE_FILE=<string>
 |--------|-------------|
 | [`--strategy.blocking.default-refresh-frequency`](#opt-strategy-blocking-default-refresh-frequency) | Default refresh frequency at which the instances status are checked for blocking strategy |
 | [`--strategy.blocking.default-timeout`](#opt-strategy-blocking-default-timeout) | Default timeout used for blocking strategy |
-| [`--strategy.dynamic.custom-themes-path`](#opt-strategy-dynamic-custom-themes-path) | Custom themes folder, will load all .html files recursively |
+| [`--strategy.dynamic.custom-themes-path`](#opt-strategy-dynamic-custom-themes-path) | Custom themes folder, will load all .html files recursively (a missing folder is not an error, Sablier then serves only the built-in themes) |
 | [`--strategy.dynamic.default-refresh-frequency`](#opt-strategy-dynamic-default-refresh-frequency) | Default refresh frequency in the HTML page for dynamic strategy |
 | [`--strategy.dynamic.default-theme`](#opt-strategy-dynamic-default-theme) | Default theme used for dynamic strategy |
 | [`--strategy.dynamic.show-details-by-default`](#opt-strategy-dynamic-show-details-by-default) | Show the loading instances details by default |
@@ -685,23 +685,23 @@ SABLIER_STRATEGY_BLOCKING_DEFAULT_TIMEOUT=1m0s
 
 ### `--strategy.dynamic.custom-themes-path` {#opt-strategy-dynamic-custom-themes-path}
 
-Custom themes folder, will load all .html files recursively
+Custom themes folder, will load all .html files recursively (a missing folder is not an error, Sablier then serves only the built-in themes)
 
-{{< badge "string" >}} {{< badge content="Since v1.0.0" link="https://github.com/sablierapp/sablier/releases/tag/v1.0.0" >}}
+{{< badge "string" >}} {{< badge content="Default: /etc/sablier/themes" >}} {{< badge content="Since v1.0.0" link="https://github.com/sablierapp/sablier/releases/tag/v1.0.0" >}}
 
 ```yaml
 # sablier.yaml
 strategy:
   dynamic:
-    custom-themes-path: <string>
+    custom-themes-path: /etc/sablier/themes
 ```
 
 ```bash
 # Environment variable
-SABLIER_STRATEGY_DYNAMIC_CUSTOM_THEMES_PATH=<string>
+SABLIER_STRATEGY_DYNAMIC_CUSTOM_THEMES_PATH=/etc/sablier/themes
 
 # Command-line flag
---strategy.dynamic.custom-themes-path=<string>
+--strategy.dynamic.custom-themes-path=/etc/sablier/themes
 ```
 
 ### `--strategy.dynamic.default-refresh-frequency` {#opt-strategy-dynamic-default-refresh-frequency}

--- a/examples/custom-theme/compose.yml
+++ b/examples/custom-theme/compose.yml
@@ -8,14 +8,14 @@ services:
       - --logging.level=debug
       - --sessions.default-duration=1m
       - --sessions.expiration-interval=10s
-      # Point Sablier at the themes directory mounted below.
-      - --strategy.dynamic.custom-themes-path=/themes
+      # No --strategy.dynamic.custom-themes-path needed: the themes below are
+      # mounted at the default location, /etc/sablier/themes.
       - --strategy.dynamic.default-theme=my-theme
       - --strategy.dynamic.show-details-by-default=true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # Mount the local themes folder so Sablier can bundle the assets at startup.
-      - ./themes:/themes
+      - ./themes:/etc/sablier/themes
     ports:
       - "10000:10000"
 

--- a/pkg/config/strategy.go
+++ b/pkg/config/strategy.go
@@ -2,14 +2,21 @@ package config
 
 import "time"
 
+// DefaultCustomThemesPath is where Sablier looks for custom waiting-page themes when
+// --strategy.dynamic.custom-themes-path is not set. It is the path the documentation
+// tells users to mount their themes at; a missing directory is not an error.
+const DefaultCustomThemesPath = "/etc/sablier/themes"
+
 // DynamicStrategy holds configuration for the dynamic (waiting-page) strategy.
 type DynamicStrategy struct {
 	// CustomThemesPath is a directory from which Sablier loads custom waiting-page themes.
 	// All .html files found recursively under this path are registered as named themes.
-	// Leave empty to use only the built-in themes.
+	// The default is the path the documentation tells you to mount your themes at; when it
+	// does not exist Sablier simply serves the built-in themes. Set it to "" to skip the
+	// lookup entirely.
 	// Env: SABLIER_STRATEGY_DYNAMIC_CUSTOM_THEMES_PATH
 	// CLI: --strategy.dynamic.custom-themes-path
-	// Default: "" (built-in themes only)
+	// Default: "/etc/sablier/themes"
 	// Since: v1.0.0
 	CustomThemesPath string
 
@@ -70,6 +77,7 @@ func NewStrategyConfig() Strategy {
 
 func newDynamicStrategy() DynamicStrategy {
 	return DynamicStrategy{
+		CustomThemesPath:        DefaultCustomThemesPath,
 		DefaultTheme:            "hacker-terminal",
 		ShowDetailsByDefault:    true,
 		DefaultRefreshFrequency: 5 * time.Second,

--- a/pkg/sabliercmd/root.go
+++ b/pkg/sabliercmd/root.go
@@ -106,7 +106,7 @@ It provides integrations with multiple reverse proxies and different loading str
 	_ = viper.BindPFlag("logging.level", rootCmd.PersistentFlags().Lookup("logging.level"))
 
 	// strategy
-	startCmd.Flags().StringVar(&conf.Strategy.Dynamic.CustomThemesPath, "strategy.dynamic.custom-themes-path", "", "Custom themes folder, will load all .html files recursively")
+	startCmd.Flags().StringVar(&conf.Strategy.Dynamic.CustomThemesPath, "strategy.dynamic.custom-themes-path", config.DefaultCustomThemesPath, "Custom themes folder, will load all .html files recursively (a missing folder is not an error, Sablier then serves only the built-in themes)")
 	_ = viper.BindPFlag("strategy.dynamic.custom-themes-path", startCmd.Flags().Lookup("strategy.dynamic.custom-themes-path"))
 	startCmd.Flags().StringVar(&conf.Strategy.Dynamic.DefaultTheme, "strategy.dynamic.default-theme", "hacker-terminal", "Default theme used for dynamic strategy")
 	_ = viper.BindPFlag("strategy.dynamic.default-theme", startCmd.Flags().Lookup("strategy.dynamic.default-theme"))

--- a/pkg/sabliercmd/testdata/config_default.json
+++ b/pkg/sabliercmd/testdata/config_default.json
@@ -45,7 +45,7 @@
   },
   "Strategy": {
     "Dynamic": {
-      "CustomThemesPath": "",
+      "CustomThemesPath": "/etc/sablier/themes",
       "ShowDetailsByDefault": true,
       "DefaultTheme": "hacker-terminal",
       "DefaultRefreshFrequency": 5000000000

--- a/pkg/sabliercmd/theme.go
+++ b/pkg/sabliercmd/theme.go
@@ -2,6 +2,8 @@ package sabliercmd
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"log/slog"
 
 	"github.com/sablierapp/sablier/pkg/config"
@@ -9,23 +11,27 @@ import (
 )
 
 func setupTheme(ctx context.Context, conf config.Config, logger *slog.Logger) (*theme.Themes, error) {
-	if conf.Strategy.Dynamic.CustomThemesPath != "" {
-		logger.DebugContext(ctx, "loading themes from custom theme path", slog.String("path", conf.Strategy.Dynamic.CustomThemesPath))
-		t, err := theme.NewWithCustomThemesFromPath(conf.Strategy.Dynamic.CustomThemesPath, logger)
-		if err != nil {
-			logger.WarnContext(ctx, "loading themes without custom theme path", slog.String("reason", "failed to load custom themes"), slog.String("error", err.Error()))
-			t, err = theme.New(logger)
-			if err != nil {
-				return nil, err
-			}
-		}
+	path := conf.Strategy.Dynamic.CustomThemesPath
+	if path == "" {
+		logger.DebugContext(ctx, "loading themes without custom theme path", slog.String("reason", "--strategy.dynamic.custom-themes-path is empty"))
+		return theme.New(logger)
+	}
+
+	logger.DebugContext(ctx, "loading themes from custom theme path", slog.String("path", path))
+	t, err := theme.NewWithCustomThemesFromPath(path, logger)
+	if err == nil {
 		return t, nil
 	}
-	logger.DebugContext(ctx, "loading themes without custom theme path", slog.String("reason", "--strategy.dynamic.custom-themes-path is empty"))
-	t, err := theme.New(logger)
-	if err != nil {
-		return nil, err
 
+	// The custom themes path now defaults to /etc/sablier/themes, which nothing creates:
+	// an absent directory is the normal case for every deployment that does not mount
+	// custom themes, so it must not be reported as a problem. Anything else (permissions,
+	// an unparsable template) is a real misconfiguration and stays a warning.
+	if errors.Is(err, fs.ErrNotExist) {
+		logger.DebugContext(ctx, "loading themes without custom theme path", slog.String("reason", "custom themes path does not exist"), slog.String("path", path))
+	} else {
+		logger.WarnContext(ctx, "loading themes without custom theme path", slog.String("reason", "failed to load custom themes"), slog.String("path", path), slog.String("error", err.Error()))
 	}
-	return t, nil
+
+	return theme.New(logger)
 }

--- a/pkg/sabliercmd/theme_test.go
+++ b/pkg/sabliercmd/theme_test.go
@@ -1,0 +1,80 @@
+package sabliercmd
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sablierapp/sablier/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestLogger returns a debug-level logger writing into buf so the tests can
+// assert on the severity used to report a missing custom themes directory.
+func newTestLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func confWithThemesPath(path string) config.Config {
+	c := config.NewConfig()
+	c.Strategy.Dynamic.CustomThemesPath = path
+	return c
+}
+
+func TestSetupTheme(t *testing.T) {
+	t.Run("default path is the documented mount point", func(t *testing.T) {
+		assert.Equal(t, "/etc/sablier/themes", config.NewConfig().Strategy.Dynamic.CustomThemesPath)
+	})
+
+	t.Run("missing directory keeps the embedded themes without warning", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		// The default path does not exist on the machine running the tests, which is
+		// exactly the situation every deployment without custom themes is in.
+		missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+		themes, err := setupTheme(context.Background(), confWithThemesPath(missing), newTestLogger(buf))
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t, []string{"ghost", "hacker-terminal", "matrix", "shuffle"}, themes.List())
+		assert.NotContains(t, buf.String(), "level=WARN")
+	})
+
+	t.Run("custom themes are loaded from the directory", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "mine.html"), []byte("<html></html>"), 0o600))
+
+		themes, err := setupTheme(context.Background(), confWithThemesPath(dir), newTestLogger(&bytes.Buffer{}))
+		require.NoError(t, err)
+
+		assert.True(t, themes.Exists("mine"))
+	})
+
+	t.Run("an unreadable directory is still reported as a warning", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+		dir := filepath.Join(t.TempDir(), "unreadable")
+		require.NoError(t, os.Mkdir(dir, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+		buf := &bytes.Buffer{}
+		themes, err := setupTheme(context.Background(), confWithThemesPath(dir), newTestLogger(buf))
+		require.NoError(t, err)
+
+		assert.True(t, themes.Exists("hacker-terminal"))
+		assert.Contains(t, buf.String(), "level=WARN")
+	})
+
+	t.Run("an empty path skips the lookup entirely", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		themes, err := setupTheme(context.Background(), confWithThemesPath(""), newTestLogger(buf))
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t, []string{"ghost", "hacker-terminal", "matrix", "shuffle"}, themes.List())
+		assert.Contains(t, buf.String(), "--strategy.dynamic.custom-themes-path is empty")
+	})
+}

--- a/sablier.sample.yaml
+++ b/sablier.sample.yaml
@@ -18,7 +18,7 @@ logging:
   level: info
 strategy:
   dynamic:
-    custom-themes-path:
+    custom-themes-path: /etc/sablier/themes
     show-details-by-default: true
     default-theme: hacker-terminal
     default-refresh-frequency: 5s


### PR DESCRIPTION
Part 2 of 3 for #1081 — the reported bug itself.

Fixes #1081

## The problem

The documentation has always said:

> By default, the docker image looks for themes located inside the `/etc/sablier/themes` folder. The volume mount shown at the top of this page makes your themes available at that path.

But `--strategy.dynamic.custom-themes-path` defaulted to `""`, so the documented volume mount on its own did nothing. Every user had to discover and repeat the path by hand:

```yaml
volumes:
  - ./themes:/etc/sablier/themes:ro
command:
  - --strategy.dynamic.custom-themes-path=/etc/sablier/themes   # ← should not be necessary
```

## The change

`config.DefaultCustomThemesPath` (`/etc/sablier/themes`) is now the flag's default, so the documented mount is all that is needed. Setting the option to `""` still skips the lookup entirely.

### Keeping startup quiet

Nothing creates `/etc/sablier/themes`, so with this default an absent directory becomes the normal case for every deployment that does not use custom themes. `setupTheme` would otherwise have warned on every single startup. It now reports a missing directory at `debug` and keeps the embedded themes; permission errors and unparsable templates stay warnings, since those *are* misconfigurations.

### Also updated

- `docs/content/reference/cli.md` regenerated (`make cli-docs`) — the option now carries a `Default: /etc/sablier/themes` badge
- `sablier.sample.yaml`, the README config sample, and `pkg/sabliercmd/testdata/config_default.json`
- `examples/custom-theme` now demonstrates the default: it mounts at `/etc/sablier/themes` and passes no path flag at all

## Test plan

- [x] New `pkg/sabliercmd/theme_test.go` covering: the default value, a missing directory (embedded themes kept, no `WARN`), themes loaded from a real directory, an unreadable directory (still `WARN`), and `""` skipping the lookup
- [x] `go test ./pkg/... ./internal/...` — `pkg/provider/docker` fails locally on a testcontainers/colima DinD socket-mount issue unrelated to this change; everything else passes
- [x] `make check-generate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)