### PR TITLE
fix(theme): name custom themes after their path, ignore non-theme entries

### DIFF
--- a/pkg/theme/list.go
+++ b/pkg/theme/list.go
@@ -1,13 +1,20 @@
 package theme
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 // Exists reports whether a theme with the given name is loaded.
 func (t *Themes) Exists(name string) bool {
 	return t.themes.Lookup(name+".html") != nil
 }
 
-// List all the loaded themes
+// List all the loaded themes, sorted by name.
+//
+// The order is explicit because the underlying templates are held in a map:
+// without sorting, the themes endpoint and the "theme not found" problem detail
+// returned a differently ordered list on every call.
 func (t *Themes) List() []string {
 	themes := make([]string, 0)
 
@@ -17,5 +24,6 @@ func (t *Themes) List() []string {
 		}
 	}
 
+	slices.Sort(themes)
 	return themes
 }

--- a/pkg/theme/list_test.go
+++ b/pkg/theme/list_test.go
@@ -1,12 +1,16 @@
 package theme_test
 
 import (
-	"github.com/neilotoole/slogt"
-	"github.com/sablierapp/sablier/pkg/theme"
+	"bytes"
+	"slices"
 	"testing"
 	"testing/fstest"
 
+	"github.com/neilotoole/slogt"
+	"github.com/sablierapp/sablier/pkg/theme"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestList(t *testing.T) {
@@ -22,7 +26,9 @@ func TestList(t *testing.T) {
 
 	list := themes.List()
 
-	assert.ElementsMatch(t, []string{"theme1", "theme2", "ghost", "hacker-terminal", "matrix", "shuffle"}, list)
+	// Nested themes are named after their path relative to the themes directory,
+	// and the list is sorted so that the API returns a stable order.
+	assert.Equal(t, []string{"ghost", "hacker-terminal", "inner/theme2", "matrix", "shuffle", "theme1"}, list)
 }
 
 func TestExists(t *testing.T) {
@@ -38,4 +44,69 @@ func TestExists(t *testing.T) {
 	assert.True(t, themes.Exists("custom"))
 	assert.True(t, themes.Exists("ghost")) // embedded
 	assert.False(t, themes.Exists("nope"))
+}
+
+// TestListDoesNotCollideOnBaseName covers the case reported in #1081: naming a
+// theme after its base name let "special/secret.html" silently replace
+// "secret.html", so one of the two themes was unreachable and never listed.
+func TestListDoesNotCollideOnBaseName(t *testing.T) {
+	themes, err := theme.NewWithCustomThemes(
+		fstest.MapFS{
+			"secret.html":         &fstest.MapFile{Data: []byte("root")},
+			"special/secret.html": &fstest.MapFile{Data: []byte("nested")},
+		}, slogt.New(t))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	assert.Equal(t, []string{"ghost", "hacker-terminal", "matrix", "secret", "shuffle", "special/secret"}, themes.List())
+	assert.True(t, themes.Exists("secret"))
+	assert.True(t, themes.Exists("special/secret"))
+
+	for name, want := range map[string]string{"secret": "root", "special/secret": "nested"} {
+		w := &bytes.Buffer{}
+		require.NoError(t, themes.Render(name, theme.Options{}, w))
+		assert.Equal(t, want, w.String(), "theme %q rendered the wrong file", name)
+	}
+}
+
+// TestListIsSorted pins the ordering of the list returned to the themes
+// endpoint: the templates live in a map, so without an explicit sort the API
+// returned a different order on every call.
+func TestListIsSorted(t *testing.T) {
+	themes, err := theme.NewWithCustomThemes(
+		fstest.MapFS{
+			"zulu.html":  &fstest.MapFile{},
+			"alpha.html": &fstest.MapFile{},
+			"mike.html":  &fstest.MapFile{},
+		}, slogt.New(t))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	want := themes.List()
+	assert.True(t, slices.IsSorted(want))
+	for range 10 {
+		assert.Equal(t, want, themes.List())
+	}
+}
+
+// TestNonThemeEntriesAreIgnored covers the second half of #1081: the walk used
+// to accept anything whose path merely contained ".html", so a directory named
+// "partials.html" was handed to the bundler, failed to be read, and took every
+// custom theme down with it.
+func TestNonThemeEntriesAreIgnored(t *testing.T) {
+	themes, err := theme.NewWithCustomThemes(
+		fstest.MapFS{
+			"mine.html":                &fstest.MapFile{},
+			"partials.html/header.txt": &fstest.MapFile{},
+			"mine.html.bak":            &fstest.MapFile{},
+		}, slogt.New(t))
+	require.NoError(t, err)
+
+	assert.True(t, themes.Exists("mine"))
+	assert.False(t, themes.Exists("mine.html.bak"))
+	assert.NotContains(t, themes.List(), "partials.html/header.txt")
 }

--- a/pkg/theme/parse.go
+++ b/pkg/theme/parse.go
@@ -7,33 +7,51 @@ import (
 	"strings"
 )
 
+// isThemeFile reports whether the walked entry is a theme template: a regular
+// file whose extension is exactly ".html".
+//
+// The check used to be strings.Contains(filePath, ".html"), which also matched
+// directories such as "partials.html/" and files such as "theme.html.bak". A
+// matching directory was then handed to bundleHTML, whose read failed and
+// aborted the whole walk, so a single oddly named folder silently cost the user
+// every one of their custom themes.
+func isThemeFile(filePath string, d fs.DirEntry) bool {
+	return d != nil && !d.IsDir() && path.Ext(filePath) == ".html"
+}
+
 func (t *Themes) ParseTemplatesFS(f fs.FS) error {
-	err := fs.WalkDir(f, ".", func(filePath string, d fs.DirEntry, err error) error {
-		if strings.Contains(filePath, ".html") {
-			t.l.Info("theme found", slog.String("path", filePath))
-			_, err = t.themes.ParseFS(f, filePath)
-			if err != nil {
-				t.l.Info("cannot add theme", slog.String("path", filePath), slog.Any("reason", err))
-				return err
-			}
-
-			t.l.Info("successfully added theme", slog.String("path", filePath))
+	return fs.WalkDir(f, ".", func(filePath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		return err
-	})
+		if !isThemeFile(filePath, d) {
+			return nil
+		}
+		t.l.Info("theme found", slog.String("path", filePath))
+		if _, err = t.themes.ParseFS(f, filePath); err != nil {
+			t.l.Info("cannot add theme", slog.String("path", filePath), slog.Any("reason", err))
+			return err
+		}
 
-	return err
+		t.l.Info("successfully added theme", slog.String("path", filePath))
+		return nil
+	})
 }
 
 // ParseAndBundleTemplatesFS walks f and registers every .html file as a named
 // template, inlining relative CSS, JS, and image assets so that the resulting
 // template is fully self-contained (see bundleHTML for details).
+//
+// A theme is named after its path relative to the themes directory, without the
+// ".html" extension, so that "special/secret.html" is requested as
+// "special/secret". Naming themes after their base name instead let two files
+// in different sub-directories silently overwrite each other.
 func (t *Themes) ParseAndBundleTemplatesFS(f fs.FS) error {
 	return fs.WalkDir(f, ".", func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !strings.Contains(filePath, ".html") {
+		if !isThemeFile(filePath, d) {
 			return nil
 		}
 		t.l.Info("theme found", slog.String("path", filePath))
@@ -42,12 +60,17 @@ func (t *Themes) ParseAndBundleTemplatesFS(f fs.FS) error {
 			t.l.Info("cannot bundle theme", slog.String("path", filePath), slog.Any("reason", err))
 			return err
 		}
-		name := path.Base(filePath)
+		// Relative paths are unique, so the only name a custom theme can already
+		// occupy is that of an embedded theme, which it deliberately replaces.
+		name := path.Clean(filePath)
+		if t.themes.Lookup(name) != nil {
+			t.l.Info("theme overrides an embedded theme", slog.String("path", filePath), slog.String("name", strings.TrimSuffix(name, ".html")))
+		}
 		if _, err = t.themes.New(name).Parse(content); err != nil {
 			t.l.Info("cannot add theme", slog.String("path", filePath), slog.Any("reason", err))
 			return err
 		}
-		t.l.Info("successfully added theme", slog.String("path", filePath))
+		t.l.Info("successfully added theme", slog.String("path", filePath), slog.String("name", strings.TrimSuffix(name, ".html")))
 		return nil
 	})
 }

--- a/pkg/theme/render_test.go
+++ b/pkg/theme/render_test.go
@@ -133,12 +133,20 @@ func TestThemes_Render(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Load custom theme",
+			name: "Load custom theme by its path relative to the themes directory",
+			args: args{
+				name: "inner/custom-theme",
+				opts: options,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Load custom theme by its base name only",
 			args: args{
 				name: "custom-theme",
 				opts: options,
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -190,7 +198,7 @@ func ExampleThemes_Render() {
 		ErrorInstanceInfo,
 	}
 
-	err = themes.Render("custom-theme", theme.Options{
+	err = themes.Render("inner/custom-theme", theme.Options{
 		DisplayName:      "Test",
 		InstanceStates:   instances,
 		ShowDetails:      true,


### PR DESCRIPTION
Part 3 of 3 for #1081 — checking the loading code the reporter suspected. Three real defects, each with a regression test.

Refs #1081

## 1. Nested themes were named after their base name

The docs have always described relative-path naming:

```
/my/custom/strategies/themes/
├── custom1.html      # custom1
├── custom2.html      # custom2
└── special
    └── secret.html   # special/secret
```

`ParseAndBundleTemplatesFS` used `path.Base(filePath)`, so `special/secret.html` registered as `secret`. With both files present, one silently overwrote the other:

```
list = [shuffle secret ghost hacker-terminal matrix]   # six themes on disk, five loaded
Exists("special/secret") = false
Exists("secret")         = true   # ← whichever file the walk reached last
```

A theme is now named after its path relative to the themes directory, so relative paths are unique and cannot collide. Overriding an *embedded* theme still works and is now logged.

## 2. One oddly named folder disabled every custom theme

The walk matched any path merely *containing* `.html`, including directories. A folder named `partials.html/` was handed to `bundleHTML`, whose read failed, and the returned error aborted `fs.WalkDir` — so a single folder cost the user all of their custom themes. A file like `theme.html.bak` was also registered as a template that no name could ever look up.

`isThemeFile` now requires a regular file whose extension is exactly `.html`.

## 3. The themes list came back in a random order

`List()` iterated `template.Templates()`, which is backed by a map, so `/api/themes` and the `availableTheme` field of the *theme not found* problem detail returned a different order on every call. The list is now sorted.

## ⚠️ Behavior change

A custom theme in a sub-directory is now requested as `<subdir>/<name>` instead of `<name>`. This matches what the documentation has always said, but anyone who worked out the base-name behavior empirically will need to update their `theme=` parameter. Themes at the root of the themes directory are unaffected. Happy to add a base-name fallback for one release instead if you would rather not break those users.

Note that no documentation change is needed here — the docs already describe the fixed behavior. PR #1086 documents the corrected sample response that assumes this fix.

## Test plan

- [x] `TestListDoesNotCollideOnBaseName` — both `secret` and `special/secret` load, are listed, and render their own file
- [x] `TestNonThemeEntriesAreIgnored` — a `partials.html/` directory and a `.html.bak` file no longer break or pollute loading
- [x] `TestListIsSorted` — the list is sorted and stable across repeated calls
- [x] `TestThemes_Render` extended: the nested theme resolves by relative path and no longer by base name
- [x] `go test ./pkg/theme/... ./internal/... ./pkg/sabliercmd/...` passes; `make check-generate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)