### PR TITLE
fix(tinykv): send onExpire when a stale timer is in the same cycle

### DIFF
--- a/pkg/tinykv/tinykv.go
+++ b/pkg/tinykv/tinykv.go
@@ -344,15 +344,15 @@ func (kv *store[T]) expireFunc() time.Duration {
 			expired[last.key] = entry.value
 		}
 	}
-REVAL:
+	// Validate all candidates before you delete them. A deleted key looks like a
+	// renewed key. See https://github.com/sablierapp/sablier/issues/1110
 	for k := range expired {
-		newVal, ok := kv.kv[k]
-		if !ok ||
-			newVal.timeout == nil ||
-			!newVal.expired() {
+		current, ok := kv.kv[k]
+		if !ok || current.timeout == nil || !current.expired() {
 			delete(expired, k)
-			goto REVAL
 		}
+	}
+	for k := range expired {
 		delete(kv.kv, k)
 	}
 	go notifyExpirations(expired, kv.onExpire)

--- a/pkg/tinykv/tinykv_test.go
+++ b/pkg/tinykv/tinykv_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -409,6 +410,83 @@ func TestOrdering(t *testing.T) {
 	}
 
 	assert.Equal(1, 1)
+}
+
+// putAt adds an entry with a given expiry time. It keeps the timers from
+// earlier calls in the heap, the same as Put.
+func putAt[T any](kv *store[T], k string, v T, expiresAt time.Time) {
+	to := &timeout{
+		expiresAt:    expiresAt,
+		expiresAfter: time.Until(expiresAt),
+		key:          k,
+	}
+	kv.kv[k] = &entry[T]{timeout: to, value: v}
+	timeheapPush(&kv.heap, to)
+}
+
+// One expiry cycle can pop an expired key and a stale timer of a renewed key.
+// See https://github.com/sablierapp/sablier/issues/1110
+func TestExpireFuncNotifiesExpiredKeyWithRenewedNeighbour(t *testing.T) {
+	for i := range 200 {
+		expired := make(chan string, 4)
+		kv := &store[int]{
+			onExpire:           func(k string, _ int) { expired <- k },
+			stop:               make(chan struct{}),
+			kv:                 make(map[string]*entry[int]),
+			expirationInterval: time.Hour,
+			heap:               th{},
+		}
+
+		// Key "a" is expired. Key "b" has a stale timer and a new timer.
+		past := time.Now().Add(-time.Minute)
+		putAt(kv, "a", 1, past)
+		timeheapPush(&kv.heap, &timeout{expiresAt: past, expiresAfter: time.Minute, key: "b"})
+		putAt(kv, "b", 2, time.Now().Add(time.Hour))
+
+		kv.expireFunc()
+
+		select {
+		case k := <-expired:
+			require.Equalf(t, "a", k, "iteration %d, only the idle key must expire", i)
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d, onExpire did not fire for the expired key", i)
+		}
+
+		_, ok := kv.kv["a"]
+		assert.Falsef(t, ok, "iteration %d, the store must not contain the expired key", i)
+		_, ok = kv.kv["b"]
+		assert.Truef(t, ok, "iteration %d, the store must contain the renewed key", i)
+	}
+}
+
+// The same defect through the public API.
+// See https://github.com/sablierapp/sablier/issues/1110
+func TestRenewedKeyKeepsNeighbourNotification(t *testing.T) {
+	for i := range 5 {
+		var mu sync.Mutex
+		fired := map[string]int{}
+		kv := New[int](20*time.Millisecond, func(k string, _ int) {
+			mu.Lock()
+			fired[k]++
+			mu.Unlock()
+		})
+
+		require.NoError(t, kv.Put("a", 1, 100*time.Millisecond))
+		require.NoError(t, kv.Put("b", 1, 100*time.Millisecond))
+		<-time.After(60 * time.Millisecond)
+		require.NoError(t, kv.Put("b", 2, time.Hour))
+		<-time.After(300 * time.Millisecond)
+
+		_, ok := kv.Get("a")
+		assert.Falsef(t, ok, "iteration %d, the store must not contain the idle key", i)
+
+		mu.Lock()
+		assert.Positivef(t, fired["a"], "iteration %d, onExpire must fire for the idle key", i)
+		assert.Zerof(t, fired["b"], "iteration %d, the renewed key must not expire", i)
+		mu.Unlock()
+
+		kv.Stop()
+	}
 }
 
 func BenchmarkGetNoValue(b *testing.B) {


### PR DESCRIPTION
Fixes #1110

## Problem

`Put` adds a new timer to the heap for each renewal. `Put` keeps the old timer in the heap. Thus one expiry cycle can pop an expired key and also a stale timer of a key that a renewal replaced.

The validation loop deletes store entries in the same loop that validates the candidates. The loop also restarts itself with `goto REVAL` each time it finds a renewed candidate.

```go
REVAL:
	for k := range expired {
		newVal, ok := kv.kv[k]
		if !ok || newVal.timeout == nil || !newVal.expired() {
			delete(expired, k)
			goto REVAL
		}
		delete(kv.kv, k)
	}
```

The candidates are key `a` and key `b`. Key `a` is expired. A renewal replaced the timer of key `b`. The loop finds key `a` first.

1. Key `a` is valid. The loop does `delete(kv.kv, "a")`.
2. Key `b` is not valid. The loop removes key `b` from `expired` and does `goto REVAL`.
3. The new loop finds key `a` again. Key `a` is absent from the store, thus the loop removes key `a` from `expired`.
4. `notifyExpirations` gets an empty map.

Key `a` is now absent from the store and from the heap. Thus `onExpire` does not fire, Sablier writes no log, and Sablier does not stop the instance. Key `a` cannot expire later, because the store does not contain it. Only a new session from `--provider.auto-warm-externally-started` or a manual stop can stop the instance.

The in-memory store does this cycle each second. Thus the two requests must occur in the same second, one session duration before. Two independent groups with the default duration can do this on a usual day.

## Solution

Validate all candidates first. Then delete the keys that stay. Go permits a delete during a range loop, thus the restart is not necessary and the loop cannot find a key after the deletion of its entry. See the Go specification, For statements with range clause. https://go.dev/ref/spec#For_range

## Tests

There are two new tests in `pkg/tinykv`. Both tests fail on `main` and pass with this change.

- `TestExpireFuncNotifiesExpiredKeyWithRenewedNeighbour` calls `expireFunc` directly on a store with known content. The test is thus quick and has no dependency on time. The 200 iterations cover the random order of the map. On `main` the test fails at iteration 0.
- `TestRenewedKeyKeepsNeighbourNotification` does the same test through the public API. The test renews key `b` immediately before the first timer of key `b` expires. On `main` the test fails at each iteration.

`go test ./pkg/tinykv/ -count=1` and `go test ./pkg/store/inmemory/... -count=1` pass. `go vet` and `gofmt` show no problem. The race detector did not run locally, because the cgo tools on this Windows machine are defective. The same failure occurs on packages with no change. CI must do this test.

## Not in this pull request

Issue #1110 also mentions `sessions.expiration-interval`. The configuration parses this value, but `inmemory.NewInMemory()` uses a constant interval of 1 second. This is a different defect. It is thus not in this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
