### PR TITLE
fix(kubernetes): list only the running workloads when All is false

### DIFF
--- a/pkg/provider/kubernetes/cnpgcluster_integration_test.go
+++ b/pkg/provider/kubernetes/cnpgcluster_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/neilotoole/slogt"
 	"github.com/sablierapp/sablier/pkg/config"
+	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/provider/kubernetes"
 	"github.com/sablierapp/sablier/pkg/sablier"
 	"gotest.tools/v3/assert"
@@ -170,7 +171,7 @@ func TestKubernetesProvider_CNPGCluster(t *testing.T) {
 	})
 
 	t.Run("list discovers the cluster", func(t *testing.T) {
-		instances, err := p.ClusterList(ctx)
+		instances, err := p.ClusterList(ctx, provider.InstanceListOptions{All: true})
 		assert.NilError(t, err)
 		found := false
 		for _, i := range instances {

--- a/pkg/provider/kubernetes/cnpgcluster_list.go
+++ b/pkg/provider/kubernetes/cnpgcluster_list.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
@@ -33,7 +34,7 @@ func (p *Provider) listClusters(ctx context.Context) ([]unstructured.Unstructure
 	return list.Items, nil
 }
 
-func (p *Provider) ClusterList(ctx context.Context) ([]sablier.InstanceConfiguration, error) {
+func (p *Provider) ClusterList(ctx context.Context, opts provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
 	items, err := p.listClusters(ctx)
 	if err != nil {
 		return nil, err
@@ -41,10 +42,18 @@ func (p *Provider) ClusterList(ctx context.Context) ([]sablier.InstanceConfigura
 
 	instances := make([]sablier.InstanceConfiguration, 0, len(items))
 	for i := range items {
+		if !opts.All && !clusterIsRunning(&items[i]) {
+			continue
+		}
 		instances = append(instances, p.clusterToInstance(&items[i]))
 	}
 
 	return instances, nil
+}
+
+// The provider stops a Cluster when it sets the hibernation annotation to on.
+func clusterIsRunning(u *unstructured.Unstructured) bool {
+	return u.GetAnnotations()[cnpgHibernationAnnotation] != cnpgHibernationOn
 }
 
 func (p *Provider) clusterToInstance(u *unstructured.Unstructured) sablier.InstanceConfiguration {

--- a/pkg/provider/kubernetes/cnpgcluster_test.go
+++ b/pkg/provider/kubernetes/cnpgcluster_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/neilotoole/slogt"
+	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/sablier"
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
@@ -162,7 +163,7 @@ func TestProvider_ClusterListAndGroups(t *testing.T) {
 
 	p := newFakeCNPGProvider(t, enabled, enabledDefaultGroup, disabled)
 
-	instances, err := p.ClusterList(context.Background())
+	instances, err := p.ClusterList(context.Background(), provider.InstanceListOptions{All: true})
 	assert.NilError(t, err)
 	// Only the two sablier.enable=true clusters are listed.
 	assert.Equal(t, len(instances), 2)

--- a/pkg/provider/kubernetes/deployment_list.go
+++ b/pkg/provider/kubernetes/deployment_list.go
@@ -3,13 +3,14 @@ package kubernetes
 import (
 	"context"
 
+	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/sablier"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (p *Provider) DeploymentList(ctx context.Context) ([]sablier.InstanceConfiguration, error) {
+func (p *Provider) DeploymentList(ctx context.Context, opts provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
 	labelSelector := metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			sablier.LabelEnable: "true",
@@ -24,11 +25,20 @@ func (p *Provider) DeploymentList(ctx context.Context) ([]sablier.InstanceConfig
 
 	instances := make([]sablier.InstanceConfiguration, 0, len(deployments.Items))
 	for _, d := range deployments.Items {
+		if !opts.All && !deploymentIsRunning(&d) {
+			continue
+		}
 		instance := p.deploymentToInstance(&d)
 		instances = append(instances, instance)
 	}
 
 	return instances, nil
+}
+
+// A nil replicas value defaults to 1 replica.
+// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec
+func deploymentIsRunning(d *v1.Deployment) bool {
+	return d.Spec.Replicas == nil || *d.Spec.Replicas != 0
 }
 
 func (p *Provider) deploymentToInstance(d *v1.Deployment) sablier.InstanceConfiguration {

--- a/pkg/provider/kubernetes/instance_list.go
+++ b/pkg/provider/kubernetes/instance_list.go
@@ -8,17 +8,17 @@ import (
 )
 
 func (p *Provider) InstanceList(ctx context.Context, options provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
-	deployments, err := p.DeploymentList(ctx)
+	deployments, err := p.DeploymentList(ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	statefulSets, err := p.StatefulSetList(ctx)
+	statefulSets, err := p.StatefulSetList(ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	clusters, err := p.ClusterList(ctx)
+	clusters, err := p.ClusterList(ctx, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/kubernetes/instance_list_running_test.go
+++ b/pkg/provider/kubernetes/instance_list_running_test.go
@@ -1,0 +1,185 @@
+package kubernetes
+
+// Unit tests for InstanceListOptions.All. They run without a Kubernetes cluster.
+// https://github.com/sablierapp/sablier/issues/1095
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/neilotoole/slogt"
+	"go.opentelemetry.io/otel"
+	"gotest.tools/v3/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/sablierapp/sablier/pkg/provider"
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
+
+func newListTestDeployment(name string, replicas *int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{sablier.LabelEnable: "true"},
+		},
+		Spec: appsv1.DeploymentSpec{Replicas: replicas},
+	}
+}
+
+func newListTestStatefulSet(name string, replicas *int32) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{sablier.LabelEnable: "true"},
+		},
+		Spec: appsv1.StatefulSetSpec{Replicas: replicas},
+	}
+}
+
+func newListTestProvider(t *testing.T, typed []runtime.Object, clusters []runtime.Object) *Provider {
+	t.Helper()
+	return &Provider{
+		Client: k8sfake.NewSimpleClientset(typed...),
+		dynamic: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			runtime.NewScheme(),
+			map[schema.GroupVersionResource]string{cnpgClusterGVR: "ClusterList"},
+			clusters...,
+		),
+		delimiter: "_",
+		l:         slogt.New(t),
+		tracer:    otel.Tracer("test"),
+	}
+}
+
+func instanceNames(instances []sablier.InstanceConfiguration) []string {
+	names := make([]string, 0, len(instances))
+	for _, i := range instances {
+		names = append(names, i.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestProvider_DeploymentList_All(t *testing.T) {
+	t.Parallel()
+
+	zero, one := int32(0), int32(1)
+	p := newListTestProvider(t, []runtime.Object{
+		newListTestDeployment("running", &one),
+		newListTestDeployment("scaled-to-zero", &zero),
+		newListTestDeployment("unset-replicas", nil),
+	}, nil)
+
+	all, err := p.DeploymentList(context.Background(), provider.InstanceListOptions{All: true})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, instanceNames(all), []string{
+		"deployment_default_running_1",
+		"deployment_default_scaled-to-zero_1",
+		"deployment_default_unset-replicas_1",
+	})
+
+	// A Deployment at 0 replicas is stopped. An unset value defaults to 1.
+	running, err := p.DeploymentList(context.Background(), provider.InstanceListOptions{All: false})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, instanceNames(running), []string{
+		"deployment_default_running_1",
+		"deployment_default_unset-replicas_1",
+	})
+}
+
+func TestProvider_StatefulSetList_All(t *testing.T) {
+	t.Parallel()
+
+	zero, three := int32(0), int32(3)
+	p := newListTestProvider(t, []runtime.Object{
+		newListTestStatefulSet("running", &three),
+		newListTestStatefulSet("scaled-to-zero", &zero),
+		newListTestStatefulSet("unset-replicas", nil),
+	}, nil)
+
+	all, err := p.StatefulSetList(context.Background(), provider.InstanceListOptions{All: true})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, instanceNames(all), []string{
+		"statefulset_default_running_1",
+		"statefulset_default_scaled-to-zero_1",
+		"statefulset_default_unset-replicas_1",
+	})
+
+	running, err := p.StatefulSetList(context.Background(), provider.InstanceListOptions{All: false})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, instanceNames(running), []string{
+		"statefulset_default_running_1",
+		"statefulset_default_unset-replicas_1",
+	})
+}
+
+func TestProvider_ClusterList_All(t *testing.T) {
+	t.Parallel()
+
+	enabled := map[string]string{sablier.LabelEnable: "true"}
+	p := newListTestProvider(t, nil, []runtime.Object{
+		newClusterObj("default", "pg-running", enabled, nil, 1, 1),
+		newClusterObj("default", "pg-hibernated", enabled,
+			map[string]string{cnpgHibernationAnnotation: cnpgHibernationOn}, 1, 0),
+		newClusterObj("default", "pg-resumed", enabled,
+			map[string]string{cnpgHibernationAnnotation: cnpgHibernationOff}, 1, 1),
+	})
+
+	all, err := p.ClusterList(context.Background(), provider.InstanceListOptions{All: true})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, instanceNames(all), []string{
+		"cnpgcluster_default_pg-hibernated_1",
+		"cnpgcluster_default_pg-resumed_1",
+		"cnpgcluster_default_pg-running_1",
+	})
+
+	// A Cluster with hibernation set to on is stopped.
+	running, err := p.ClusterList(context.Background(), provider.InstanceListOptions{All: false})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, instanceNames(running), []string{
+		"cnpgcluster_default_pg-resumed_1",
+		"cnpgcluster_default_pg-running_1",
+	})
+}
+
+// StopAllUnregisteredInstances lists with All set to false and stops each
+// result. The idle workloads must not be in that list.
+func TestProvider_InstanceList_All(t *testing.T) {
+	t.Parallel()
+
+	zero, one := int32(0), int32(1)
+	enabled := map[string]string{sablier.LabelEnable: "true"}
+	p := newListTestProvider(t,
+		[]runtime.Object{
+			newListTestDeployment("d-running", &one),
+			newListTestDeployment("d-idle", &zero),
+			newListTestStatefulSet("s-running", &one),
+			newListTestStatefulSet("s-idle", &zero),
+		},
+		[]runtime.Object{
+			newClusterObj("default", "pg-running", enabled, nil, 1, 1),
+			newClusterObj("default", "pg-idle", enabled,
+				map[string]string{cnpgHibernationAnnotation: cnpgHibernationOn}, 1, 0),
+		},
+	)
+
+	all, err := p.InstanceList(context.Background(), provider.InstanceListOptions{All: true})
+	assert.NilError(t, err)
+	assert.Equal(t, len(all), 6)
+
+	running, err := p.InstanceList(context.Background(), provider.InstanceListOptions{All: false})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, instanceNames(running), []string{
+		"cnpgcluster_default_pg-running_1",
+		"deployment_default_d-running_1",
+		"statefulset_default_s-running_1",
+	})
+}

--- a/pkg/provider/kubernetes/statefulset_list.go
+++ b/pkg/provider/kubernetes/statefulset_list.go
@@ -3,13 +3,14 @@ package kubernetes
 import (
 	"context"
 
+	"github.com/sablierapp/sablier/pkg/provider"
 	"github.com/sablierapp/sablier/pkg/sablier"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (p *Provider) StatefulSetList(ctx context.Context) ([]sablier.InstanceConfiguration, error) {
+func (p *Provider) StatefulSetList(ctx context.Context, opts provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
 	labelSelector := metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			sablier.LabelEnable: "true",
@@ -24,11 +25,20 @@ func (p *Provider) StatefulSetList(ctx context.Context) ([]sablier.InstanceConfi
 
 	instances := make([]sablier.InstanceConfiguration, 0, len(statefulSets.Items))
 	for _, ss := range statefulSets.Items {
+		if !opts.All && !statefulSetIsRunning(&ss) {
+			continue
+		}
 		instance := p.statefulSetToInstance(&ss)
 		instances = append(instances, instance)
 	}
 
 	return instances, nil
+}
+
+// A nil replicas value defaults to 1 replica.
+// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/#StatefulSetSpec
+func statefulSetIsRunning(ss *v1.StatefulSet) bool {
+	return ss.Spec.Replicas == nil || *ss.Spec.Replicas != 0
 }
 
 func (p *Provider) statefulSetToInstance(ss *v1.StatefulSet) sablier.InstanceConfiguration {

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -1,6 +1,8 @@
 package provider
 
 type InstanceListOptions struct {
+	// All includes the stopped instances. If All is false, the provider must
+	// return only the running instances.
 	All bool
 }
 


### PR DESCRIPTION
## Problem

The Kubernetes provider accepted `provider.InstanceListOptions` but did not use it. `InstanceList` returned each workload that has the label `sablier.enable=true`, in all states.

`StopAllUnregisteredInstances` calls `InstanceList` with `All` set to false and then stops each instance in the result. Because the provider did not remove the stopped workloads from the result, Sablier stopped again each workload that was already scaled to zero. Each scan wrote a log entry and recorded a stop metric for each idle workload.

```text
stopped unregistered instance instance=deployment_namespace_application_1 reason="instance is enabled but not started by Sablier"
```

The scan runs every 30 seconds when `provider.auto-stop-externally-started` is enabled. The user who reported the defect has six idle workloads and approximately 19000 log entries each day. The quantity of log entries increases with the quantity of managed workloads.

This behavior is different from #565. To stop a running workload that Sablier did not start is correct. To stop again a workload that is already stopped is not correct.

## Solution

Each workload kind now reports if it is running. The rule for each kind is the same as the rule in its `Inspect` function.

| Kind | The workload is stopped when |
| --- | --- |
| `Deployment` | `spec.replicas` is 0 |
| `StatefulSet` | `spec.replicas` is 0 |
| CloudNativePG `Cluster` | the `cnpg.io/hibernation` annotation is `on` |

`DeploymentList`, `StatefulSetList` and `ClusterList` receive the list options and apply the filter for their own kind. `InstanceGroups` does not change, because the group membership does not change with the state.

A nil `spec.replicas` value defaults to 1 replica. Refer to [DeploymentSpec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec) and [StatefulSetSpec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/#StatefulSetSpec). Thus the provider reports such a workload as a running workload.

### Why the filter uses spec.replicas

The filter uses the desired replica count and not `status.readyReplicas`, for two reasons.

1. Sablier must stop an enabled workload that runs but is not healthy. A filter on the ready pods keeps such a workload in operation for an unlimited time.
2. Sablier must not stop again a workload that is scaled to zero while its pods terminate. At that moment `spec.replicas` is 0, but `status.readyReplicas` can be more than 0 for a short time.

`DeploymentInspect` and `StatefulSetInspect` use the same rule to report the status `InstanceStatusStopped`.

## Contract

`InstanceListOptions.All` now has documentation for the rule. If `All` is false, the provider must return only the running instances. The Docker, Docker Swarm, Podman and Proxmox LXC providers already obey this rule. Thus they do not change.

## Tests

`instance_list_running_test.go` has tests for the Deployment, the StatefulSet and the CloudNativePG Cluster. For each kind, the idle workload is not in the result when `All` is false, and the idle workload is in the result when `All` is true. The tests also include a workload that has an unset `spec.replicas` value, and one test on `InstanceList`.

The tests use the fake clientset and the fake dynamic client. Thus they run in short mode and do not need a KinD cluster.

To make sure that the tests find the defect, I disabled the filter. The tests failed and showed `deployment_default_d-idle_1` as an unwanted result. This is the same symptom as the symptom in the issue.

`go build ./...`, `go vet ./...` and `go test ./... -short` completed with no error.

Fixes #1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)
