### PR TITLE
feat(kubernetes): support public sablierapp.dev label keys

### DIFF
--- a/cmd/labelsgen/main.go
+++ b/cmd/labelsgen/main.go
@@ -89,8 +89,9 @@ func writeApplying(b *strings.Builder) {
 
 	b.WriteString("{{< tab name=\"Kubernetes\" >}}\n")
 	b.WriteString("```yaml\n")
-	b.WriteString("metadata:\n  labels:\n    sablier.enable: \"true\"      # discovery uses a label selector\n  annotations:\n    sablier.group: \"my-group\"   # all other settings are annotations\n")
-	b.WriteString("```\n")
+	b.WriteString("metadata:\n  labels:\n    sablierapp.dev/enable: \"true\"      # discovery uses a label selector\n  annotations:\n    sablierapp.dev/group: \"my-group\"   # all other settings are annotations\n")
+	b.WriteString("```\n\n")
+	b.WriteString("On Kubernetes, replace the `sablier.` prefix with `sablierapp.dev/`. For example, `sablier.idle.replicas` becomes `sablierapp.dev/idle.replicas`. The legacy `sablier.*` keys continue to work, but they are deprecated.\n")
 	b.WriteString("{{< /tab >}}\n")
 
 	b.WriteString("{{< tab name=\"Proxmox LXC\" >}}\n")

--- a/docs/content/concepts/configuring-instances.md
+++ b/docs/content/concepts/configuring-instances.md
@@ -37,11 +37,11 @@ Each platform exposes labels differently, and Sablier reads them from the native
 |----------|-----------------------------------|
 | Docker, Podman | container `labels` |
 | Docker Swarm | service `deploy.labels` |
-| Kubernetes | workload `labels` for `sablier.enable`, `annotations` for every other key |
+| Kubernetes | workload `labels` for `sablierapp.dev/enable`, `annotations` for every other key |
 | Proxmox LXC | container `tags` |
 
 {{< callout type="info" >}}
-On **Kubernetes**, `sablier.enable` must be a *label* because workload discovery uses a label selector; multi-value settings such as `sablier.group` must be *annotations*. On **Proxmox LXC** there are no key/value labels, so Sablier reads *tags* like `sablier` and `sablier-group-<name>`.
+On **Kubernetes**, keys use the public `sablierapp.dev/` prefix in place of `sablier.`, for example `sablierapp.dev/enable`. The legacy `sablier.*` keys continue to work, but they are deprecated. `sablierapp.dev/enable` must be a *label* because workload discovery uses a label selector; multi-value settings such as `sablierapp.dev/group` must be *annotations*. On **Proxmox LXC** there are no key/value labels, so Sablier reads *tags* like `sablier` and `sablier-group-<name>`.
 {{< /callout >}}
 
 See [Applying labels](/reference/labels/#applying-labels) for copy-paste examples in each provider's syntax.

--- a/docs/content/how-to-guides/scaling-resources/scale-cpu.md
+++ b/docs/content/how-to-guides/scaling-resources/scale-cpu.md
@@ -84,11 +84,11 @@ kind: Deployment
 metadata:
   name: myapp
   labels:
-    sablier.enable: "true"
-    sablier.group: myapp
-    sablier.idle.replicas: "1"
-    sablier.idle.cpu: "100m"
-    sablier.active.cpu: "2000m"
+    sablierapp.dev/enable: "true"
+    sablierapp.dev/group: myapp
+    sablierapp.dev/idle.replicas: "1"
+    sablierapp.dev/idle.cpu: "100m"
+    sablierapp.dev/active.cpu: "2000m"
 ```
 
 {{< callout type="info" >}}

--- a/docs/content/how-to-guides/scaling-resources/scale-memory.md
+++ b/docs/content/how-to-guides/scaling-resources/scale-memory.md
@@ -88,11 +88,11 @@ kind: Deployment
 metadata:
   name: myapp
   labels:
-    sablier.enable: "true"
-    sablier.group: myapp
-    sablier.idle.replicas: "1"
-    sablier.idle.memory: "64Mi"
-    sablier.active.memory: "512Mi"
+    sablierapp.dev/enable: "true"
+    sablierapp.dev/group: myapp
+    sablierapp.dev/idle.replicas: "1"
+    sablierapp.dev/idle.memory: "64Mi"
+    sablierapp.dev/active.memory: "512Mi"
 ```
 {{< /provider-tab >}}
 {{< provider-tab name="podman" >}}

--- a/docs/content/reference/labels.md
+++ b/docs/content/reference/labels.md
@@ -38,10 +38,12 @@ services:
 ```yaml
 metadata:
   labels:
-    sablier.enable: "true"      # discovery uses a label selector
+    sablierapp.dev/enable: "true"      # discovery uses a label selector
   annotations:
-    sablier.group: "my-group"   # all other settings are annotations
+    sablierapp.dev/group: "my-group"   # all other settings are annotations
 ```
+
+On Kubernetes, replace the `sablier.` prefix with `sablierapp.dev/`. For example, `sablier.idle.replicas` becomes `sablierapp.dev/idle.replicas`. The legacy `sablier.*` keys continue to work, but they are deprecated.
 {{< /tab >}}
 {{< tab name="Proxmox LXC" >}}
 ```bash

--- a/docs/content/tutorials/providers/kubernetes.md
+++ b/docs/content/tutorials/providers/kubernetes.md
@@ -102,8 +102,8 @@ metadata:
   name: whoami
   labels:
     app: whoami
-    sablier.enable: "true"
-    sablier.group: mygroup
+    sablierapp.dev/enable: "true"
+    sablierapp.dev/group: mygroup
 spec:
   selector:
     matchLabels:
@@ -128,18 +128,20 @@ Kubernetes uses the Pod healthcheck to check if the Pod is up and running. So th
 
 ## Configure with labels or annotations
 
-On Kubernetes, `sablier.*` keys can be set either as a **label** or as an **annotation**, with one exception: `sablier.enable` must always be a label (see the note below). This applies to Deployments, StatefulSets, CloudNativePG Clusters and OT-CONTAINER-KIT Redis instances.
+On Kubernetes, Sablier keys use the public `sablierapp.dev/` prefix. To get the Kubernetes key of a key in the [Label reference](/reference/labels/), replace `sablier.` with `sablierapp.dev/`. For example, `sablier.idle.replicas` becomes `sablierapp.dev/idle.replicas`.
+
+You can set each key as a **label** or as an **annotation**, with one exception: `sablierapp.dev/enable` must always be a label (see the note below). This applies to Deployments, StatefulSets, CloudNativePG Clusters and OT-CONTAINER-KIT Redis instances.
 
 Annotations are useful because Kubernetes **label values are restricted** (max 63 characters, only `[A-Za-z0-9._-]`, no commas or colons). Some Sablier values cannot be expressed as labels and must use annotations, for example:
 
-- `sablier.group` with multiple comma-separated groups (e.g. `team-a,team-b`)
-- `sablier.running-hours` (e.g. `09:00-18:00`), where the colon is invalid in a label value
-- `sablier.running-days` (e.g. `Mon,Tue,Wed,Thu,Fri`)
+- `sablierapp.dev/group` with multiple comma-separated groups (e.g. `team-a,team-b`)
+- `sablierapp.dev/running-hours` (e.g. `09:00-18:00`), where the colon is invalid in a label value
+- `sablierapp.dev/running-days` (e.g. `Mon,Tue,Wed,Thu,Fri`)
 
 When the same key is present as both a label and an annotation, the **annotation takes precedence**.
 
 {{< callout type="warning" >}}
-`sablier.enable` must be set as a **label**. Workload discovery relies on a server-side label selector, which cannot match annotations. All other keys work as labels or annotations.
+`sablierapp.dev/enable` must be set as a **label**. Workload discovery relies on a server-side label selector, which cannot match annotations. All other keys work as labels or annotations.
 {{< /callout >}}
 
 ```yaml
@@ -149,14 +151,20 @@ metadata:
   name: whoami
   labels:
     app: whoami
-    sablier.enable: "true"       # must be a label
+    sablierapp.dev/enable: "true"       # must be a label
   annotations:
-    sablier.group: "team-a,team-b"          # comma is invalid as a label value
-    sablier.running-hours: "09:00-18:00"    # colon is invalid as a label value
-    sablier.running-days: "Mon,Tue,Wed,Thu,Fri"
+    sablierapp.dev/group: "team-a,team-b"          # comma is invalid as a label value
+    sablierapp.dev/running-hours: "09:00-18:00"    # colon is invalid as a label value
+    sablierapp.dev/running-days: "Mon,Tue,Wed,Thu,Fri"
 spec:
   # ...existing spec...
 ```
+
+### Legacy `sablier.*` keys
+
+Sablier continues to read the `sablier.*` keys, for example `sablier.enable` and `sablier.group`. On Kubernetes, these keys are deprecated. A key without a prefix is [private to the user](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set), thus it can conflict with the label conventions of your organization. Use the `sablierapp.dev/` keys for new workloads.
+
+During a migration, a workload can have the two forms of a key. In this case, the `sablierapp.dev/` key takes precedence over the `sablier.` key from the same source. An annotation continues to take precedence over a label.
 
 ## Register CloudNativePG Clusters
 
@@ -173,15 +181,15 @@ kind: Cluster
 metadata:
   name: opencell-db
   labels:
-    sablier.enable: "true"
-    sablier.group: opencell
+    sablierapp.dev/enable: "true"
+    sablierapp.dev/group: opencell
 spec:
   instances: 3
   storage:
     size: 1Gi
 ```
 
-This makes it possible to put an application, its Keycloak and its database in a single `sablier.group`, so that a single request wakes up the whole stack and inactivity hibernates all of it.
+This makes it possible to put an application, its Keycloak and its database in a single `sablierapp.dev/group`, so that a single request wakes up the whole stack and inactivity hibernates all of it.
 
 ### Cluster readiness
 
@@ -212,8 +220,8 @@ kind: Redis
 metadata:
   name: myapp-redis
   labels:
-    sablier.enable: "true"
-    sablier.group: myapp
+    sablierapp.dev/enable: "true"
+    sablierapp.dev/group: myapp
 spec:
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.12

--- a/docs/data/en/termbase.yaml
+++ b/docs/data/en/termbase.yaml
@@ -4,7 +4,7 @@
 - term: Instance
   definition: A single workload Sablier manages — a Docker container, Docker Swarm service, Kubernetes Deployment or StatefulSet, Podman container, or Proxmox LXC container.
 - term: Label
-  definition: A key/value pair you attach to a workload to opt it into Sablier and configure it (for example `sablier.enable=true`, `sablier.group=web`). Expressed as Docker/Swarm/Podman labels, Kubernetes labels and annotations, or Proxmox tags.
+  definition: A key/value pair you attach to a workload to opt it into Sablier and configure it (for example `sablier.enable=true`, `sablier.group=web`). Expressed as Docker/Swarm/Podman labels, Kubernetes labels and annotations with the `sablierapp.dev/` prefix, or Proxmox tags.
 - term: Provider
   definition: How Sablier interacts with your instances (start, stop, status, lifecycle events). One provider is configured per Sablier server.
 - term: Group

--- a/pkg/provider/kubernetes/cnpgcluster_list.go
+++ b/pkg/provider/kubernetes/cnpgcluster_list.go
@@ -11,17 +11,21 @@ import (
 	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
-// listClusters returns the CloudNativePG Clusters labelled sablier.enable=true across
-// all namespaces. When the dynamic client is unset or the CloudNativePG CRD is not
-// installed, it returns no clusters rather than an error, so the provider keeps working
-// on clusters that don't run CloudNativePG.
+// listClusters returns the CloudNativePG Clusters labelled sablierapp.dev/enable=true
+// or sablier.enable=true across all namespaces. When the dynamic client is unset or the
+// CloudNativePG CRD is not installed, it returns no clusters rather than an error, so the
+// provider keeps working on clusters that don't run CloudNativePG.
 func (p *Provider) listClusters(ctx context.Context) ([]unstructured.Unstructured, error) {
 	if p.dynamic == nil {
 		return nil, nil
 	}
 
-	list, err := p.dynamic.Resource(cnpgClusterGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
-		LabelSelector: "sablier.enable=true",
+	items, err := listEnabled(func(opts metav1.ListOptions) ([]unstructured.Unstructured, error) {
+		list, err := p.dynamic.Resource(cnpgClusterGVR).Namespace(metav1.NamespaceAll).List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		return list.Items, nil
 	})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -31,7 +35,7 @@ func (p *Provider) listClusters(ctx context.Context) ([]unstructured.Unstructure
 		return nil, err
 	}
 
-	return list.Items, nil
+	return items, nil
 }
 
 func (p *Provider) ClusterList(ctx context.Context, opts provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {

--- a/pkg/provider/kubernetes/deployment_list.go
+++ b/pkg/provider/kubernetes/deployment_list.go
@@ -11,20 +11,13 @@ import (
 )
 
 func (p *Provider) DeploymentList(ctx context.Context, opts provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
-	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			sablier.LabelEnable: "true",
-		},
-	}
-	deployments, err := p.Client.AppsV1().Deployments(corev1.NamespaceAll).List(ctx, metav1.ListOptions{
-		LabelSelector: metav1.FormatLabelSelector(&labelSelector),
-	})
+	deployments, err := p.listDeployments(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	instances := make([]sablier.InstanceConfiguration, 0, len(deployments.Items))
-	for _, d := range deployments.Items {
+	instances := make([]sablier.InstanceConfiguration, 0, len(deployments))
+	for _, d := range deployments {
 		if !opts.All && !deploymentIsRunning(&d) {
 			continue
 		}
@@ -59,21 +52,13 @@ func (p *Provider) deploymentToInstance(d *v1.Deployment) sablier.InstanceConfig
 }
 
 func (p *Provider) DeploymentGroups(ctx context.Context) (map[string][]string, error) {
-	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			sablier.LabelEnable: "true",
-		},
-	}
-	deployments, err := p.Client.AppsV1().Deployments(corev1.NamespaceAll).List(ctx, metav1.ListOptions{
-		LabelSelector: metav1.FormatLabelSelector(&labelSelector),
-	})
-
+	deployments, err := p.listDeployments(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	groups := make(map[string][]string)
-	for _, deployment := range deployments.Items {
+	for _, deployment := range deployments {
 		parsed := DeploymentName(&deployment, ParseOptions{Delimiter: p.delimiter})
 		config := sablierConfig(deployment.Labels, deployment.Annotations)
 		for _, groupName := range sablier.ParseGroups(config[sablier.LabelGroup]) {
@@ -82,4 +67,14 @@ func (p *Provider) DeploymentGroups(ctx context.Context) (map[string][]string, e
 	}
 
 	return groups, nil
+}
+
+func (p *Provider) listDeployments(ctx context.Context) ([]v1.Deployment, error) {
+	return listEnabled(func(opts metav1.ListOptions) ([]v1.Deployment, error) {
+		deployments, err := p.Client.AppsV1().Deployments(corev1.NamespaceAll).List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		return deployments.Items, nil
+	})
 }

--- a/pkg/provider/kubernetes/sablier_config.go
+++ b/pkg/provider/kubernetes/sablier_config.go
@@ -1,9 +1,26 @@
 package kubernetes
 
-import "strings"
+import (
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/sablierapp/sablier/pkg/sablier"
+)
 
 // sablierConfigPrefix is the common prefix for all Sablier configuration keys.
 const sablierConfigPrefix = "sablier."
+
+// sablierPublicPrefix makes "sablierapp.dev/<name>" the public form of "sablier.<name>".
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+const sablierPublicPrefix = "sablierapp.dev/"
+
+// enableSelectors match the public and the legacy enable label.
+// A label selector cannot express OR, thus each selector needs its own list call.
+var enableSelectors = []string{
+	sablierPublicPrefix + "enable=true",
+	sablier.LabelEnable + "=true",
+}
 
 // sablierConfig merges a workload's labels and annotations into a single
 // configuration map from which Sablier reads its "sablier.*" keys.
@@ -15,12 +32,15 @@ const sablierConfigPrefix = "sablier."
 // "sablier.running-hours=09:00-18:00". Annotations have no such restriction, so
 // they are supported as an alternative source for every Sablier key.
 //
-// Only keys carrying the "sablier." prefix are copied from annotations, so
-// unrelated (and potentially large) annotations such as
-// kubectl.kubernetes.io/last-applied-configuration are never included.
+// Only Sablier keys are copied from annotations, so unrelated (and potentially
+// large) annotations such as kubectl.kubernetes.io/last-applied-configuration
+// are never included.
 // Annotations take precedence over labels when the same key is present in both.
 //
-// Note: "sablier.enable" should still be set as a label because workload
+// A "sablierapp.dev/<name>" key is read as "sablier.<name>". In the same source,
+// the public key takes precedence over the legacy key.
+//
+// Note: the enable key should still be set as a label because workload
 // discovery relies on a server-side label selector; annotations are not
 // selectable. Setting it only as an annotation keeps it out of discovery.
 func sablierConfig(labels, annotations map[string]string) map[string]string {
@@ -28,11 +48,46 @@ func sablierConfig(labels, annotations map[string]string) map[string]string {
 	for k, v := range labels {
 		merged[k] = v
 	}
+	copyPublicKeys(merged, labels)
 	for k, v := range annotations {
 		if strings.HasPrefix(k, sablierConfigPrefix) {
 			merged[k] = v
 		}
 	}
+	copyPublicKeys(merged, annotations)
 	return merged
 }
 
+// copyPublicKeys copies each "sablierapp.dev/<name>" key of src to dst as "sablier.<name>".
+func copyPublicKeys(dst, src map[string]string) {
+	for k, v := range src {
+		if name, ok := strings.CutPrefix(k, sablierPublicPrefix); ok {
+			dst[sablierConfigPrefix+name] = v
+		}
+	}
+}
+
+// listEnabled calls list one time for each enable selector and removes the duplicates.
+func listEnabled[T any, PT interface {
+	*T
+	metav1.Object
+}](list func(metav1.ListOptions) ([]T, error)) ([]T, error) {
+	var items []T
+	seen := make(map[string]bool)
+	for _, selector := range enableSelectors {
+		found, err := list(metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return nil, err
+		}
+		for i := range found {
+			obj := PT(&found[i])
+			key := obj.GetNamespace() + "/" + obj.GetName()
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			items = append(items, found[i])
+		}
+	}
+	return items, nil
+}

--- a/pkg/provider/kubernetes/sablier_config_test.go
+++ b/pkg/provider/kubernetes/sablier_config_test.go
@@ -1,9 +1,17 @@
 package kubernetes
 
 import (
+	"sort"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/sablierapp/sablier/pkg/provider"
+	"github.com/sablierapp/sablier/pkg/sablier"
 )
 
 func TestSablierConfig(t *testing.T) {
@@ -46,6 +54,42 @@ func TestSablierConfig(t *testing.T) {
 			annotations: nil,
 			want:        map[string]string{},
 		},
+		{
+			name:   "public labels are read as sablier keys",
+			labels: map[string]string{"sablierapp.dev/enable": "true", "sablierapp.dev/idle.replicas": "1"},
+			want: map[string]string{
+				"sablierapp.dev/enable":        "true",
+				"sablierapp.dev/idle.replicas": "1",
+				"sablier.enable":               "true",
+				"sablier.idle.replicas":        "1",
+			},
+		},
+		{
+			name:        "public annotations are read as sablier keys",
+			labels:      map[string]string{"sablierapp.dev/enable": "true"},
+			annotations: map[string]string{"sablierapp.dev/running-hours": "09:00-18:00", "example.com/other": "demo"},
+			want: map[string]string{
+				"sablierapp.dev/enable": "true",
+				"sablier.enable":        "true",
+				"sablier.running-hours": "09:00-18:00",
+			},
+		},
+		{
+			name:   "public label overrides legacy label",
+			labels: map[string]string{"sablier.group": "legacy", "sablierapp.dev/group": "public"},
+			want:   map[string]string{"sablier.group": "public", "sablierapp.dev/group": "public"},
+		},
+		{
+			name:        "public annotation overrides legacy annotation",
+			annotations: map[string]string{"sablier.group": "legacy", "sablierapp.dev/group": "public"},
+			want:        map[string]string{"sablier.group": "public"},
+		},
+		{
+			name:        "legacy annotation overrides public label",
+			labels:      map[string]string{"sablierapp.dev/group": "from-label"},
+			annotations: map[string]string{"sablier.group": "from-annotation"},
+			want:        map[string]string{"sablierapp.dev/group": "from-label", "sablier.group": "from-annotation"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -56,3 +100,68 @@ func TestSablierConfig(t *testing.T) {
 	}
 }
 
+func TestProvider_InstanceList_EnableKeys(t *testing.T) {
+	t.Parallel()
+
+	deployment := func(name string, labels map[string]string) *appsv1.Deployment {
+		return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name, Labels: labels}}
+	}
+	statefulSet := func(name string, labels map[string]string) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name, Labels: labels}}
+	}
+
+	p := newFakeCNPGProvider(t,
+		newClusterObj("default", "pg-public", map[string]string{"sablierapp.dev/enable": "true", "sablierapp.dev/group": "db"}, nil, 1, 1),
+		newClusterObj("default", "pg-legacy", map[string]string{"sablier.enable": "true", "sablier.group": "db"}, nil, 1, 1),
+	)
+	p.Client = k8sfake.NewSimpleClientset(
+		deployment("public", map[string]string{"sablierapp.dev/enable": "true", "sablierapp.dev/group": "web"}),
+		deployment("legacy", map[string]string{"sablier.enable": "true", "sablier.group": "web"}),
+		deployment("both", map[string]string{"sablierapp.dev/enable": "true", "sablier.enable": "true"}),
+		deployment("disabled", map[string]string{"sablierapp.dev/enable": "false"}),
+		deployment("unlabeled", nil),
+		statefulSet("public", map[string]string{"sablierapp.dev/enable": "true", "sablierapp.dev/group": "web"}),
+		statefulSet("legacy", map[string]string{"sablier.enable": "true"}),
+	)
+
+	opts := ParseOptions{Delimiter: "_"}
+	dPublic := DeploymentName(deployment("public", nil), opts).Original
+	dLegacy := DeploymentName(deployment("legacy", nil), opts).Original
+	dBoth := DeploymentName(deployment("both", nil), opts).Original
+	ssPublic := StatefulSetName(statefulSet("public", nil), opts).Original
+	ssLegacy := StatefulSetName(statefulSet("legacy", nil), opts).Original
+	cPublic := ClusterName("default", "pg-public", opts).Original
+	cLegacy := ClusterName("default", "pg-legacy", opts).Original
+
+	got, err := p.InstanceList(t.Context(), provider.InstanceListOptions{All: true})
+	assert.NilError(t, err)
+
+	want := []sablier.InstanceConfiguration{
+		{Name: dPublic, Groups: []string{"web"}, Enabled: "true"},
+		{Name: dLegacy, Groups: []string{"web"}, Enabled: "true"},
+		{Name: dBoth, Groups: []string{"default"}, Enabled: "true"},
+		{Name: ssPublic, Groups: []string{"web"}, Enabled: "true"},
+		{Name: ssLegacy, Groups: []string{"default"}, Enabled: "true"},
+		{Name: cPublic, Groups: []string{"db"}, Enabled: "true"},
+		{Name: cLegacy, Groups: []string{"db"}, Enabled: "true"},
+	}
+	sort.Slice(got, func(i, j int) bool { return strings.Compare(got[i].Name, got[j].Name) < 0 })
+	sort.Slice(want, func(i, j int) bool { return strings.Compare(want[i].Name, want[j].Name) < 0 })
+	assert.DeepEqual(t, got, want)
+
+	groups, err := p.InstanceGroups(t.Context())
+	assert.NilError(t, err)
+	for _, instances := range groups {
+		sort.Strings(instances)
+	}
+
+	wantGroups := map[string][]string{
+		"web":     {dPublic, dLegacy, ssPublic},
+		"default": {dBoth, ssLegacy},
+		"db":      {cPublic, cLegacy},
+	}
+	for _, instances := range wantGroups {
+		sort.Strings(instances)
+	}
+	assert.DeepEqual(t, groups, wantGroups)
+}

--- a/pkg/provider/kubernetes/statefulset_list.go
+++ b/pkg/provider/kubernetes/statefulset_list.go
@@ -11,20 +11,13 @@ import (
 )
 
 func (p *Provider) StatefulSetList(ctx context.Context, opts provider.InstanceListOptions) ([]sablier.InstanceConfiguration, error) {
-	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			sablier.LabelEnable: "true",
-		},
-	}
-	statefulSets, err := p.Client.AppsV1().StatefulSets(corev1.NamespaceAll).List(ctx, metav1.ListOptions{
-		LabelSelector: metav1.FormatLabelSelector(&labelSelector),
-	})
+	statefulSets, err := p.listStatefulSets(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	instances := make([]sablier.InstanceConfiguration, 0, len(statefulSets.Items))
-	for _, ss := range statefulSets.Items {
+	instances := make([]sablier.InstanceConfiguration, 0, len(statefulSets))
+	for _, ss := range statefulSets {
 		if !opts.All && !statefulSetIsRunning(&ss) {
 			continue
 		}
@@ -59,20 +52,13 @@ func (p *Provider) statefulSetToInstance(ss *v1.StatefulSet) sablier.InstanceCon
 }
 
 func (p *Provider) StatefulSetGroups(ctx context.Context) (map[string][]string, error) {
-	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			sablier.LabelEnable: "true",
-		},
-	}
-	statefulSets, err := p.Client.AppsV1().StatefulSets(corev1.NamespaceAll).List(ctx, metav1.ListOptions{
-		LabelSelector: metav1.FormatLabelSelector(&labelSelector),
-	})
+	statefulSets, err := p.listStatefulSets(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	groups := make(map[string][]string)
-	for _, ss := range statefulSets.Items {
+	for _, ss := range statefulSets {
 		parsed := StatefulSetName(&ss, ParseOptions{Delimiter: p.delimiter})
 		config := sablierConfig(ss.Labels, ss.Annotations)
 		for _, groupName := range sablier.ParseGroups(config[sablier.LabelGroup]) {
@@ -81,4 +67,14 @@ func (p *Provider) StatefulSetGroups(ctx context.Context) (map[string][]string, 
 	}
 
 	return groups, nil
+}
+
+func (p *Provider) listStatefulSets(ctx context.Context) ([]v1.StatefulSet, error) {
+	return listEnabled(func(opts metav1.ListOptions) ([]v1.StatefulSet, error) {
+		statefulSets, err := p.Client.AppsV1().StatefulSets(corev1.NamespaceAll).List(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		return statefulSets.Items, nil
+	})
 }


### PR DESCRIPTION
## Summary

This change adds public label keys for the Kubernetes provider. Closes #449.

Kubernetes treats a label key without a prefix as private to the user ([Kubernetes label syntax](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)). Sablier now also reads each key with the `sablierapp.dev/` prefix. `sablierapp.dev` is the domain of the Sablier documentation.

```yaml
metadata:
  labels:
    sablierapp.dev/enable: "true"
    sablierapp.dev/group: mygroup
```

## Changes

- `sablierConfig` reads a `sablierapp.dev/<name>` label or annotation as `sablier.<name>`. Thus inspect, events, groups, and scale mode get the new keys with no other change.
- Discovery of Deployments, StatefulSets, and CloudNativePG Clusters sends one list request for each enable label and removes the duplicates. A label selector cannot express OR.
- The legacy `sablier.*` keys continue to work. The documentation recommends the new keys and marks the legacy keys as deprecated on Kubernetes.
- The Kubernetes tutorial, the scale guides, the concepts page, the glossary, and the generated label reference use the new keys.

## Precedence

From the lowest to the highest priority:

1. Legacy label (`sablier.group`)
2. Public label (`sablierapp.dev/group`)
3. Legacy annotation (`sablier.group`)
4. Public annotation (`sablierapp.dev/group`)

An annotation always overrides a label. In the same source, the public key overrides the legacy key.

## Notes for review

- Discovery now sends two list requests for each workload kind instead of one.
- The logs do not show a deprecation warning. A warning for each workload on each list can be noisy. A warning that shows one time for each workload is possible as a follow-up.
- This branch is rebased on #1112. `DeploymentList`, `StatefulSetList`, and `ClusterList` keep the `All` filter from #1112.
- The Docker, Docker Swarm, Podman, Proxmox LXC, and systemd providers do not change.

## Tests

- `go build ./...` passes.
- `go test -short ./pkg/provider/kubernetes/ ./pkg/sablier/` passes. New unit tests cover the key precedence, and the discovery with the public key, the legacy key, and the two keys together.
- `golangci-lint run ./pkg/provider/kubernetes/... ./cmd/labelsgen/...` reports 0 issues.
- `docs/content/reference/labels.md` is regenerated with `cmd/labelsgen`.
- The KinD integration tests did not run locally because Docker was not available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
