### PR TITLE
build: use Go 1.27.1 and apply go fix modernizers

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.26.3
-golangci-lint 2.12.2
+golang 1.27.1
+golangci-lint 2.13.2
 goreleaser 2.15.4
 hugo 0.163.3

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -247,8 +247,8 @@ func writeOption(b *strings.Builder, o option) {
 // categoryOf maps a flag name to its documentation category via the first key segment.
 func categoryOf(name string) string {
 	seg := name
-	if i := strings.Index(name, "."); i >= 0 {
-		seg = name[:i]
+	if before, _, ok := strings.Cut(name, "."); ok {
+		seg = before
 	}
 	switch seg {
 	case "logging":

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/sablierapp/sablier
 
-go 1.26.3
+go 1.27.1
 
 require (
 	github.com/coreos/go-systemd/v22 v22.7.0
+	github.com/docker/go-units v0.5.0
 	github.com/getkin/kin-openapi v0.149.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/godbus/dbus/v5 v5.2.2
@@ -30,8 +31,12 @@ require (
 	github.com/tniswong/go.rfcx v0.0.0-20181019234604-07783c52761f
 	github.com/valkey-io/valkey-go v1.0.77
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.71.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.71.0
+	go.opentelemetry.io/otel v1.46.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.46.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.46.0
+	go.opentelemetry.io/otel/sdk v1.46.0
+	go.opentelemetry.io/otel/trace v1.46.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/sync v0.22.0
 	google.golang.org/grpc v1.83.2
@@ -43,46 +48,19 @@ require (
 )
 
 require (
-	github.com/KyleBanks/depth v1.2.1 // indirect
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/buger/jsonparser v1.1.2 // indirect
-	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/go-openapi/spec v0.22.9 // indirect
-	github.com/go-openapi/swag/cmdutils v0.28.0 // indirect
-	github.com/go-openapi/swag/conv v0.28.0 // indirect
-	github.com/go-openapi/swag/fileutils v0.28.0 // indirect
-	github.com/go-openapi/swag/jsonutils v0.28.0 // indirect
-	github.com/go-openapi/swag/loading v0.28.0 // indirect
-	github.com/go-openapi/swag/mangling v0.28.0 // indirect
-	github.com/go-openapi/swag/netutils v0.28.0 // indirect
-	github.com/go-openapi/swag/pools v0.28.0 // indirect
-	github.com/go-openapi/swag/stringutils v0.28.0 // indirect
-	github.com/go-openapi/swag/typeutils v0.28.0 // indirect
-	github.com/go-openapi/swag/yamlutils v0.28.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
-	github.com/oasdiff/yaml v0.1.1 // indirect
-	github.com/oasdiff/yaml3 v0.0.14 // indirect
-	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
-	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
-	golang.org/x/mod v0.38.0 // indirect
-	golang.org/x/tools v0.48.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 // indirect
-)
-
-require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/goterm v1.0.4 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/bytedance/gopkg v0.1.4 // indirect
 	github.com/bytedance/sonic v1.15.2 // indirect
 	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.7 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
@@ -95,7 +73,6 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/djherbis/times v1.6.0 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
-	github.com/docker/go-units v0.5.0
 	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
@@ -108,7 +85,19 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
 	github.com/go-openapi/jsonreference v1.0.0 // indirect
+	github.com/go-openapi/spec v0.22.9 // indirect
 	github.com/go-openapi/swag v0.28.0 // indirect
+	github.com/go-openapi/swag/cmdutils v0.28.0 // indirect
+	github.com/go-openapi/swag/conv v0.28.0 // indirect
+	github.com/go-openapi/swag/fileutils v0.28.0 // indirect
+	github.com/go-openapi/swag/jsonutils v0.28.0 // indirect
+	github.com/go-openapi/swag/loading v0.28.0 // indirect
+	github.com/go-openapi/swag/mangling v0.28.0 // indirect
+	github.com/go-openapi/swag/netutils v0.28.0 // indirect
+	github.com/go-openapi/swag/pools v0.28.0 // indirect
+	github.com/go-openapi/swag/stringutils v0.28.0 // indirect
+	github.com/go-openapi/swag/typeutils v0.28.0 // indirect
+	github.com/go-openapi/swag/yamlutils v0.28.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect
@@ -118,6 +107,7 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jinzhu/copier v0.3.4 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -141,9 +131,12 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
+	github.com/oasdiff/yaml v0.1.1 // indirect
+	github.com/oasdiff/yaml3 v0.0.14 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
@@ -152,6 +145,7 @@ require (
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.61.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
@@ -166,21 +160,24 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.8.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.71.0
-	go.opentelemetry.io/otel v1.46.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.46.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.46.0
-	go.opentelemetry.io/otel/trace v1.46.0
+	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/arch v0.30.0 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/tools v0.48.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/internal/configdoc/configdoc.go
+++ b/internal/configdoc/configdoc.go
@@ -63,7 +63,7 @@ func SinceByFlag(dir string) (map[string]string, error) {
 
 // docMeta extracts the "CLI:" and "Since:" values from a field doc comment.
 func docMeta(doc string) (cli, since string) {
-	for _, raw := range strings.Split(doc, "\n") {
+	for raw := range strings.SplitSeq(doc, "\n") {
 		line := strings.TrimSpace(raw)
 		switch {
 		case strings.HasPrefix(line, "CLI:"):

--- a/internal/labeldoc/labeldoc.go
+++ b/internal/labeldoc/labeldoc.go
@@ -91,7 +91,7 @@ func decodeDoc(l *Label, doc string) {
 	var desc []string
 	curKey := ""
 
-	for _, raw := range strings.Split(doc, "\n") {
+	for raw := range strings.SplitSeq(doc, "\n") {
 		line := strings.TrimSpace(raw)
 		if line == "" {
 			curKey = ""
@@ -139,8 +139,8 @@ func splitField(line string) (key, value string, ok bool) {
 func finalizeDescription(constName, s string) string {
 	s = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(s), constName))
 	for _, p := range []string{"is ", "are "} {
-		if strings.HasPrefix(s, p) {
-			s = strings.TrimPrefix(s, p)
+		if after, ok := strings.CutPrefix(s, p); ok {
+			s = after
 			break
 		}
 	}

--- a/pkg/metrics/collector_test.go
+++ b/pkg/metrics/collector_test.go
@@ -133,7 +133,7 @@ func TestSessionExpiryCollector_NonDestructive(t *testing.T) {
 	if first <= 0 {
 		t.Fatalf("expected a positive expiry timestamp, got %v", first)
 	}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		<-time.After(10 * time.Millisecond)
 		if got := testutil.ToFloat64(c); got != first {
 			t.Fatalf("expiry moved across scrapes (%v -> %v): the collector renews sessions", first, got)

--- a/pkg/provider/docker/compose.go
+++ b/pkg/provider/docker/compose.go
@@ -34,7 +34,7 @@ func parseComposeDependsOn(label string) []composeDependency {
 	}
 
 	var deps []composeDependency
-	for _, entry := range strings.Split(label, ",") {
+	for entry := range strings.SplitSeq(label, ",") {
 		entry = strings.TrimSpace(entry)
 		if entry == "" {
 			continue

--- a/pkg/provider/kubernetes/deployment_inspect_test.go
+++ b/pkg/provider/kubernetes/deployment_inspect_test.go
@@ -91,9 +91,7 @@ func TestKubernetesProvider_DeploymentInspect(t *testing.T) {
 					}
 
 					_, err = dind.client.AppsV1().Deployments(d.Namespace).UpdateScale(ctx, d.Name, &autoscalingv1.Scale{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: d.Name,
-						},
+						Name: d.Name,
 						Spec: autoscalingv1.ScaleSpec{
 							Replicas: 0,
 						},
@@ -315,8 +313,8 @@ func TestKubernetesProvider_DeploymentInspect_ReadyOnFirstReplica(t *testing.T) 
 	assert.NilError(t, WaitForDeploymentReady(ctx, c.client, "default", d.Name))
 
 	_, err = c.client.AppsV1().Deployments(d.Namespace).UpdateScale(ctx, d.Name, &autoscalingv1.Scale{
-		ObjectMeta: metav1.ObjectMeta{Name: d.Name},
-		Spec:       autoscalingv1.ScaleSpec{Replicas: 2},
+		Name: d.Name,
+		Spec: autoscalingv1.ScaleSpec{Replicas: 2},
 	}, metav1.UpdateOptions{})
 	assert.NilError(t, err)
 	assert.NilError(t, WaitForDeploymentScale(ctx, c.client, "default", d.Name, 2))
@@ -342,8 +340,8 @@ func TestKubernetesProvider_DeploymentInspect_ReadyOnFirstReplica(t *testing.T) 
 
 	// Scaled to zero, the workload must still be reported as stopped.
 	_, err = c.client.AppsV1().Deployments(d.Namespace).UpdateScale(ctx, d.Name, &autoscalingv1.Scale{
-		ObjectMeta: metav1.ObjectMeta{Name: d.Name},
-		Spec:       autoscalingv1.ScaleSpec{Replicas: 0},
+		Name: d.Name,
+		Spec: autoscalingv1.ScaleSpec{Replicas: 0},
 	}, metav1.UpdateOptions{})
 	assert.NilError(t, err)
 	assert.NilError(t, WaitForDeploymentScale(ctx, c.client, "default", d.Name, 0))

--- a/pkg/provider/kubernetes/events_tombstone_test.go
+++ b/pkg/provider/kubernetes/events_tombstone_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/sablierapp/sablier/pkg/provider"
@@ -31,7 +30,7 @@ func TestDeploymentDeleteHandlesTombstone(t *testing.T) {
 	handler := p.deploymentEventHandler(t.Context(), events, true, true, true, true)
 
 	deleted := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{Name: "myapp", Namespace: "demo"},
+		Name: "myapp", Namespace: "demo",
 	}
 	handler.OnDelete(cache.DeletedFinalStateUnknown{Key: "demo/myapp", Obj: deleted})
 
@@ -50,7 +49,7 @@ func TestStatefulSetDeleteHandlesTombstone(t *testing.T) {
 	handler := p.statefulSetEventHandler(t.Context(), events, true, true, true, true)
 
 	deleted := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "mydb", Namespace: "demo"},
+		Name: "mydb", Namespace: "demo",
 	}
 	handler.OnDelete(cache.DeletedFinalStateUnknown{Key: "demo/mydb", Obj: deleted})
 
@@ -71,7 +70,7 @@ func TestUpdateHandlesNilReplicas(t *testing.T) {
 	events := make(chan sablier.InstanceEvent, 4)
 	handler := p.deploymentEventHandler(t.Context(), events, false, false, false, false)
 
-	oldD := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "myapp", Namespace: "demo", ResourceVersion: "1"}}
-	newD := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "myapp", Namespace: "demo", ResourceVersion: "2"}}
+	oldD := &appsv1.Deployment{Name: "myapp", Namespace: "demo", ResourceVersion: "1"}
+	newD := &appsv1.Deployment{Name: "myapp", Namespace: "demo", ResourceVersion: "2"}
 	handler.OnUpdate(oldD, newD) // Spec.Replicas nil on both: must not panic
 }

--- a/pkg/provider/kubernetes/instance_list_running_test.go
+++ b/pkg/provider/kubernetes/instance_list_running_test.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -24,23 +23,19 @@ import (
 
 func newListTestDeployment(name string, replicas *int32) *appsv1.Deployment {
 	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-			Labels:    map[string]string{sablier.LabelEnable: "true"},
-		},
-		Spec: appsv1.DeploymentSpec{Replicas: replicas},
+		Name:      name,
+		Namespace: "default",
+		Labels:    map[string]string{sablier.LabelEnable: "true"},
+		Spec:      appsv1.DeploymentSpec{Replicas: replicas},
 	}
 }
 
 func newListTestStatefulSet(name string, replicas *int32) *appsv1.StatefulSet {
 	return &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-			Labels:    map[string]string{sablier.LabelEnable: "true"},
-		},
-		Spec: appsv1.StatefulSetSpec{Replicas: replicas},
+		Name:      name,
+		Namespace: "default",
+		Labels:    map[string]string{sablier.LabelEnable: "true"},
+		Spec:      appsv1.StatefulSetSpec{Replicas: replicas},
 	}
 }
 

--- a/pkg/provider/kubernetes/parse_name_test.go
+++ b/pkg/provider/kubernetes/parse_name_test.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	v1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
 
@@ -65,10 +64,8 @@ func TestParseName(t *testing.T) {
 
 func TestDeploymentName(t *testing.T) {
 	deployment := v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test-namespace",
-			Name:      "test-deployment",
-		},
+		Namespace: "test-namespace",
+		Name:      "test-deployment",
 	}
 	opts := ParseOptions{Delimiter: ":"}
 	expected := ParsedName{
@@ -87,10 +84,8 @@ func TestDeploymentName(t *testing.T) {
 
 func TestStatefulSetName(t *testing.T) {
 	statefulSet := v1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test-namespace",
-			Name:      "test-statefulset",
-		},
+		Namespace: "test-namespace",
+		Name:      "test-statefulset",
 	}
 	opts := ParseOptions{Delimiter: ":"}
 	expected := ParsedName{

--- a/pkg/provider/kubernetes/sablier_config.go
+++ b/pkg/provider/kubernetes/sablier_config.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"maps"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,9 +46,7 @@ var enableSelectors = []string{
 // selectable. Setting it only as an annotation keeps it out of discovery.
 func sablierConfig(labels, annotations map[string]string) map[string]string {
 	merged := make(map[string]string, len(labels)+len(annotations))
-	for k, v := range labels {
-		merged[k] = v
-	}
+	maps.Copy(merged, labels)
 	copyPublicKeys(merged, labels)
 	for k, v := range annotations {
 		if strings.HasPrefix(k, sablierConfigPrefix) {

--- a/pkg/provider/kubernetes/sablier_config_test.go
+++ b/pkg/provider/kubernetes/sablier_config_test.go
@@ -7,7 +7,6 @@ import (
 
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/sablierapp/sablier/pkg/provider"
@@ -104,10 +103,10 @@ func TestProvider_InstanceList_EnableKeys(t *testing.T) {
 	t.Parallel()
 
 	deployment := func(name string, labels map[string]string) *appsv1.Deployment {
-		return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name, Labels: labels}}
+		return &appsv1.Deployment{Namespace: "default", Name: name, Labels: labels}
 	}
 	statefulSet := func(name string, labels map[string]string) *appsv1.StatefulSet {
-		return &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: name, Labels: labels}}
+		return &appsv1.StatefulSet{Namespace: "default", Name: name, Labels: labels}
 	}
 
 	p := newFakeCNPGProvider(t,

--- a/pkg/provider/kubernetes/statefulset_inspect_test.go
+++ b/pkg/provider/kubernetes/statefulset_inspect_test.go
@@ -90,9 +90,7 @@ func TestKubernetesProvider_InspectStatefulSet(t *testing.T) {
 					}
 
 					_, err = dind.client.AppsV1().StatefulSets(d.Namespace).UpdateScale(ctx, d.Name, &autoscalingv1.Scale{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: d.Name,
-						},
+						Name: d.Name,
 						Spec: autoscalingv1.ScaleSpec{
 							Replicas: 0,
 						},

--- a/pkg/provider/kubernetes/statefulset_redis_operator.go
+++ b/pkg/provider/kubernetes/statefulset_redis_operator.go
@@ -41,8 +41,8 @@ func redisOperatorOwner(ss *appsv1.StatefulSet) (name string, ok bool) {
 // string (e.g. "apps" from "apps/v1"). Returns the full string unchanged for
 // core resources that have no group prefix.
 func apiVersionGroup(apiVersion string) string {
-	if i := strings.Index(apiVersion, "/"); i >= 0 {
-		return apiVersion[:i]
+	if before, _, ok := strings.Cut(apiVersion, "/"); ok {
+		return before
 	}
 	return apiVersion
 }

--- a/pkg/provider/kubernetes/statefulset_redis_operator_integration_test.go
+++ b/pkg/provider/kubernetes/statefulset_redis_operator_integration_test.go
@@ -114,18 +114,16 @@ func createRedisAndStatefulSet(ctx context.Context, t *testing.T, kind *kindCont
 	isController := true
 	one := int32(1)
 	sts := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-			Labels:    labels,
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "redis.redis.opstreelabs.in/v1beta2",
-				Kind:       "Redis",
-				Name:       cr.GetName(),
-				UID:        cr.GetUID(),
-				Controller: &isController,
-			}},
-		},
+		Name:      name,
+		Namespace: "default",
+		Labels:    labels,
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: "redis.redis.opstreelabs.in/v1beta2",
+			Kind:       "Redis",
+			Name:       cr.GetName(),
+			UID:        cr.GetUID(),
+			Controller: &isController,
+		}},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &one,
 			Selector: &metav1.LabelSelector{

--- a/pkg/provider/kubernetes/statefulset_redis_operator_test.go
+++ b/pkg/provider/kubernetes/statefulset_redis_operator_test.go
@@ -26,17 +26,15 @@ func newRedisOwnerSTS(namespace, name string, replicas int32, apiVersion string)
 	}
 	isController := true
 	return &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    map[string]string{"sablier.enable": "true"},
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: apiVersion,
-				Kind:       "Redis",
-				Name:       name, // Redis CR has same name as the StatefulSet by convention
-				Controller: &isController,
-			}},
-		},
+		Name:      name,
+		Namespace: namespace,
+		Labels:    map[string]string{"sablier.enable": "true"},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: apiVersion,
+			Kind:       "Redis",
+			Name:       name, // Redis CR has same name as the StatefulSet by convention
+			Controller: &isController,
+		}},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,
 		},
@@ -68,8 +66,8 @@ func newRedisOperatorTestProvider(t *testing.T, sts *appsv1.StatefulSet) (*Provi
 		}
 		name := action.(k8stesting.GetAction).GetName()
 		return true, &autoscalingv1.Scale{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: action.GetNamespace()},
-			Spec:       autoscalingv1.ScaleSpec{Replicas: stsReplicas[name]},
+			Name: name, Namespace: action.GetNamespace(),
+			Spec: autoscalingv1.ScaleSpec{Replicas: stsReplicas[name]},
 		}, nil
 	})
 	client.PrependReactor("update", "statefulsets", func(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -235,7 +233,7 @@ func TestSetRedisOperatorSkipReconcile_NonRedisStatefulSet(t *testing.T) {
 	t.Parallel()
 	// Plain StatefulSet with no owner references — patch must not be called.
 	sts := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "plain-sts", Namespace: "default"},
+		Name: "plain-sts", Namespace: "default",
 	}
 	scheme := runtime.NewScheme()
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,

--- a/pkg/provider/kubernetes/testcontainers_test.go
+++ b/pkg/provider/kubernetes/testcontainers_test.go
@@ -48,10 +48,8 @@ type MimicOptions struct {
 // instead of flipping to Ready as soon as the container is running.
 func mimicHealthcheck() *corev1.Probe {
 	return &corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"/mimic", "healthcheck"},
-			},
+		Exec: &corev1.ExecAction{
+			Command: []string{"/mimic", "healthcheck"},
 		},
 		PeriodSeconds: 1,
 	}
@@ -68,11 +66,9 @@ func (d *kindContainer) CreateMimicDeployment(ctx context.Context, opts MimicOpt
 	}
 	replicas := int32(1)
 	return d.client.AppsV1().Deployments("default").Create(ctx, &v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Labels:      opts.Labels,
-			Annotations: opts.Annotations,
-		},
+		Name:        name,
+		Labels:      opts.Labels,
+		Annotations: opts.Annotations,
 		Spec: v1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
@@ -112,11 +108,9 @@ func (d *kindContainer) CreateMimicStatefulSet(ctx context.Context, opts MimicOp
 	}
 	replicas := int32(1)
 	return d.client.AppsV1().StatefulSets("default").Create(ctx, &v1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Labels:      opts.Labels,
-			Annotations: opts.Annotations,
-		},
+		Name:        name,
+		Labels:      opts.Labels,
+		Annotations: opts.Annotations,
 		Spec: v1.StatefulSetSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{

--- a/pkg/provider/systemd/testhelper_test.go
+++ b/pkg/provider/systemd/testhelper_test.go
@@ -131,7 +131,7 @@ func newMockSystemd(t *testing.T, configs []mockUnitConfig) *mockSystemd {
 	}
 
 	var conn *godbus.Conn
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		conn, err = godbus.Connect(addr)
 		if err == nil {
 			break
@@ -358,10 +358,8 @@ func (m *mockSystemd) ListUnitsFiltered(states []string) ([]unitStatus, error) {
 func stateOverlaps(states []string, u unitStatus) bool {
 	candidates := []string{u.LoadState, u.ActiveState, u.SubState}
 	for _, s := range states {
-		for _, c := range candidates {
-			if s == c {
-				return true
-			}
+		if slices.Contains(candidates, s) {
+			return true
 		}
 	}
 	return false

--- a/pkg/sablier/anti_affinity_test.go
+++ b/pkg/sablier/anti_affinity_test.go
@@ -602,7 +602,7 @@ func TestRequestReadySession_TimeoutReportsAntiAffinityHold(t *testing.T) {
 
 // eventually polls cond for up to a second, returning true as soon as it holds.
 func eventually(cond func() bool) bool {
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		if cond() {
 			return true
 		}

--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -314,7 +314,7 @@ func ScaleConfigFromLabels(labels map[string]string) ScaleConfig {
 // Entries with out-of-range weights (10-1000) or malformed format are skipped.
 func parseWeightDevices(s string) []BlkioWeightDevice {
 	var out []BlkioWeightDevice
-	for _, entry := range strings.Split(s, ",") {
+	for entry := range strings.SplitSeq(s, ",") {
 		entry = strings.TrimSpace(entry)
 		i := strings.LastIndex(entry, ":")
 		if i <= 0 {
@@ -335,7 +335,7 @@ func parseWeightDevices(s string) []BlkioWeightDevice {
 // provider's responsibility. Entries with a missing path or empty rate are skipped.
 func parseThrottleDevices(s string) []BlkioThrottleDevice {
 	var out []BlkioThrottleDevice
-	for _, entry := range strings.Split(s, ",") {
+	for entry := range strings.SplitSeq(s, ",") {
 		entry = strings.TrimSpace(entry)
 		i := strings.LastIndex(entry, ":")
 		if i <= 0 {

--- a/pkg/sablier/running_hours.go
+++ b/pkg/sablier/running_hours.go
@@ -126,7 +126,7 @@ var weekdayNames = map[string]time.Weekday{
 // is case-insensitive and whitespace around entries is ignored.
 func ParseRunningDays(v string) (RunningDays, error) {
 	days := make(RunningDays)
-	for _, p := range strings.Split(v, ",") {
+	for p := range strings.SplitSeq(v, ",") {
 		token := strings.ToLower(strings.TrimSpace(p))
 		if token == "" {
 			continue
@@ -147,4 +147,3 @@ func ParseRunningDays(v string) (RunningDays, error) {
 func (d RunningDays) Contains(day time.Weekday) bool {
 	return d[day]
 }
-

--- a/pkg/sablier/running_hours_test.go
+++ b/pkg/sablier/running_hours_test.go
@@ -1,6 +1,7 @@
 package sablier_test
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -87,16 +88,9 @@ func TestParseRunningDays(t *testing.T) {
 			}
 			// Days not in want must not be present.
 			for d := time.Sunday; d <= time.Saturday; d++ {
-				expected := false
-				for _, w := range tt.want {
-					if w == d {
-						expected = true
-						break
-					}
-				}
+				expected := slices.Contains(tt.want, d)
 				assert.Equal(t, days.Contains(d), expected)
 			}
 		})
 	}
 }
-

--- a/pkg/sabliercmd/storage_test.go
+++ b/pkg/sabliercmd/storage_test.go
@@ -126,8 +126,7 @@ func TestSaveToFile(t *testing.T) {
 }
 
 func TestSetupStorage_LoadOnStartup(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	path := filepath.Join(t.TempDir(), "state.json")
 	require.NoError(t, os.WriteFile(path, storeJSON("startup-service", time.Now().Add(time.Hour)), 0o600))
@@ -144,8 +143,7 @@ func TestSetupStorage_LoadOnStartup(t *testing.T) {
 }
 
 func TestSetupStorage_SaveOnShutdown(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	path := filepath.Join(t.TempDir(), "state.json")
 

--- a/pkg/tinykv/tinykv_test.go
+++ b/pkg/tinykv/tinykv_test.go
@@ -267,11 +267,11 @@ func Test04(t *testing.T) {
 func Test05(t *testing.T) {
 	assert := assert.New(t)
 	N := 10000
-	var cnt int64
+	var cnt atomic.Int64
 	kv := New(
 		time.Millisecond*10,
 		func(k string, v any) {
-			atomic.AddInt64(&cnt, 1)
+			cnt.Add(1)
 		})
 
 	src := rand.NewSource(time.Now().Unix())

--- a/pkg/tracing/grpclog.go
+++ b/pkg/tracing/grpclog.go
@@ -16,53 +16,53 @@ type grpcSlogBridge struct {
 	l *slog.Logger
 }
 
-func (b *grpcSlogBridge) Info(args ...interface{}) {
+func (b *grpcSlogBridge) Info(args ...any) {
 	b.l.Debug("[grpc] " + fmt.Sprint(args...))
 }
 
-func (b *grpcSlogBridge) Infoln(args ...interface{}) {
+func (b *grpcSlogBridge) Infoln(args ...any) {
 	b.l.Debug("[grpc] " + fmt.Sprint(args...))
 }
 
-func (b *grpcSlogBridge) Infof(format string, args ...interface{}) {
+func (b *grpcSlogBridge) Infof(format string, args ...any) {
 	b.l.Debug("[grpc] " + fmt.Sprintf(format, args...))
 }
 
-func (b *grpcSlogBridge) Warning(args ...interface{}) {
+func (b *grpcSlogBridge) Warning(args ...any) {
 	b.l.Warn("[grpc] " + fmt.Sprint(args...))
 }
 
-func (b *grpcSlogBridge) Warningln(args ...interface{}) {
+func (b *grpcSlogBridge) Warningln(args ...any) {
 	b.l.Warn("[grpc] " + fmt.Sprint(args...))
 }
 
-func (b *grpcSlogBridge) Warningf(format string, args ...interface{}) {
+func (b *grpcSlogBridge) Warningf(format string, args ...any) {
 	b.l.Warn("[grpc] " + fmt.Sprintf(format, args...))
 }
 
-func (b *grpcSlogBridge) Error(args ...interface{}) {
+func (b *grpcSlogBridge) Error(args ...any) {
 	b.l.Error("[grpc] " + fmt.Sprint(args...))
 }
 
-func (b *grpcSlogBridge) Errorln(args ...interface{}) {
+func (b *grpcSlogBridge) Errorln(args ...any) {
 	b.l.Error("[grpc] " + fmt.Sprint(args...))
 }
 
-func (b *grpcSlogBridge) Errorf(format string, args ...interface{}) {
+func (b *grpcSlogBridge) Errorf(format string, args ...any) {
 	b.l.Error("[grpc] " + fmt.Sprintf(format, args...))
 }
 
 // Fatal is intentionally demoted to Error so the gRPC library cannot call
 // os.Exit and bypass Sablier's graceful shutdown.
-func (b *grpcSlogBridge) Fatal(args ...interface{}) {
+func (b *grpcSlogBridge) Fatal(args ...any) {
 	b.l.Error("[grpc] " + fmt.Sprint(args...))
 }
 
-func (b *grpcSlogBridge) Fatalln(args ...interface{}) {
+func (b *grpcSlogBridge) Fatalln(args ...any) {
 	b.l.Error("[grpc] " + fmt.Sprint(args...))
 }
 
-func (b *grpcSlogBridge) Fatalf(format string, args ...interface{}) {
+func (b *grpcSlogBridge) Fatalf(format string, args ...any) {
 	b.l.Error("[grpc] " + fmt.Sprintf(format, args...))
 }
 

--- a/tools.mod
+++ b/tools.mod
@@ -1,6 +1,6 @@
 module github.com/sablierapp/sablier/tools
 
-go 1.26.3
+go 1.27.1
 
 tool (
 	github.com/Zxilly/go-size-analyzer/cmd/gsa


### PR DESCRIPTION
## Summary

This PR changes the Go version from 1.26.3 to 1.27.1. It also applies the `go fix` modernizers of Go 1.27.1.

## Changes

### Commit 1. Toolchain

- The `go` directive in `go.mod` and `tools.mod` is now `1.27.1`. The CI workflows read the Go version from `go.mod`, so the workflows do not change.
- In `.tool-versions`, `golang` is now `1.27.1` and `golangci-lint` is now `2.13.2`. golangci-lint 2.13.0 adds Go 1.27 support ([golangci/golangci-lint#6642](https://github.com/golangci/golangci-lint/pull/6642)).
- `go mod tidy` of Go 1.27 merges duplicate `require` blocks. Now `go.mod` has one direct block and one indirect block. Five direct dependencies were in the second block without an `// indirect` comment, and they moved to the direct block. No dependency version changes. `go.sum` does not change.

### Commit 2. go fix

This commit contains only the output of `go fix ./...` with Go 1.27.1. There are no manual edits. A second `go fix` run finds no more changes.

| Analyzer | Change | Files |
| --- | --- | --- |
| `embedlit` (new in 1.27) | Uses promoted field names as keys in composite literals | 9 Kubernetes test files |
| `atomictypes` (new in 1.27) | Replaces `atomic.AddInt64(&cnt, 1)` with an `atomic.Int64` | `pkg/tinykv/tinykv_test.go` |
| `stringsseq` | Replaces `range strings.Split` with `range strings.SplitSeq` | `internal/configdoc`, `internal/labeldoc`, `pkg/provider/docker/compose.go`, `pkg/sablier/instance.go`, `pkg/sablier/running_hours.go` |
| `stringscut`, `stringscutprefix` | Replaces `strings.Index` with `strings.Cut`, and `HasPrefix` plus `TrimPrefix` with `strings.CutPrefix` | `cmd/docgen`, `internal/labeldoc`, `pkg/provider/kubernetes/statefulset_redis_operator.go` |
| `mapsloop`, `slicescontains` | Replaces loops with `maps.Copy` and `slices.Contains` | `pkg/provider/kubernetes/sablier_config.go`, `pkg/provider/systemd/testhelper_test.go`, `pkg/sablier/running_hours_test.go` |
| `rangeint` | Replaces `for i := 0; i < n; i++` with `for range n` | 3 test files |
| `testingcontext` | Replaces `context.WithCancel(context.Background())` with `t.Context()` in tests | `pkg/sabliercmd/storage_test.go` |
| `any` | Replaces `interface{}` with `any` | `pkg/tracing/grpclog.go` |

> [!NOTE]
> `embedlit` uses a new Go 1.27 language feature. A struct literal key can now be a promoted field. For example, `&appsv1.Deployment{Name: "app"}` replaces `&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "app"}}`. This change is only in 9 Kubernetes test files. It is different from the usual Kubernetes style. To keep the usual style, run `go fix -embedlit=false ./...` in place of `go fix ./...`.

## Verification

Local checks on Windows with Go 1.27.1:

- `go build ./...` passes.
- `go vet ./...` passes. This includes the `stdversion` check, which `go test` now runs by default.
- `golangci-lint run` 2.13.2 with the CI build tags reports 0 issues.
- `go test -short ./...` passes, with one exception. `TestSetupTheme` in `pkg/sabliercmd` fails. It also fails on `main` with Go 1.26.3 on Windows, because `os.Mkdir(dir, 0o000)` does not block reads on Windows. CI runs on Linux.
- Docker was not available, so the integration tests did not run. They compile, and CI runs them.

## Go 1.27 features for Sablier

### Benefits with no code change

- `encoding/json` now uses the v2 implementation. Unmarshal is much faster. Sablier decodes JSON for each Valkey session read (`pkg/store/valkey/valkey.go`), for the state file restore (`pkg/sabliercmd/storage.go`), and in `pkg/tinykv`. Error message text can change, but no test checks JSON error text. To use the old implementation, build with `GOEXPERIMENT=nojsonv2`.
- An HTTP/1 `Response.Body` now drains unread content when it closes. The webhook dispatcher closes the body without a read (`pkg/webhook/dispatcher.go`). Now webhook calls to endpoints that send a response body can reuse connections.
- Some small allocations (under 80 bytes) cost up to 30% less. The Go team expects a total gain of about 1% in programs with many allocations. The binary becomes about 60 KB larger.
- `http.Server` now limits the number of request header values (`DefaultMaxHeaderValueCount`). The Sablier server (`internal/server/server.go`) sets no header limits, so it gets this limit.

### Candidates for later PRs

- `testing/synctest` with the new `synctest.Sleep`. 17 test files use `time.Sleep`. The in-memory tests in `pkg/sablier` and `pkg/tinykv` can become fast and deterministic. Tests that use a real network or containers cannot use synctest.
- `httptest.NewTestServer(t, handler)`. It closes the server when the test ends, and a handler panic fails the test. By default, the server uses an in-memory network that only `srv.Client()` can reach. Call `srv.Start()` to use a loopback listener. Candidates are `pkg/metrics/handler_test.go` (in-memory network), `pkg/webhook/dispatcher_test.go` (8 servers), and `pkg/provider/proxmoxlxc/testhelper_test.go`. The webhook `Dispatcher` and the Proxmox client make their own HTTP clients, so these two need `srv.Start()`.
- `strings.CutLast`. It can replace `strings.LastIndex` and the slice operations in `parseWeightDevices` and `parseThrottleDevices` (`pkg/sablier/instance.go`). Keep the check for an empty path.
- The `goroutineleak` profile is now generally available. Sablier has no pprof endpoint. A `TestMain` check with `pprof.Lookup("goroutineleak")` can help find leaked goroutines in packages that start watchers, for example `pkg/sablier`, `pkg/webhook`, and the providers.

### No clear benefit now

- Generic methods. The only generic types are in `pkg/tinykv`, and they do not need methods with more type parameters.
- The `uuid` package. Sablier does not make UUIDs. `github.com/google/uuid` is only an indirect dependency.
- The `encoding/json/v2` API. Its stricter defaults reject duplicate names and invalid UTF-8. This can change how Sablier reads stored state. The automatic v2 backend already gives the speed gain.
- `crypto/mldsa`, `simd`, `runtime/secret`, `database/sql`, `math/big`, and `hash/maphash`. Sablier does not use these areas.
- Go 1.27 needs macOS 13 or later. Release builds are only for Linux, so users see no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
