### PR TITLE
fix(strategy): do not wait a full refresh interval in blocking strategy

### DIFF
--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -679,7 +679,7 @@ SABLIER_STORAGE_FILE=<string>
 
 | Option | Description |
 |--------|-------------|
-| [`--strategy.blocking.default-refresh-frequency`](#opt-strategy-blocking-default-refresh-frequency) | Default refresh frequency at which the instances status are checked for blocking strategy |
+| [`--strategy.blocking.default-refresh-frequency`](#opt-strategy-blocking-default-refresh-frequency) | Maximum interval between two instance status checks for blocking strategy |
 | [`--strategy.blocking.default-timeout`](#opt-strategy-blocking-default-timeout) | Default timeout used for blocking strategy |
 | [`--strategy.dynamic.custom-themes-path`](#opt-strategy-dynamic-custom-themes-path) | Custom themes folder, will load all .html files recursively (a missing folder is not an error, Sablier then serves only the built-in themes) |
 | [`--strategy.dynamic.default-refresh-frequency`](#opt-strategy-dynamic-default-refresh-frequency) | Default refresh frequency in the HTML page for dynamic strategy |
@@ -688,7 +688,7 @@ SABLIER_STORAGE_FILE=<string>
 
 ### `--strategy.blocking.default-refresh-frequency` {#opt-strategy-blocking-default-refresh-frequency}
 
-Default refresh frequency at which the instances status are checked for blocking strategy
+Maximum interval between two instance status checks for blocking strategy
 
 {{< badge "duration" >}} {{< badge content="Default: 5s" >}} {{< badge content="Since v1.9.0" link="https://github.com/sablierapp/sablier/releases/tag/v1.9.0" >}}
 

--- a/pkg/config/strategy.go
+++ b/pkg/config/strategy.go
@@ -54,8 +54,8 @@ type BlockingStrategy struct {
 	// Since: v1.0.0
 	DefaultTimeout time.Duration
 
-	// DefaultRefreshFrequency is how often the blocking strategy polls instance readiness
-	// while waiting for workloads to start.
+	// DefaultRefreshFrequency is the maximum interval between two readiness checks
+	// while the blocking strategy waits for workloads to start.
 	// Env: SABLIER_STRATEGY_BLOCKING_DEFAULT_REFRESH_FREQUENCY
 	// CLI: --strategy.blocking.default-refresh-frequency
 	// Default: 5s

--- a/pkg/sablier/instance_request.go
+++ b/pkg/sablier/instance_request.go
@@ -49,6 +49,31 @@ func (s *Sablier) consumePendingError(name string) (bool, error) {
 	}
 }
 
+// startsDone returns a channel that is closed when every start in progress for
+// names completes. It returns nil when no start is in progress.
+func (s *Sablier) startsDone(names []string) <-chan struct{} {
+	s.pendingMu.Lock()
+	var pending []chan struct{}
+	for _, name := range names {
+		if ps, ok := s.pendingStarts[name]; ok {
+			pending = append(pending, ps.done)
+		}
+	}
+	s.pendingMu.Unlock()
+
+	if len(pending) == 0 {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for _, ch := range pending {
+			<-ch
+		}
+	}()
+	return done
+}
+
 func (s *Sablier) requestStart(ctx context.Context, name string, rejectUnlabeled bool) (InstanceInfo, error) {
 	// First critical section: check whether a start is already in progress.
 	// We release the lock before doing the remote inspect to avoid holding a

--- a/pkg/sablier/sablier.go
+++ b/pkg/sablier/sablier.go
@@ -40,8 +40,8 @@ type Sablier struct {
 	// group members that both depend on the same database) never start it twice.
 	depStarts map[string]*depStart
 
-	// BlockingRefreshFrequency is the frequency at which the instances are checked
-	// against the provider. Defaults to 5 seconds.
+	// BlockingRefreshFrequency is the maximum interval between two readiness
+	// checks of a blocking request. Defaults to 5 seconds.
 	BlockingRefreshFrequency time.Duration
 
 	// InstanceStartTimeout is the maximum time allowed for an async InstanceStart

--- a/pkg/sablier/session_request.go
+++ b/pkg/sablier/session_request.go
@@ -91,6 +91,10 @@ func (s *Sablier) RequestReadySession(ctx context.Context, names []string, durat
 	return s.requestReadySession(ctx, names, duration, timeout, s.rejectUnlabeledRequests)
 }
 
+// blockingFirstRecheck is the wait before the first new readiness check of a
+// blocking request. Each next wait is two times longer, up to BlockingRefreshFrequency.
+const blockingFirstRecheck = 100 * time.Millisecond
+
 func (s *Sablier) requestReadySession(ctx context.Context, names []string, duration time.Duration, timeout time.Duration, rejectUnlabeled bool) (*SessionState, error) {
 	s.l.DebugContext(ctx, "requesting ready session", slog.Any("names", names), slog.Duration("duration", duration), slog.Duration("timeout", timeout))
 	session, err := s.requestSession(ctx, names, duration, rejectUnlabeled)
@@ -106,7 +110,13 @@ func (s *Sablier) requestReadySession(ctx context.Context, names []string, durat
 		return nil, err
 	}
 
-	ticker := time.NewTicker(s.BlockingRefreshFrequency)
+	// A zero or negative frequency makes the timer fire at once, in a busy loop.
+	maxDelay := s.BlockingRefreshFrequency
+	if maxDelay <= 0 {
+		maxDelay = blockingFirstRecheck
+	}
+	delay := min(blockingFirstRecheck, maxDelay)
+	timer := time.NewTimer(delay)
 	// Buffered capacity 1: the goroutine can complete its send even when the
 	// outer select has already chosen a different case (timeout, cancellation).
 	// Without the buffer the goroutine would block forever on the channel send.
@@ -120,28 +130,33 @@ func (s *Sablier) requestReadySession(ctx context.Context, names []string, durat
 	var last atomic.Pointer[SessionState]
 	last.Store(session)
 
+	started := s.startsDone(names)
 	go func() {
+		defer timer.Stop()
 		for {
 			select {
-			case <-ticker.C:
-				session, err := s.requestSession(ctx, names, duration, rejectUnlabeled)
-				if err != nil {
-					errch <- err
-					return
-				}
-				if session.IsReady() {
-					readiness <- session
-					return
-				}
-				if err := session.InstanceErrors(); err != nil {
-					errch <- err
-					return
-				}
-				last.Store(session)
+			case <-timer.C:
+				delay = min(delay*2, maxDelay)
+			case <-started:
+				started = nil // disable this select case
 			case <-quit:
-				ticker.Stop()
 				return
 			}
+			session, err := s.requestSession(ctx, names, duration, rejectUnlabeled)
+			if err != nil {
+				errch <- err
+				return
+			}
+			if session.IsReady() {
+				readiness <- session
+				return
+			}
+			if err := session.InstanceErrors(); err != nil {
+				errch <- err
+				return
+			}
+			last.Store(session)
+			timer.Reset(delay)
 		}
 	}()
 

--- a/pkg/sablier/session_request_test.go
+++ b/pkg/sablier/session_request_test.go
@@ -8,8 +8,11 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/neilotoole/slogt"
+	"github.com/sablierapp/sablier/pkg/provider/providertest"
 	"github.com/sablierapp/sablier/pkg/sablier"
 	"github.com/sablierapp/sablier/pkg/store"
+	"github.com/sablierapp/sablier/pkg/store/inmemory"
 	"go.uber.org/mock/gomock"
 
 	"gotest.tools/v3/assert"
@@ -334,7 +337,7 @@ func TestSessionsManager_RequestReadySessionCancelledByTimeout(t *testing.T) {
 			store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil).AnyTimes()
 			store.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-			provider.EXPECT().InstanceInspect(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil)
+			provider.EXPECT().InstanceInspect(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil).AnyTimes()
 
 			errchan := make(chan error)
 			go func() {
@@ -365,4 +368,128 @@ func TestSessionsManager_RequestReadySession(t *testing.T) {
 
 		assert.NilError(t, <-errchan)
 	})
+}
+
+// setupSablierWithInMemoryStore uses a real session store, so each poll of a
+// blocking request reads the state that the previous poll wrote.
+func setupSablierWithInMemoryStore(t *testing.T) (*sablier.Sablier, *providertest.MockProvider) {
+	t.Helper()
+	p := providertest.NewMockProvider(gomock.NewController(t))
+	p.EXPECT().InstanceDependencies(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	return sablier.New(slogt.New(t), inmemory.NewInMemory(), p), p
+}
+
+// A running instance must not wait a full refresh interval before the blocking
+// request returns. See https://github.com/sablierapp/sablier/issues/282
+func TestRequestReadySession_RunningInstanceDoesNotWaitRefreshFrequency(t *testing.T) {
+	manager, provider := setupSablierWithInMemoryStore(t)
+	manager.BlockingRefreshFrequency = 5 * time.Second
+
+	running := sablier.InstanceInfo{Name: "whoami", CurrentReplicas: 1, DesiredReplicas: 1, Status: sablier.InstanceStatusReady}
+	provider.EXPECT().InstanceInspect(gomock.Any(), "whoami").Return(running, nil).AnyTimes()
+	provider.EXPECT().InstanceStart(gomock.Any(), "whoami").Return(nil)
+
+	begin := time.Now()
+	session, err := manager.RequestReadySession(t.Context(), []string{"whoami"}, time.Minute, 30*time.Second)
+	elapsed := time.Since(begin)
+
+	assert.NilError(t, err)
+	assert.Assert(t, session.IsReady())
+	assert.Assert(t, elapsed < time.Second, "blocking request took %s", elapsed)
+}
+
+func TestRequestReadySession_ChecksAtLeastEveryRefreshFrequency(t *testing.T) {
+	manager, provider := setupSablierWithInMemoryStore(t)
+	manager.BlockingRefreshFrequency = 20 * time.Millisecond
+
+	begin := time.Now()
+	readyAt := begin.Add(1550 * time.Millisecond)
+	provider.EXPECT().InstanceInspect(gomock.Any(), "whoami").DoAndReturn(func(_ context.Context, name string) (sablier.InstanceInfo, error) {
+		if time.Now().Before(readyAt) {
+			return sablier.InstanceInfo{Name: name, CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStarting}, nil
+		}
+		return sablier.InstanceInfo{Name: name, CurrentReplicas: 1, DesiredReplicas: 1, Status: sablier.InstanceStatusReady}, nil
+	}).AnyTimes()
+	provider.EXPECT().InstanceStart(gomock.Any(), "whoami").Return(nil)
+
+	session, err := manager.RequestReadySession(t.Context(), []string{"whoami"}, time.Minute, 5*time.Second)
+	elapsed := time.Since(begin)
+
+	assert.NilError(t, err)
+	assert.Assert(t, session.IsReady())
+	assert.Assert(t, elapsed < 2100*time.Millisecond, "blocking request took %s", elapsed)
+}
+
+// The start is released between two backoff checks. The request must return
+// when the start completes, not at the next backoff check.
+func TestRequestReadySession_ChecksAgainWhenStartCompletes(t *testing.T) {
+	manager, provider := setupSablierWithInMemoryStore(t)
+	manager.BlockingRefreshFrequency = 5 * time.Second
+
+	release := make(chan struct{})
+	running := sablier.InstanceInfo{Name: "whoami", CurrentReplicas: 1, DesiredReplicas: 1, Status: sablier.InstanceStatusReady}
+	provider.EXPECT().InstanceInspect(gomock.Any(), "whoami").Return(running, nil).AnyTimes()
+	provider.EXPECT().InstanceStart(gomock.Any(), "whoami").DoAndReturn(func(context.Context, string) error {
+		<-release
+		return nil
+	})
+
+	type result struct {
+		session *sablier.SessionState
+		err     error
+	}
+	results := make(chan result, 1)
+	go func() {
+		session, err := manager.RequestReadySession(t.Context(), []string{"whoami"}, time.Minute, 30*time.Second)
+		results <- result{session, err}
+	}()
+
+	time.Sleep(1600 * time.Millisecond)
+	close(release)
+	releasedAt := time.Now()
+
+	select {
+	case r := <-results:
+		assert.NilError(t, r.err)
+		assert.Assert(t, r.session.IsReady())
+		assert.Assert(t, time.Since(releasedAt) < 750*time.Millisecond, "blocking request returned %s after the start completed", time.Since(releasedAt))
+	case <-time.After(10 * time.Second):
+		t.Fatal("blocking request did not return")
+	}
+}
+
+// An instance that stays starting must not cause a busy loop of readiness checks.
+func TestRequestReadySession_DoesNotBusyLoop(t *testing.T) {
+	tests := []struct {
+		name             string
+		refreshFrequency time.Duration
+	}{
+		{name: "after the start completes", refreshFrequency: 5 * time.Second},
+		{name: "with a zero refresh frequency", refreshFrequency: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager, provider := setupSablierWithInMemoryStore(t)
+			manager.BlockingRefreshFrequency = tt.refreshFrequency
+
+			var mu sync.Mutex
+			inspects := 0
+			starting := sablier.InstanceInfo{Name: "whoami", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStarting}
+			provider.EXPECT().InstanceInspect(gomock.Any(), "whoami").DoAndReturn(func(context.Context, string) (sablier.InstanceInfo, error) {
+				mu.Lock()
+				defer mu.Unlock()
+				inspects++
+				return starting, nil
+			}).AnyTimes()
+			provider.EXPECT().InstanceStart(gomock.Any(), "whoami").Return(nil)
+
+			_, err := manager.RequestReadySession(t.Context(), []string{"whoami"}, time.Minute, 450*time.Millisecond)
+
+			_, ok := errors.AsType[sablier.ErrTimeout](err)
+			assert.Assert(t, ok, "expected ErrTimeout, got %v", err)
+			mu.Lock()
+			defer mu.Unlock()
+			assert.Assert(t, inspects < 10, "InstanceInspect was called %d times in 450ms", inspects)
+		})
+	}
 }

--- a/pkg/sabliercmd/root.go
+++ b/pkg/sabliercmd/root.go
@@ -121,7 +121,7 @@ It provides integrations with multiple reverse proxies and different loading str
 	_ = viper.BindPFlag("strategy.dynamic.default-refresh-frequency", startCmd.Flags().Lookup("strategy.dynamic.default-refresh-frequency"))
 	startCmd.Flags().DurationVar(&conf.Strategy.Blocking.DefaultTimeout, "strategy.blocking.default-timeout", 1*time.Minute, "Default timeout used for blocking strategy")
 	_ = viper.BindPFlag("strategy.blocking.default-timeout", startCmd.Flags().Lookup("strategy.blocking.default-timeout"))
-	startCmd.Flags().DurationVar(&conf.Strategy.Blocking.DefaultRefreshFrequency, "strategy.blocking.default-refresh-frequency", 5*time.Second, "Default refresh frequency at which the instances status are checked for blocking strategy")
+	startCmd.Flags().DurationVar(&conf.Strategy.Blocking.DefaultRefreshFrequency, "strategy.blocking.default-refresh-frequency", 5*time.Second, "Maximum interval between two instance status checks for blocking strategy")
 	_ = viper.BindPFlag("strategy.blocking.default-refresh-frequency", startCmd.Flags().Lookup("strategy.blocking.default-refresh-frequency"))
 
 	rootCmd.AddCommand(startCmd)


### PR DESCRIPTION
## Summary

The blocking strategy checked the instances again with a fixed ticker at `BlockingRefreshFrequency` (5s by default). The first request for an instance always got the `starting` status, also when the instance was already running and ready. Thus the request waited at least one full interval before it returned. See #282.

This PR changes the wait loop in `requestReadySession`:

- The request checks the instances again when the starts in progress for these instances complete. The new `startsDone` helper gives a channel that closes at that time.
- After each check, the request waits 100ms, then 200ms, 400ms, and so on, up to `BlockingRefreshFrequency`. A slow start is still checked at least once in each `BlockingRefreshFrequency`.
- A zero or negative `BlockingRefreshFrequency` made `time.NewTicker` panic. With a timer, these values cause a busy loop. The maximum wait is now 100ms for these values.
- The flag description and `docs/content/reference/cli.md` now tell that the refresh frequency is the maximum interval between two checks.

The start path does not change. An instance in idle scale mode, or an instance with `depends_on` dependencies, can show ready before its start completes. Thus the request still waits for the start.

## Tests

New tests in `pkg/sablier/session_request_test.go` use the in-memory store and a mock provider.

- `TestRequestReadySession_RunningInstanceDoesNotWaitRefreshFrequency` reproduces #282. It failed with the fixed ticker (5.0s). It passes now (0.00s).
- `TestRequestReadySession_ChecksAgainWhenStartCompletes` failed with the backoff only (the request returned 1.5s after the start completed). It passes now.
- `TestRequestReadySession_DoesNotBusyLoop/with_a_zero_refresh_frequency` failed before the guard (10,827 inspect calls in 500ms). It passes now.
- `TestRequestReadySession_ChecksAtLeastEveryRefreshFrequency` and `TestRequestReadySession_DoesNotBusyLoop/after_the_start_completes` prevent regressions of the maximum interval and of the start completion wake up.

`TestSessionsManager_RequestReadySessionCancelledByTimeout` accepted only one `InstanceInspect` call. That limit came from the old 5s ticker and the 1s timeout. The test now accepts more calls and still checks the timeout error.

The timing tests have large margins, because CI runs them with `-race`.

## Local results (Windows)

- `go test ./pkg/sablier/...` passes.
- `go vet` passes for the provider, sablier, cmd and internal packages.
- `golangci-lint run` reports 0 issues.
- `docs/content/reference/cli.md` agrees with `cmd/docgen`.
- I could not run `-race`, because the MinGW toolchain on this computer does not start race binaries. CI runs `-race`.
- The Docker, Swarm, Kubernetes, Podman and Valkey tests need testcontainers, which does not work on this computer.

Fixes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
