### PR TITLE
refactor(sablier): use strings.CutLast to parse blkio device lists

### DIFF
--- a/pkg/sablier/instance.go
+++ b/pkg/sablier/instance.go
@@ -315,13 +315,11 @@ func ScaleConfigFromLabels(labels map[string]string) ScaleConfig {
 func parseWeightDevices(s string) []BlkioWeightDevice {
 	var out []BlkioWeightDevice
 	for entry := range strings.SplitSeq(s, ",") {
-		entry = strings.TrimSpace(entry)
-		i := strings.LastIndex(entry, ":")
-		if i <= 0 {
+		path, wstr, ok := strings.CutLast(strings.TrimSpace(entry), ":")
+		if !ok || path == "" {
 			continue
 		}
-		path, wstr := entry[:i], strings.TrimSpace(entry[i+1:])
-		n, err := strconv.ParseUint(wstr, 10, 16)
+		n, err := strconv.ParseUint(strings.TrimSpace(wstr), 10, 16)
 		if err != nil || n < 10 || n > 1000 {
 			continue
 		}
@@ -336,13 +334,9 @@ func parseWeightDevices(s string) []BlkioWeightDevice {
 func parseThrottleDevices(s string) []BlkioThrottleDevice {
 	var out []BlkioThrottleDevice
 	for entry := range strings.SplitSeq(s, ",") {
-		entry = strings.TrimSpace(entry)
-		i := strings.LastIndex(entry, ":")
-		if i <= 0 {
-			continue
-		}
-		path, rate := entry[:i], strings.TrimSpace(entry[i+1:])
-		if path == "" || rate == "" {
+		path, rate, ok := strings.CutLast(strings.TrimSpace(entry), ":")
+		rate = strings.TrimSpace(rate)
+		if !ok || path == "" || rate == "" {
 			continue
 		}
 		out = append(out, BlkioThrottleDevice{Path: path, Rate: rate})

--- a/pkg/sablier/scale_test.go
+++ b/pkg/sablier/scale_test.go
@@ -185,8 +185,8 @@ func TestScaleConfigFromLabels_BlkioDeviceMultiple(t *testing.T) {
 
 func TestScaleConfigFromLabels_BlkioWeightDeviceInvalidWeight(t *testing.T) {
 	labels := map[string]string{
-		// weight=9 is below minimum (10), weight=bad is not a number — both skipped
-		"sablier.idle.blkio-weight-device": "/dev/sda:9,/dev/sdb:bad,/dev/sdc:100",
+		// Weight 9 is below the minimum, "bad" is not a number, and ":100" has no path.
+		"sablier.idle.blkio-weight-device": "/dev/sda:9,/dev/sdb:bad,:100,/dev/sdc:100",
 	}
 	got := sablier.ScaleConfigFromLabels(labels)
 	// Only the valid entry survives
@@ -196,12 +196,24 @@ func TestScaleConfigFromLabels_BlkioWeightDeviceInvalidWeight(t *testing.T) {
 
 func TestScaleConfigFromLabels_BlkioThrottleDeviceMalformed(t *testing.T) {
 	labels := map[string]string{
-		// No colon → skipped; empty rate → skipped; valid entry survives
-		"sablier.idle.blkio-device-read-bps": "nocodon,/dev/sda:,/dev/sdb:5m",
+		// Entries with no colon, an empty rate, or an empty path are skipped.
+		"sablier.idle.blkio-device-read-bps": "nocodon,/dev/sda:,:5m,/dev/sdb:5m",
 	}
 	got := sablier.ScaleConfigFromLabels(labels)
 	assert.Assert(t, cmp.DeepEqual(got.Idle.BlkioDeviceReadBps,
 		[]sablier.BlkioThrottleDevice{{Path: "/dev/sdb", Rate: "5m"}}))
+}
+
+func TestScaleConfigFromLabels_BlkioDevicePathWithColons(t *testing.T) {
+	labels := map[string]string{
+		"sablier.idle.blkio-weight-device":   "/dev/disk/by-path/pci-0000:00:1f.2-ata-1:300",
+		"sablier.idle.blkio-device-read-bps": "/dev/disk/by-path/pci-0000:00:1f.2-ata-1:5m",
+	}
+	got := sablier.ScaleConfigFromLabels(labels)
+	assert.Assert(t, cmp.DeepEqual(got.Idle.BlkioWeightDevice,
+		[]sablier.BlkioWeightDevice{{Path: "/dev/disk/by-path/pci-0000:00:1f.2-ata-1", Weight: 300}}))
+	assert.Assert(t, cmp.DeepEqual(got.Idle.BlkioDeviceReadBps,
+		[]sablier.BlkioThrottleDevice{{Path: "/dev/disk/by-path/pci-0000:00:1f.2-ata-1", Rate: "5m"}}))
 }
 
 func TestPopulateEnabledAndGroup_BlkioDeviceLabels(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR uses `strings.CutLast` (new in Go 1.27) in `parseWeightDevices` and `parseThrottleDevices`. It replaces `strings.LastIndex` and the manual slice operations. The behavior does not change.

## Changes

- `pkg/sablier/instance.go`: `strings.CutLast` splits each `path:value` entry at the last colon. The code skips an entry with no colon (`!ok`) or with an empty path (`path == ""`). This is the same as the old `strings.LastIndex(entry, ":") <= 0` check.
- `pkg/sablier/scale_test.go`: new test cases lock the behavior.
  - An entry with an empty path (`:100`, `:5m`) is skipped.
  - A device path that contains colons (`/dev/disk/by-path/pci-0000:00:1f.2-ata-1:5m`) is split at the last colon.

## Verification

- The new test cases pass on the old code and on the new code.
- `go test -short ./pkg/sablier/` passes.
- `go vet ./pkg/sablier/` passes. golangci-lint 2.13.2 reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
