### PR TITLE
test: use httptest.NewTestServer in the webhook, metrics and proxmoxlxc tests

### DIFF
--- a/pkg/metrics/handler_test.go
+++ b/pkg/metrics/handler_test.go
@@ -2,7 +2,6 @@ package metrics_test
 
 import (
 	"io"
-	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -14,10 +13,11 @@ func TestNewHandler_ServesPrometheusExposition(t *testing.T) {
 	r := metrics.NewPromRecorder()
 	r.RecordSessionRequest("dynamic", "names")
 
-	srv := httptest.NewServer(metrics.NewHandler(r))
-	defer srv.Close()
+	srv := httptest.NewTestServer(t, metrics.NewHandler(r))
+	// Client starts the in-memory server and sets srv.URL, so call it before srv.URL is read.
+	client := srv.Client()
 
-	resp, err := http.Get(srv.URL)
+	resp, err := client.Get(srv.URL)
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}

--- a/pkg/provider/proxmoxlxc/container_inspect_test.go
+++ b/pkg/provider/proxmoxlxc/container_inspect_test.go
@@ -55,7 +55,6 @@ func TestProxmoxLXCProvider_InstanceInspect(t *testing.T) {
 			t.Parallel()
 
 			server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{tt.container})
-			defer server.Close()
 
 			p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 			assert.NilError(t, err)
@@ -73,7 +72,6 @@ func TestProxmoxLXCProvider_InstanceInspect_ByVMID(t *testing.T) {
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
 		{VMID: 100, Name: "web", Status: "running", Tags: "sablier", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -94,7 +92,6 @@ func TestProxmoxLXCProvider_InstanceInspect_ByNodeVMID(t *testing.T) {
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
 		{VMID: 100, Name: "web", Status: "running", Tags: "sablier", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -114,7 +111,6 @@ func TestProxmoxLXCProvider_InstanceInspect_NotFound(t *testing.T) {
 	t.Parallel()
 
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)

--- a/pkg/provider/proxmoxlxc/container_list_test.go
+++ b/pkg/provider/proxmoxlxc/container_list_test.go
@@ -19,7 +19,6 @@ func TestProxmoxLXCProvider_InstanceList(t *testing.T) {
 		{VMID: 101, Name: "db", Status: "stopped", Tags: "sablier", Node: "pve1"},
 		{VMID: 102, Name: "unmanaged", Status: "running", Tags: "production", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -42,7 +41,6 @@ func TestProxmoxLXCProvider_InstanceList_RunningOnly(t *testing.T) {
 		{VMID: 101, Name: "db", Status: "stopped", Tags: "sablier", Node: "pve1"},
 		{VMID: 102, Name: "unmanaged", Status: "running", Tags: "production", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -62,7 +60,6 @@ func TestProxmoxLXCProvider_InstanceList_MultiNode(t *testing.T) {
 		{VMID: 100, Name: "app1", Status: "running", Tags: "sablier;sablier-group-apps", Node: "pve1"},
 		{VMID: 200, Name: "app2", Status: "stopped", Tags: "sablier;sablier-group-apps", Node: "pve2"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -84,7 +81,6 @@ func TestProxmoxLXCProvider_InstanceList_DuplicateHostname(t *testing.T) {
 		{VMID: 100, Name: "web", Status: "running", Tags: "sablier", Node: "pve1"},
 		{VMID: 200, Name: "web", Status: "stopped", Tags: "sablier", Node: "pve2"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -101,7 +97,6 @@ func TestProxmoxLXCProvider_InstanceGroups(t *testing.T) {
 		{VMID: 101, Name: "web2", Status: "running", Tags: "sablier;sablier-group-frontend", Node: "pve1"},
 		{VMID: 102, Name: "db", Status: "stopped", Tags: "sablier", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)

--- a/pkg/provider/proxmoxlxc/container_start_test.go
+++ b/pkg/provider/proxmoxlxc/container_start_test.go
@@ -15,7 +15,6 @@ func TestProxmoxLXCProvider_InstanceStart(t *testing.T) {
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
 		{VMID: 100, Name: "web", Status: "stopped", Tags: "sablier", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -35,7 +34,6 @@ func TestProxmoxLXCProvider_InstanceStart_ByVMID(t *testing.T) {
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
 		{VMID: 100, Name: "web", Status: "stopped", Tags: "sablier", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -48,7 +46,6 @@ func TestProxmoxLXCProvider_InstanceStart_NotFound(t *testing.T) {
 	t.Parallel()
 
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -63,7 +60,6 @@ func TestProxmoxLXCProvider_InstanceStart_WithoutSablierTag(t *testing.T) {
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
 		{VMID: 200, Name: "unmanaged", Status: "stopped", Tags: "", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -79,7 +75,6 @@ func TestProxmoxLXCProvider_InstanceStart_AlreadyRunning(t *testing.T) {
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
 		{VMID: 100, Name: "web", Status: "running", Tags: "sablier", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -100,7 +95,6 @@ func TestProxmoxLXCProvider_InstanceStart_TaskFailure(t *testing.T) {
 		{VMID: 100, Name: "broken", Status: "stopped", Tags: "sablier", Node: "pve1",
 			StartTaskState: proxmoxlxc.TaskFailed, StartTaskExitStatus: "startup for container '100' failed"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -126,7 +120,6 @@ func TestProxmoxLXCProvider_InstanceStart_TaskFailureTTLExpiry(t *testing.T) {
 			StartTaskExitStatus: "startup for container '100' failed",
 			StartTaskEndTime:    time.Now().Add(-time.Minute)},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -149,7 +142,6 @@ func TestProxmoxLXCProvider_InstanceStart_TaskInProgress(t *testing.T) {
 		{VMID: 100, Name: "slow", Status: "stopped", Tags: "sablier", Node: "pve1",
 			StartTaskState: proxmoxlxc.TaskRunning},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)

--- a/pkg/provider/proxmoxlxc/container_stop_test.go
+++ b/pkg/provider/proxmoxlxc/container_stop_test.go
@@ -14,7 +14,6 @@ func TestProxmoxLXCProvider_InstanceStop(t *testing.T) {
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
 		{VMID: 100, Name: "web", Status: "running", Tags: "sablier", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -27,7 +26,6 @@ func TestProxmoxLXCProvider_InstanceStop_NotFound(t *testing.T) {
 	t.Parallel()
 
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)

--- a/pkg/provider/proxmoxlxc/events_test.go
+++ b/pkg/provider/proxmoxlxc/events_test.go
@@ -17,7 +17,6 @@ func TestProxmoxLXCProvider_InstanceEvents_ContextCancel(t *testing.T) {
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
 		{VMID: 100, Name: "web", Status: "running", Tags: "sablier", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -54,7 +53,6 @@ func TestProxmoxLXCProvider_InstanceEvents_Started_ContextCancel(t *testing.T) {
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
 		{VMID: 100, Name: "web", Status: "running", Tags: "sablier", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)
@@ -91,7 +89,6 @@ func TestProxmoxLXCProvider_InstanceEvents_AllTypes_ContextCancel(t *testing.T) 
 	server := proxmoxlxc.MockServer(t, []string{"pve1"}, []proxmoxlxc.TestContainer{
 		{VMID: 100, Name: "web", Status: "running", Tags: "sablier", Node: "pve1"},
 	})
-	defer server.Close()
 
 	p, err := proxmoxlxc.New(t.Context(), proxmoxlxc.NewTestClient(server.URL), slogt.New(t))
 	assert.NilError(t, err)

--- a/pkg/provider/proxmoxlxc/testhelper_test.go
+++ b/pkg/provider/proxmoxlxc/testhelper_test.go
@@ -202,5 +202,9 @@ func mockServer(t *testing.T, nodes []string, containers []testContainer) *httpt
 		})
 	}
 
-	return httptest.NewServer(mux)
+	// Use a loopback listener. NewTestClient uses http.DefaultClient, which cannot reach
+	// the in-memory network (https://pkg.go.dev/net/http/httptest#Server).
+	srv := httptest.NewTestServer(t, mux)
+	srv.Start()
+	return srv
 }

--- a/pkg/webhook/dispatcher_test.go
+++ b/pkg/webhook/dispatcher_test.go
@@ -85,10 +85,18 @@ func startWatch(t *testing.T, d *webhook.Dispatcher, ctx context.Context, cancel
 	})
 }
 
+// startServer starts a test server on a loopback listener. The Dispatcher client uses
+// http.DefaultTransport, which cannot reach the in-memory network (https://pkg.go.dev/net/http/httptest#Server).
+func startServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewTestServer(t, handler)
+	srv.Start()
+	return srv
+}
+
 func TestDispatcher_FiresOnStartedEvent(t *testing.T) {
 	c := &capture{}
-	srv := httptest.NewServer(http.HandlerFunc(c.handler))
-	defer srv.Close()
+	srv := startServer(t, c.handler)
 
 	d := webhook.NewDispatcher(
 		[]config.WebhookEndpoint{{URL: srv.URL}},
@@ -112,8 +120,7 @@ func TestDispatcher_FiresOnStartedEvent(t *testing.T) {
 
 func TestDispatcher_FiresOnStoppedEvent(t *testing.T) {
 	c := &capture{}
-	srv := httptest.NewServer(http.HandlerFunc(c.handler))
-	defer srv.Close()
+	srv := startServer(t, c.handler)
 
 	d := webhook.NewDispatcher(
 		[]config.WebhookEndpoint{{URL: srv.URL}},
@@ -136,8 +143,7 @@ func TestDispatcher_FiresOnStoppedEvent(t *testing.T) {
 
 func TestDispatcher_IgnoresNonLifecycleEvents(t *testing.T) {
 	c := &capture{}
-	srv := httptest.NewServer(http.HandlerFunc(c.handler))
-	defer srv.Close()
+	srv := startServer(t, c.handler)
 
 	d := webhook.NewDispatcher(
 		[]config.WebhookEndpoint{{URL: srv.URL}},
@@ -162,12 +168,10 @@ func TestDispatcher_IgnoresNonLifecycleEvents(t *testing.T) {
 
 func TestDispatcher_FiltersEventsByEndpointConfig(t *testing.T) {
 	cStart := &capture{}
-	srvStart := httptest.NewServer(http.HandlerFunc(cStart.handler))
-	defer srvStart.Close()
+	srvStart := startServer(t, cStart.handler)
 
 	cStop := &capture{}
-	srvStop := httptest.NewServer(http.HandlerFunc(cStop.handler))
-	defer srvStop.Close()
+	srvStop := startServer(t, cStop.handler)
 
 	d := webhook.NewDispatcher([]config.WebhookEndpoint{
 		{URL: srvStart.URL, Events: []string{"started"}},
@@ -196,11 +200,10 @@ func TestDispatcher_FiltersEventsByEndpointConfig(t *testing.T) {
 
 func TestDispatcher_ForwardsCustomHeaders(t *testing.T) {
 	gotAuth := make(chan string, 1)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := startServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotAuth <- r.Header.Get("Authorization")
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
+	})
 
 	d := webhook.NewDispatcher([]config.WebhookEndpoint{
 		{URL: srv.URL, Headers: map[string]string{"Authorization": "Bearer secret"}},
@@ -223,14 +226,13 @@ func TestDispatcher_ForwardsCustomHeaders(t *testing.T) {
 func TestDispatcher_HandlesHTTPError(t *testing.T) {
 	// Endpoint that always returns 500 — dispatcher must not crash.
 	delivered := make(chan struct{}, 1)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := startServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		select {
 		case delivered <- struct{}{}:
 		default:
 		}
-	}))
-	defer srv.Close()
+	})
 
 	d := webhook.NewDispatcher([]config.WebhookEndpoint{{URL: srv.URL}}, slogt.New(t))
 
@@ -306,12 +308,10 @@ func TestDispatcher_MultipleEndpoints(t *testing.T) {
 	const numEndpoints = 3
 	captures := make([]*capture, numEndpoints)
 	endpoints := make([]config.WebhookEndpoint, numEndpoints)
-	servers := make([]*httptest.Server, numEndpoints)
 	for i := range numEndpoints {
 		captures[i] = &capture{}
-		servers[i] = httptest.NewServer(http.HandlerFunc(captures[i].handler))
-		defer servers[i].Close()
-		endpoints[i] = config.WebhookEndpoint{URL: servers[i].URL}
+		srv := startServer(t, captures[i].handler)
+		endpoints[i] = config.WebhookEndpoint{URL: srv.URL}
 	}
 
 	d := webhook.NewDispatcher(endpoints, slogt.New(t))


### PR DESCRIPTION
## Summary

Go 1.27 adds `httptest.NewTestServer`. The function registers a test cleanup that closes the server, and a handler panic fails the test. This PR uses it in the tests that start an HTTP test server.

## Changes

- `pkg/metrics/handler_test.go`: the test uses the in-memory network of `NewTestServer` through `srv.Client()`, so it does not open a socket. `srv.Client()` starts the server and sets `srv.URL`. A comment tells to call it before `srv.URL` is read.
- `pkg/webhook/dispatcher_test.go`: a new `startServer` helper calls `NewTestServer` and then `Start`, which gives a loopback listener. The `Dispatcher` makes its own HTTP client from `http.DefaultTransport`, and that client cannot reach the in-memory network.
- `pkg/provider/proxmoxlxc/testhelper_test.go`: `mockServer` calls `NewTestServer` and then `Start`, for the same reason. `NewTestClient` uses `http.DefaultClient`.
- The `defer Close()` calls are removed from these tests, because the cleanup closes the server. The cleanup runs after the test function returns. In the webhook tests, the server now closes after `startWatch` stops the dispatcher.

## Notes

- Only `srv.Client()` can reach the in-memory network, because its transport dials the in-memory listener for every address ([server.go](https://github.com/golang/go/blob/go1.27.1/src/net/http/httptest/server.go#L418-L448)). If you only replace `NewServer` with `NewTestServer`, `srv.URL` stays empty and the tests fail.
- The webhook tests cannot run in `testing/synctest` with this change. A goroutine that waits on a loopback socket is not durably blocked, so the fake clock does not advance. To use the in-memory network, the `Dispatcher` must accept an HTTP client. This PR does not change production code.
- A follow-up can pass `srv.Client()` to `NewTestClient` with `proxmox.WithHTTPClient`. Then the proxmoxlxc tests can use the in-memory network.

## Verification

- `go test -short -count=3 ./pkg/webhook/ ./pkg/metrics/ ./pkg/provider/proxmoxlxc/` passes. The proxmoxlxc tests that use `mockServer` run in short mode.
- `go vet ./...` passes. golangci-lint 2.13.2 reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
