### PR TITLE
test: fail the test run when goroutines leak

### DIFF
--- a/internal/leakcheck/leakcheck.go
+++ b/internal/leakcheck/leakcheck.go
@@ -1,0 +1,52 @@
+// Package leakcheck makes a test binary fail when its tests leak goroutines.
+// It uses the goroutineleak profile. See https://pkg.go.dev/runtime/pprof#Profile
+package leakcheck
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"strings"
+	"testing"
+)
+
+// Main runs the tests and exits. If the tests pass but goroutines leaked,
+// Main writes the leaked stacks and panics. Call Main from TestMain.
+func Main(m *testing.M) {
+	code := m.Run()
+	if code == 0 {
+		if report := find(); report != "" {
+			fmt.Fprint(os.Stderr, report)
+			// Do not use os.Exit(1). gotestsum --rerun-fails runs a failed TestMain again with no tests, and that run passes.
+			// A panic stops the reruns. See https://github.com/gotestyourself/gotestsum/blob/v1.13.0/cmd/rerunfails.go#L98-L112
+			panic("leakcheck: the goroutine leak check failed, see the output above")
+		}
+	}
+	os.Exit(code)
+}
+
+// find returns the stacks of the leaked goroutines, or "" if no goroutine leaked.
+func find() string {
+	p := pprof.Lookup("goroutineleak")
+	var b bytes.Buffer
+	// WriteTo runs the GC cycle that finds the leaks, then Count gives their number.
+	// With debug=2, the header of each leaked goroutine shows "(leaked)".
+	if err := p.WriteTo(&b, 2); err != nil {
+		return fmt.Sprintf("leakcheck: cannot write the goroutineleak profile: %v\n", err)
+	}
+	n := p.Count()
+	if n == 0 {
+		return ""
+	}
+	var leaked []string
+	for stack := range strings.SplitSeq(b.String(), "\n\n") {
+		if header, _, _ := strings.Cut(stack, "\n"); strings.Contains(header, "(leaked)") {
+			leaked = append(leaked, stack)
+		}
+	}
+	if len(leaked) == 0 {
+		leaked = []string{b.String()}
+	}
+	return fmt.Sprintf("leakcheck: %d goroutine(s) leaked\n\n%s\n", n, strings.Join(leaked, "\n\n"))
+}

--- a/internal/leakcheck/leakcheck_test.go
+++ b/internal/leakcheck/leakcheck_test.go
@@ -1,0 +1,42 @@
+package leakcheck
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+//go:noinline
+func blockOnUnreachableChannel() {
+	<-make(chan struct{})
+}
+
+//go:noinline
+func blockOnReachableChannel(ch chan struct{}) {
+	<-ch
+}
+
+func TestFind(t *testing.T) {
+	ch := make(chan struct{})
+	defer close(ch)
+	go blockOnReachableChannel(ch)
+	// This goroutine leaks on purpose. It stays blocked until the test binary exits.
+	go blockOnUnreachableChannel()
+
+	var report string
+	for deadline := time.Now().Add(10 * time.Second); time.Now().Before(deadline); time.Sleep(10 * time.Millisecond) {
+		if report = find(); strings.Contains(report, "leakcheck.blockOnUnreachableChannel") {
+			break
+		}
+	}
+
+	if !strings.Contains(report, "leakcheck.blockOnUnreachableChannel") {
+		t.Fatalf("find() does not report the leaked goroutine:\n%s", report)
+	}
+	if !strings.Contains(report, "created by github.com/sablierapp/sablier/internal/leakcheck.TestFind") {
+		t.Errorf("find() does not report the goroutine that started the leak:\n%s", report)
+	}
+	if strings.Contains(report, "blockOnReachableChannel") {
+		t.Errorf("find() reports a goroutine that waits on a reachable channel:\n%s", report)
+	}
+}

--- a/pkg/sablier/main_test.go
+++ b/pkg/sablier/main_test.go
@@ -1,0 +1,11 @@
+package sablier_test
+
+import (
+	"testing"
+
+	"github.com/sablierapp/sablier/internal/leakcheck"
+)
+
+func TestMain(m *testing.M) {
+	leakcheck.Main(m)
+}

--- a/pkg/store/inmemory/main_test.go
+++ b/pkg/store/inmemory/main_test.go
@@ -1,0 +1,11 @@
+package inmemory
+
+import (
+	"testing"
+
+	"github.com/sablierapp/sablier/internal/leakcheck"
+)
+
+func TestMain(m *testing.M) {
+	leakcheck.Main(m)
+}

--- a/pkg/tinykv/main_test.go
+++ b/pkg/tinykv/main_test.go
@@ -1,0 +1,11 @@
+package tinykv
+
+import (
+	"testing"
+
+	"github.com/sablierapp/sablier/internal/leakcheck"
+)
+
+func TestMain(m *testing.M) {
+	leakcheck.Main(m)
+}

--- a/pkg/webhook/main_test.go
+++ b/pkg/webhook/main_test.go
@@ -1,0 +1,11 @@
+package webhook_test
+
+import (
+	"testing"
+
+	"github.com/sablierapp/sablier/internal/leakcheck"
+)
+
+func TestMain(m *testing.M) {
+	leakcheck.Main(m)
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,8 +3,8 @@ sonar.projectKey=sablierapp_sablier
 sonar.sources=.
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
-sonar.coverage.exclusions=**/*_test.go,cmd/**,**/apitest/**,**/providertest/**,**/storetest/**
-sonar.exclusions=**/apitest/**,**/providertest/**,**/storetest/**,pkg/theme/embedded/**,examples/**,docs/**,**/*.md,pkg/config/**
+sonar.coverage.exclusions=**/*_test.go,cmd/**,**/apitest/**,**/providertest/**,**/storetest/**,**/leakcheck/**
+sonar.exclusions=**/apitest/**,**/providertest/**,**/storetest/**,**/leakcheck/**,pkg/theme/embedded/**,examples/**,docs/**,**/*.md,pkg/config/**
 sonar.go.coverage.reportPaths=coverage.out
 
 sonar.issue.ignore.multicriteria=e1


### PR DESCRIPTION
## Summary

This PR adds a goroutine leak check to the tests of `pkg/sablier`, `pkg/webhook`, `pkg/tinykv` and `pkg/store/inmemory`. The check uses the `goroutineleak` profile, which is generally available in Go 1.27.

## How it works

- The new `internal/leakcheck` package has one function, `Main`. A new `main_test.go` file in each package calls `leakcheck.Main` from `TestMain`.
- `Main` runs the tests. If the tests pass, `Main` writes the `goroutineleak` profile. This starts a GC cycle that finds goroutines that wait on a channel, `sync.Mutex`, `sync.WaitGroup` or `sync.Cond` that no running goroutine can reach. Such a goroutine can never continue.
- If a goroutine leaked, `Main` writes the stack and the `created by` line of each leaked goroutine, and then it panics.
- If the tests fail, `Main` does not do the check. A failed test often leaves blocked goroutines, and the test failure is the important result.
- `sonar-project.properties` excludes `internal/leakcheck` from analysis and coverage, like the other test helper packages (`apitest`, `providertest`, `storetest`). Only test files import the package, so it is not in the Sablier binary.

## Why Main panics

CI runs the tests with `gotestsum --rerun-fails=3`. If `TestMain` calls `os.Exit(1)`, gotestsum records a failure with no test name. It runs the package again with `-test.run=^$` ([rerunfails.go](https://github.com/gotestyourself/gotestsum/blob/v1.13.0/cmd/rerunfails.go#L141-L157)). That run starts no tests, so it passes, and gotestsum exits with code 0. The leak is hidden.

When an output line starts with `panic: `, gotestsum stops the reruns and the step fails ([execution.go](https://github.com/gotestyourself/gotestsum/blob/v1.13.0/testjson/execution.go#L205-L208), [rerunfails.go](https://github.com/gotestyourself/gotestsum/blob/v1.13.0/cmd/rerunfails.go#L98-L112)). Both cases were tested with gotestsum v1.13.0.

A leak stops the reruns for all packages in that CI run, so other flaky tests in the same run do not run again.

## Limits

- The check does not find a goroutine that waits on something that a global variable, a running goroutine or a pending timer can reach. For example, it does not find a tinykv store that was not stopped, because its timer keeps the channel reachable.
- The check does not find a goroutine that is not blocked yet when the tests end.
- The check does not cover the provider packages. Most of them already have a `TestMain` that starts containers, and CI runs their integration tests with third-party libraries. It is not possible to show that the check is reliable in those runs.

## Verification

- `go test -short -count=5` on the changed packages passes. The check found no real leak.
- A temporary test with a deliberate leak in `pkg/tinykv` makes `go test` fail with the leaked stack. gotestsum with the CI flags stops with "rerun aborted because previous run had a suspected panic". The coverage files are still written. The temporary test is not in this PR.
- `internal/leakcheck` has its own test. It starts a leaked goroutine and a goroutine that waits on a reachable channel. It checks that only the leaked goroutine is in the report.
- With the change from #1119 applied, `go test -short -count=5 ./pkg/webhook/ ./pkg/metrics/` passes.
- `go vet ./...` passes. golangci-lint 2.13.2 reports 0 issues.
- The race detector does not run on the local machine. CI runs the tests with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
