### PR TITLE
test: use testing/synctest for time-based tests

### DIFF
--- a/pkg/sablier/anti_affinity_test.go
+++ b/pkg/sablier/anti_affinity_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/neilotoole/slogt"
@@ -185,27 +186,28 @@ func TestReconcileAntiAffinity_SuppressesActiveDependent(t *testing.T) {
 }
 
 func TestReconcileAntiAffinity_RestoresWhenGroupInactive(t *testing.T) {
-	s, st, p := setupAntiAffinity(t)
-	ctx := context.Background()
+	synctest.Test(t, func(t *testing.T) {
+		s, st, p := setupAntiAffinity(t)
+		ctx := context.Background()
 
-	s.SetGroups(map[string][]string{"streaming": {"plex"}})
-	s.SyncInstanceAntiAffinity("nextcloud", []string{"streaming"})
+		s.SetGroups(map[string][]string{"streaming": {"plex"}})
+		s.SyncInstanceAntiAffinity("nextcloud", []string{"streaming"})
 
-	// Activate then suppress.
-	st.session("plex")
-	st.session("nextcloud")
-	s.reconcileAntiAffinity(ctx)
-	assert.Assert(t, s.isSuppressed("nextcloud"))
+		// Activate then suppress.
+		st.session("plex")
+		st.session("nextcloud")
+		s.reconcileAntiAffinity(ctx)
+		assert.Assert(t, s.isSuppressed("nextcloud"))
 
-	// Antagonist session ends -> group inactive -> dependent must be restored.
-	_ = st.Delete(ctx, "plex")
-	s.reconcileAntiAffinity(ctx)
+		// Antagonist session ends -> group inactive -> dependent must be restored.
+		_ = st.Delete(ctx, "plex")
+		s.reconcileAntiAffinity(ctx)
 
-	// The restore goes through the request path, which starts asynchronously.
-	assert.Assert(t, eventually(func() bool {
-		return slices.Contains(p.snapshotStarted(), "nextcloud")
-	}), "dependent should be restored")
-	assert.Assert(t, !s.isSuppressed("nextcloud"), "dependent should no longer be suppressed")
+		// The restore goes through the request path, which starts asynchronously.
+		synctest.Wait()
+		assert.Assert(t, slices.Contains(p.snapshotStarted(), "nextcloud"), "dependent should be restored")
+		assert.Assert(t, !s.isSuppressed("nextcloud"), "dependent should no longer be suppressed")
+	})
 }
 
 func TestReconcileAntiAffinity_DoesNotSuppressAlreadyIdleDependent(t *testing.T) {
@@ -224,31 +226,33 @@ func TestReconcileAntiAffinity_DoesNotSuppressAlreadyIdleDependent(t *testing.T)
 }
 
 func TestReconcileAntiAffinity_RestoreOnlyWhenAllAntagonistsInactive(t *testing.T) {
-	s, st, p := setupAntiAffinity(t)
-	ctx := context.Background()
+	synctest.Test(t, func(t *testing.T) {
+		s, st, p := setupAntiAffinity(t)
+		ctx := context.Background()
 
-	s.SetGroups(map[string][]string{"streaming": {"plex"}, "backup": {"restic"}})
-	s.SyncInstanceAntiAffinity("nextcloud", []string{"streaming", "backup"})
+		s.SetGroups(map[string][]string{"streaming": {"plex"}, "backup": {"restic"}})
+		s.SyncInstanceAntiAffinity("nextcloud", []string{"streaming", "backup"})
 
-	st.session("nextcloud")
-	st.session("restic") // only backup is active
-	s.reconcileAntiAffinity(ctx)
-	assert.Assert(t, s.isSuppressed("nextcloud"), "dependent should be suppressed while any antagonist is active")
+		st.session("nextcloud")
+		st.session("restic") // only backup is active
+		s.reconcileAntiAffinity(ctx)
+		assert.Assert(t, s.isSuppressed("nextcloud"), "dependent should be suppressed while any antagonist is active")
 
-	// streaming becomes active too; backup ends. Still one antagonist active.
-	_ = st.Delete(ctx, "restic")
-	st.session("plex")
-	s.reconcileAntiAffinity(ctx)
-	assert.Assert(t, s.isSuppressed("nextcloud"), "dependent should stay suppressed while streaming is active")
-	assert.Assert(t, !slices.Contains(p.snapshotStarted(), "nextcloud"), "must not restore while an antagonist is active")
+		// streaming becomes active too; backup ends. Still one antagonist active.
+		_ = st.Delete(ctx, "restic")
+		st.session("plex")
+		s.reconcileAntiAffinity(ctx)
+		assert.Assert(t, s.isSuppressed("nextcloud"), "dependent should stay suppressed while streaming is active")
+		assert.Assert(t, !slices.Contains(p.snapshotStarted(), "nextcloud"), "must not restore while an antagonist is active")
 
-	// All antagonists inactive -> restore (asynchronously, via the request path).
-	_ = st.Delete(ctx, "plex")
-	s.reconcileAntiAffinity(ctx)
-	assert.Assert(t, eventually(func() bool {
-		return slices.Contains(p.snapshotStarted(), "nextcloud")
-	}), "dependent should be restored once all antagonists are inactive")
-	assert.Assert(t, !s.isSuppressed("nextcloud"))
+		// All antagonists inactive -> restore (asynchronously, via the request path).
+		_ = st.Delete(ctx, "plex")
+		s.reconcileAntiAffinity(ctx)
+		synctest.Wait()
+		assert.Assert(t, slices.Contains(p.snapshotStarted(), "nextcloud"),
+			"dependent should be restored once all antagonists are inactive")
+		assert.Assert(t, !s.isSuppressed("nextcloud"))
+	})
 }
 
 func TestReconcileAntiAffinity_NoOpWhenNoAntiAffinity(t *testing.T) {
@@ -439,21 +443,22 @@ func TestSuppressForAntiAffinity_Errors(t *testing.T) {
 
 func TestRestoreFromAntiAffinity(t *testing.T) {
 	t.Run("requests the instance, tracking a session and clearing suppression", func(t *testing.T) {
-		s, st, p := setupAntiAffinity(t)
-		s.affinityMu.Lock()
-		s.suppressed["nextcloud"] = struct{}{}
-		s.restoreFromAntiAffinity(context.Background(), "nextcloud")
-		s.affinityMu.Unlock()
+		synctest.Test(t, func(t *testing.T) {
+			s, st, p := setupAntiAffinity(t)
+			s.affinityMu.Lock()
+			s.suppressed["nextcloud"] = struct{}{}
+			s.restoreFromAntiAffinity(context.Background(), "nextcloud")
+			s.affinityMu.Unlock()
 
-		// Requesting establishes a tracked session synchronously (so the instance
-		// is not treated as externally started and expires normally) and starts
-		// the instance via the normal, asynchronous request path.
-		_, err := st.Get(context.Background(), "nextcloud")
-		assert.NilError(t, err, "restored instance should have a tracked session")
-		assert.Assert(t, !s.isSuppressed("nextcloud"))
-		assert.Assert(t, eventually(func() bool {
-			return slices.Contains(p.snapshotStarted(), "nextcloud")
-		}), "restored instance should be started")
+			// Requesting establishes a tracked session synchronously (so the instance
+			// is not treated as externally started and expires normally) and starts
+			// the instance via the normal, asynchronous request path.
+			_, err := st.Get(context.Background(), "nextcloud")
+			assert.NilError(t, err, "restored instance should have a tracked session")
+			assert.Assert(t, !s.isSuppressed("nextcloud"))
+			synctest.Wait()
+			assert.Assert(t, slices.Contains(p.snapshotStarted(), "nextcloud"), "restored instance should be started")
+		})
 	})
 
 	t.Run("keeps it suppressed when the request fails", func(t *testing.T) {
@@ -513,28 +518,32 @@ func TestIsGroupActive(t *testing.T) {
 
 func TestTriggerAntiAffinityReconcile(t *testing.T) {
 	t.Run("no-op without any anti-affinity", func(t *testing.T) {
-		s, st, p := setupAntiAffinity(t)
-		s.SetGroups(map[string][]string{"streaming": {"plex"}})
-		st.session("plex")
+		synctest.Test(t, func(t *testing.T) {
+			s, st, p := setupAntiAffinity(t)
+			s.SetGroups(map[string][]string{"streaming": {"plex"}})
+			st.session("plex")
 
-		s.triggerAntiAffinityReconcile(context.Background())
-		// No goroutine should have been spawned; give any stray one a moment.
-		time.Sleep(20 * time.Millisecond)
-		assert.Equal(t, len(p.snapshotStopped()), 0)
+			s.triggerAntiAffinityReconcile(context.Background())
+			// No goroutine should have been spawned. Wait until a stray one, if any, is done.
+			synctest.Wait()
+			assert.Equal(t, len(p.snapshotStopped()), 0)
+		})
 	})
 
 	t.Run("enforces in the background when configured", func(t *testing.T) {
-		s, st, p := setupAntiAffinity(t)
-		s.SetGroups(map[string][]string{"streaming": {"plex"}})
-		s.SyncInstanceAntiAffinity("nextcloud", []string{"streaming"})
-		st.session("plex")
-		st.session("nextcloud")
+		synctest.Test(t, func(t *testing.T) {
+			s, st, p := setupAntiAffinity(t)
+			s.SetGroups(map[string][]string{"streaming": {"plex"}})
+			s.SyncInstanceAntiAffinity("nextcloud", []string{"streaming"})
+			st.session("plex")
+			st.session("nextcloud")
 
-		s.triggerAntiAffinityReconcile(context.Background())
+			s.triggerAntiAffinityReconcile(context.Background())
 
-		assert.Assert(t, eventually(func() bool {
-			return slices.Contains(p.snapshotStopped(), "nextcloud")
-		}), "the background reconcile should have suppressed nextcloud")
+			synctest.Wait()
+			assert.Assert(t, slices.Contains(p.snapshotStopped(), "nextcloud"),
+				"the background reconcile should have suppressed nextcloud")
+		})
 	})
 }
 
@@ -583,30 +592,21 @@ func TestInstanceRequest_HeldByAntiAffinity(t *testing.T) {
 }
 
 func TestRequestReadySession_TimeoutReportsAntiAffinityHold(t *testing.T) {
-	s, st, _ := setupAntiAffinity(t)
-	s.BlockingRefreshFrequency = 10 * time.Millisecond
-	s.SetGroups(map[string][]string{"streaming": {"plex"}})
-	s.SyncInstanceAntiAffinity("nextcloud", []string{"streaming"})
-	st.session("plex") // antagonist active -> nextcloud is held
+	synctest.Test(t, func(t *testing.T) {
+		s, st, _ := setupAntiAffinity(t)
+		s.BlockingRefreshFrequency = 10 * time.Millisecond
+		s.SetGroups(map[string][]string{"streaming": {"plex"}})
+		s.SyncInstanceAntiAffinity("nextcloud", []string{"streaming"})
+		st.session("plex") // antagonist active -> nextcloud is held
 
-	_, err := s.requestReadySession(context.Background(), []string{"nextcloud"}, time.Minute, 60*time.Millisecond, false)
+		_, err := s.requestReadySession(context.Background(), []string{"nextcloud"}, time.Minute, 60*time.Millisecond, false)
 
-	var te ErrTimeout
-	assert.Assert(t, errors.As(err, &te), "expected ErrTimeout, got %v", err)
-	assert.Equal(t, len(te.Instances), 1)
-	assert.Equal(t, te.Instances[0].Instance.Name, "nextcloud")
-	assert.Assert(t, strings.Contains(te.Instances[0].Instance.Message, "streaming"),
-		"held instance message should name the antagonist group, got %q", te.Instances[0].Instance.Message)
-	assert.Assert(t, strings.Contains(te.Error(), "streaming"), "timeout error should carry the reason")
-}
-
-// eventually polls cond for up to a second, returning true as soon as it holds.
-func eventually(cond func() bool) bool {
-	for range 100 {
-		if cond() {
-			return true
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return cond()
+		var te ErrTimeout
+		assert.Assert(t, errors.As(err, &te), "expected ErrTimeout, got %v", err)
+		assert.Equal(t, len(te.Instances), 1)
+		assert.Equal(t, te.Instances[0].Instance.Name, "nextcloud")
+		assert.Assert(t, strings.Contains(te.Instances[0].Instance.Message, "streaming"),
+			"held instance message should name the antagonist group, got %q", te.Instances[0].Instance.Message)
+		assert.Assert(t, strings.Contains(te.Error(), "streaming"), "timeout error should carry the reason")
+	})
 }

--- a/pkg/sablier/autostop_test.go
+++ b/pkg/sablier/autostop_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/sablierapp/sablier/pkg/provider"
@@ -136,54 +137,58 @@ func TestWatchAndStopExternallyStarted_StopsExternalInstance(t *testing.T) {
 // that a "started" event for an instance already in the sessions store is
 // not stopped (Sablier started it).
 func TestWatchAndStopExternallyStarted_SkipsSablierStartedInstance_InStore(t *testing.T) {
-	s, sessions, p := setupSablier(t)
-	s.ExternallyStartedScanInterval = 24 * time.Hour
+	synctest.Test(t, func(t *testing.T) {
+		s, sessions, p := setupSablier(t)
+		s.ExternallyStartedScanInterval = 24 * time.Hour
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
 
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
 
-	// Instance IS in the sessions store → started by Sablier
-	sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
-		Name:   "nginx",
-		Status: sablier.InstanceStatusReady,
-	}, nil)
+		// Instance IS in the sessions store → started by Sablier
+		sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
+			Name:   "nginx",
+			Status: sablier.InstanceStatusReady,
+		}, nil)
 
-	// InstanceStop must NOT be called; gomock will fail the test if it is.
-	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}}
+		// InstanceStop must NOT be called; gomock will fail the test if it is.
+		eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}}
 
-	startAutostopWatcher(t, s, ctx, cancel)
+		startAutostopWatcher(t, s, ctx, cancel)
 
-	// Give the goroutine time to process the event then verify no stop happened.
-	time.Sleep(100 * time.Millisecond)
+		// Wait until the goroutine processes the event. gomock then checks that no stop occurred.
+		synctest.Wait()
+	})
 }
 
 // TestWatchAndStopExternallyStarted_SkipsNonSablierInstance verifies that a
 // "started" event for an instance without sablier.enable=true is ignored.
 func TestWatchAndStopExternallyStarted_SkipsNonSablierInstance(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.ExternallyStartedScanInterval = 24 * time.Hour
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.ExternallyStartedScanInterval = 24 * time.Hour
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
 
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
 
-	// No sessions.Get or InstanceStop expected.
-	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "false"}}
+		// No sessions.Get or InstanceStop expected.
+		eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "false"}}
 
-	startAutostopWatcher(t, s, ctx, cancel)
+		startAutostopWatcher(t, s, ctx, cancel)
 
-	time.Sleep(100 * time.Millisecond)
+		synctest.Wait()
+	})
 }
 
 // TestWatchAndStopExternallyStarted_ReconciliationTicker verifies that even without

--- a/pkg/sablier/autowarm_test.go
+++ b/pkg/sablier/autowarm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/sablierapp/sablier/pkg/provider"
@@ -155,31 +156,33 @@ func TestWatchAndWarmExternallyStarted_WarmsExternalInstance(t *testing.T) {
 // not touched (Sablier started it, or it already holds a session): the session
 // must not be re-created, so it is never renewed in a loop.
 func TestWatchAndWarmExternallyStarted_SkipsSablierStartedInstance_InStore(t *testing.T) {
-	s, sessions, p := setupSablier(t)
-	s.ExternallyStartedScanInterval = 24 * time.Hour
+	synctest.Test(t, func(t *testing.T) {
+		s, sessions, p := setupSablier(t)
+		s.ExternallyStartedScanInterval = 24 * time.Hour
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
 
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
 
-	// Instance IS in the sessions store → started by Sablier / already has a session
-	sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
-		Name:   "nginx",
-		Status: sablier.InstanceStatusReady,
-	}, nil)
+		// Instance IS in the sessions store → started by Sablier / already has a session
+		sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
+			Name:   "nginx",
+			Status: sablier.InstanceStatusReady,
+		}, nil)
 
-	// Put must NOT be called; gomock will fail the test if it is.
-	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}}
+		// Put must NOT be called; gomock will fail the test if it is.
+		eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "true"}}
 
-	startAutowarmWatcher(t, s, ctx, cancel)
+		startAutowarmWatcher(t, s, ctx, cancel)
 
-	// Give the goroutine time to process the event then verify no seed happened.
-	time.Sleep(100 * time.Millisecond)
+		// Wait until the goroutine processes the event. gomock then checks that no seed occurred.
+		synctest.Wait()
+	})
 }
 
 // TestWatchAndWarmExternallyStarted_DoesNotReseedWhenSessionAppearsBetweenChecks
@@ -187,31 +190,33 @@ func TestWatchAndWarmExternallyStarted_SkipsSablierStartedInstance_InStore(t *te
 // between the isStartedByUs check and the seed (e.g. a concurrent RequestSession),
 // no session is put on top of it.
 func TestWatchAndWarmExternallyStarted_DoesNotReseedWhenSessionAppearsBetweenChecks(t *testing.T) {
-	s, sessions, p := setupSablier(t)
-	s.ExternallyStartedScanInterval = 24 * time.Hour
+	synctest.Test(t, func(t *testing.T) {
+		s, sessions, p := setupSablier(t)
+		s.ExternallyStartedScanInterval = 24 * time.Hour
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
 
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
 
-	// First lookup (isStartedByUs): no session yet. Second lookup (seedSession):
-	// a session appeared in between. InstanceInspect and Put must NOT be called.
-	first := sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
-	sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
-		Name:   "nginx",
-		Status: sablier.InstanceStatusReady,
-	}, nil).After(first)
+		// First lookup (isStartedByUs): no session yet. Second lookup (seedSession):
+		// a session appeared in between. InstanceInspect and Put must NOT be called.
+		first := sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+		sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
+			Name:   "nginx",
+			Status: sablier.InstanceStatusReady,
+		}, nil).After(first)
 
-	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusReady, Enabled: "true"}}
+		eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusReady, Enabled: "true"}}
 
-	startAutowarmWatcher(t, s, ctx, cancel)
+		startAutowarmWatcher(t, s, ctx, cancel)
 
-	time.Sleep(100 * time.Millisecond)
+		synctest.Wait()
+	})
 }
 
 // TestWatchAndWarmExternallyStarted_SkipsPendingSablierStart verifies the
@@ -219,47 +224,49 @@ func TestWatchAndWarmExternallyStarted_DoesNotReseedWhenSessionAppearsBetweenChe
 // in-progress start for an instance whose session entry is not written yet,
 // the "started" event emitted by the provider must not trigger a seed.
 func TestWatchAndWarmExternallyStarted_SkipsPendingSablierStart(t *testing.T) {
-	s, sessions, p := setupSablier(t)
-	s.ExternallyStartedScanInterval = 24 * time.Hour
+	synctest.Test(t, func(t *testing.T) {
+		s, sessions, p := setupSablier(t)
+		s.ExternallyStartedScanInterval = 24 * time.Hour
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
 
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
 
-	// Simulate the window between a Sablier-initiated start and its session
-	// write: the store keeps answering "not found" for the whole test.
-	sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
+		// Simulate the window between a Sablier-initiated start and its session
+		// write: the store keeps answering "not found" for the whole test.
+		sessions.EXPECT().Get(gomock.Any(), "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
 
-	// InstanceRequest performs exactly one pre-start inspect; the warm watcher
-	// must not add a second inspect (seedSession would).
-	p.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
-		Name:    "nginx",
-		Status:  sablier.InstanceStatusStopped,
-		Enabled: "true",
-	}, nil).Times(1)
+		// InstanceRequest performs exactly one pre-start inspect; the warm watcher
+		// must not add a second inspect (seedSession would).
+		p.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(sablier.InstanceInfo{
+			Name:    "nginx",
+			Status:  sablier.InstanceStatusStopped,
+			Enabled: "true",
+		}, nil).Times(1)
 
-	// A failed async start leaves the pendingStarts entry in place (it is only
-	// consumed by the next request), which is exactly the state we need.
-	p.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("start failed"))
+		// A failed async start leaves the pendingStarts entry in place (it is only
+		// consumed by the next request), which is exactly the state we need.
+		p.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("start failed"))
 
-	// The only allowed Put is the one from InstanceRequest itself.
-	sessions.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		// The only allowed Put is the one from InstanceRequest itself.
+		sessions.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-	// Sablier initiates the start: nginx is now registered in pendingStarts.
-	_, err := s.InstanceRequest(ctx, "nginx", time.Minute)
-	assert.NilError(t, err)
+		// Sablier initiates the start: nginx is now registered in pendingStarts.
+		_, err := s.InstanceRequest(ctx, "nginx", time.Minute)
+		assert.NilError(t, err)
 
-	// The provider emits the started event for the Sablier-initiated start.
-	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusReady, Enabled: "true"}}
+		// The provider emits the started event for the Sablier-initiated start.
+		eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusReady, Enabled: "true"}}
 
-	startAutowarmWatcher(t, s, ctx, cancel)
+		startAutowarmWatcher(t, s, ctx, cancel)
 
-	time.Sleep(100 * time.Millisecond)
+		synctest.Wait()
+	})
 }
 
 // TestWarmAllUnregisteredInstances_SkipsOnInspectError verifies that an
@@ -303,24 +310,26 @@ func TestWarmAllUnregisteredInstances_SkipsOnSessionLookupError(t *testing.T) {
 // TestWatchAndWarmExternallyStarted_SkipsNonSablierInstance verifies that a
 // "started" event for an instance without sablier.enable=true is ignored.
 func TestWatchAndWarmExternallyStarted_SkipsNonSablierInstance(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.ExternallyStartedScanInterval = 24 * time.Hour
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.ExternallyStartedScanInterval = 24 * time.Hour
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
 
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventStarted},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventStarted},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
 
-	// No sessions.Get or Put expected.
-	eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "false"}}
+		// No sessions.Get or Put expected.
+		eventsC <- sablier.InstanceEvent{Type: provider.InstanceEventStarted, Info: sablier.InstanceInfo{Name: "nginx", Status: sablier.InstanceStatusStarting, Enabled: "false"}}
 
-	startAutowarmWatcher(t, s, ctx, cancel)
+		startAutowarmWatcher(t, s, ctx, cancel)
 
-	time.Sleep(100 * time.Millisecond)
+		synctest.Wait()
+	})
 }
 
 // TestWatchAndWarmExternallyStarted_ReconciliationTicker verifies that even without

--- a/pkg/sablier/group_watch_test.go
+++ b/pkg/sablier/group_watch_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/sablierapp/sablier/pkg/provider"
@@ -41,110 +42,116 @@ func TestGroupWatch_ContextDone(t *testing.T) {
 }
 
 func TestGroupWatch_CreatedEvent_AddsToGroup(t *testing.T) {
-	s, _, p := setupSablier(t)
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
 
-	eventsC <- sablier.InstanceEvent{
-		Type: provider.InstanceEventCreated,
-		Info: sablier.InstanceInfo{Name: "nginx", Groups: []string{"web"}},
-	}
+		eventsC <- sablier.InstanceEvent{
+			Type: provider.InstanceEventCreated,
+			Info: sablier.InstanceInfo{Name: "nginx", Groups: []string{"web"}},
+		}
+		synctest.Wait()
 
-	assert.Assert(t, pollFor(t, func() bool {
-		return containsInstance(s.Groups(), "web", "nginx")
-	}, 2*time.Second), "nginx should be in group web after created event")
+		assert.Assert(t, containsInstance(s.Groups(), "web", "nginx"), "nginx should be in group web after created event")
+	})
 }
 
 func TestGroupWatch_RemovedEvent_RemovesFromGroup(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.SetGroups(map[string][]string{"web": {"nginx"}})
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.SetGroups(map[string][]string{"web": {"nginx"}})
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
 
-	eventsC <- sablier.InstanceEvent{
-		Type: provider.InstanceEventRemoved,
-		Info: sablier.InstanceInfo{Name: "nginx"},
-	}
+		eventsC <- sablier.InstanceEvent{
+			Type: provider.InstanceEventRemoved,
+			Info: sablier.InstanceInfo{Name: "nginx"},
+		}
+		synctest.Wait()
 
-	assert.Assert(t, pollFor(t, func() bool {
-		return !containsInstance(s.Groups(), "web", "nginx")
-	}, 2*time.Second), "nginx should no longer be in group web after removed event")
+		assert.Assert(t, !containsInstance(s.Groups(), "web", "nginx"), "nginx should no longer be in group web after removed event")
+	})
 }
 
 func TestGroupWatch_UpdatedEvent_MovesGroup(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.SetGroups(map[string][]string{"web": {"nginx"}})
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.SetGroups(map[string][]string{"web": {"nginx"}})
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
 
-	eventsC <- sablier.InstanceEvent{
-		Type: provider.InstanceEventUpdated,
-		Info: sablier.InstanceInfo{Name: "nginx", Groups: []string{"api"}},
-	}
+		eventsC <- sablier.InstanceEvent{
+			Type: provider.InstanceEventUpdated,
+			Info: sablier.InstanceInfo{Name: "nginx", Groups: []string{"api"}},
+		}
+		synctest.Wait()
 
-	assert.Assert(t, pollFor(t, func() bool {
 		groups := s.Groups()
-		return !containsInstance(groups, "web", "nginx") && containsInstance(groups, "api", "nginx")
-	}, 2*time.Second), "nginx should have moved from group web to group api after updated event")
+		assert.Assert(t, !containsInstance(groups, "web", "nginx") && containsInstance(groups, "api", "nginx"),
+			"nginx should have moved from group web to group api after updated event")
+	})
 }
 
 func TestGroupWatch_ReconciliationUpdatesGroups(t *testing.T) {
-	s, _, p := setupSablier(t)
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	called := make(chan struct{}, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
+		called := make(chan struct{}, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
 
-	p.EXPECT().InstanceGroups(gomock.Any()).DoAndReturn(func(context.Context) (map[string][]string, error) {
+		p.EXPECT().InstanceGroups(gomock.Any()).DoAndReturn(func(context.Context) (map[string][]string, error) {
+			select {
+			case called <- struct{}{}:
+			default:
+			}
+			return map[string][]string{"g": {"a", "b"}}, nil
+		}).AnyTimes()
+
+		startGroupWatch(t, s, ctx, cancel)
+
 		select {
-		case called <- struct{}{}:
-		default:
+		case <-called:
+			// at least one reconciliation happened (startup call)
+		case <-time.After(3 * time.Second):
+			t.Fatal("group watch did not call InstanceGroups")
 		}
-		return map[string][]string{"g": {"a", "b"}}, nil
-	}).AnyTimes()
+		synctest.Wait()
 
-	startGroupWatch(t, s, ctx, cancel)
-
-	select {
-	case <-called:
-		// at least one reconciliation happened (startup call)
-	case <-time.After(3 * time.Second):
-		t.Fatal("group watch did not call InstanceGroups")
-	}
-
-	assert.Assert(t, pollFor(t, func() bool {
-		return containsInstance(s.Groups(), "g", "a") && containsInstance(s.Groups(), "g", "b")
-	}, 2*time.Second), "expected groups to be populated via reconciliation")
+		assert.Assert(t, containsInstance(s.Groups(), "g", "a") && containsInstance(s.Groups(), "g", "b"),
+			"expected groups to be populated via reconciliation")
+	})
 }
 
 func TestGroupWatch_EventStreamClosed_FallsBackToReconciliation(t *testing.T) {
@@ -179,279 +186,295 @@ func TestGroupWatch_EventStreamClosed_FallsBackToReconciliation(t *testing.T) {
 }
 
 func TestGroupWatch_ProviderErrorDoesNotUpdateGroups(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.SetGroups(map[string][]string{"existing": {"x"}})
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.SetGroups(map[string][]string{"existing": {"x"}})
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	called := make(chan struct{}, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
+		called := make(chan struct{}, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
 
-	p.EXPECT().InstanceGroups(gomock.Any()).DoAndReturn(func(context.Context) (map[string][]string, error) {
+		p.EXPECT().InstanceGroups(gomock.Any()).DoAndReturn(func(context.Context) (map[string][]string, error) {
+			select {
+			case called <- struct{}{}:
+			default:
+			}
+			return nil, errors.New("provider down")
+		}).AnyTimes()
+
+		startGroupWatch(t, s, ctx, cancel)
+
 		select {
-		case called <- struct{}{}:
-		default:
+		case <-called:
+			cancel()
+		case <-time.After(3 * time.Second):
+			t.Fatal("group watch did not poll provider")
 		}
-		return nil, errors.New("provider down")
-	}).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
-
-	select {
-	case <-called:
-		cancel()
-	case <-time.After(3 * time.Second):
-		t.Fatal("group watch did not poll provider")
-	}
-
-	time.Sleep(50 * time.Millisecond)
-	assert.DeepEqual(t, s.Groups(), map[string][]string{"existing": {"x"}})
+		synctest.Wait()
+		assert.DeepEqual(t, s.Groups(), map[string][]string{"existing": {"x"}})
+	})
 }
 
 func TestGroupWatch_UpdatedEvent_LostLabel(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.SetGroups(map[string][]string{"web": {"nginx"}})
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.SetGroups(map[string][]string{"web": {"nginx"}})
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
 
-	eventsC <- sablier.InstanceEvent{
-		Type: provider.InstanceEventUpdated,
-		Info: sablier.InstanceInfo{Name: "nginx", Groups: nil},
-	}
+		eventsC <- sablier.InstanceEvent{
+			Type: provider.InstanceEventUpdated,
+			Info: sablier.InstanceInfo{Name: "nginx", Groups: nil},
+		}
+		synctest.Wait()
 
-	assert.Assert(t, pollFor(t, func() bool {
-		return !containsInstance(s.Groups(), "web", "nginx")
-	}, 2*time.Second), "nginx should no longer be in group web after losing its label")
+		assert.Assert(t, !containsInstance(s.Groups(), "web", "nginx"), "nginx should no longer be in group web after losing its label")
+	})
 }
 
 func TestGroupWatch_CreatedEvent_MovesToGroup(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.SetGroups(map[string][]string{"web": {"nginx"}})
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.SetGroups(map[string][]string{"web": {"nginx"}})
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
 
-	eventsC <- sablier.InstanceEvent{
-		Type: provider.InstanceEventCreated,
-		Info: sablier.InstanceInfo{Name: "nginx", Groups: []string{"api"}},
-	}
+		eventsC <- sablier.InstanceEvent{
+			Type: provider.InstanceEventCreated,
+			Info: sablier.InstanceInfo{Name: "nginx", Groups: []string{"api"}},
+		}
+		synctest.Wait()
 
-	assert.Assert(t, pollFor(t, func() bool {
 		groups := s.Groups()
-		return !containsInstance(groups, "web", "nginx") && containsInstance(groups, "api", "nginx")
-	}, 2*time.Second), "nginx should have moved from group web to group api after created event")
+		assert.Assert(t, !containsInstance(groups, "web", "nginx") && containsInstance(groups, "api", "nginx"),
+			"nginx should have moved from group web to group api after created event")
+	})
 }
 
 func TestGroupWatch_UpdatedEvent_GroupUnchanged(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.SetGroups(map[string][]string{"web": {"nginx"}})
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.SetGroups(map[string][]string{"web": {"nginx"}})
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
 
-	eventsC <- sablier.InstanceEvent{
-		Type: provider.InstanceEventUpdated,
-		Info: sablier.InstanceInfo{Name: "nginx", Groups: []string{"web"}},
-	}
+		eventsC <- sablier.InstanceEvent{
+			Type: provider.InstanceEventUpdated,
+			Info: sablier.InstanceInfo{Name: "nginx", Groups: []string{"web"}},
+		}
 
-	// Give the event time to be processed then assert state is unchanged.
-	time.Sleep(100 * time.Millisecond)
-	groups := s.Groups()
-	assert.Assert(t, containsInstance(groups, "web", "nginx"), "nginx should still be in group web")
-	assert.Equal(t, len(groups["web"]), 1, "nginx should appear exactly once in group web")
+		// Wait until the event is processed, then make sure that the state did not change.
+		synctest.Wait()
+		groups := s.Groups()
+		assert.Assert(t, containsInstance(groups, "web", "nginx"), "nginx should still be in group web")
+		assert.Equal(t, len(groups["web"]), 1, "nginx should appear exactly once in group web")
+	})
 }
 
 func TestGroupWatch_ReconciliationMovesGroup(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.SetGroups(map[string][]string{"web": {"nginx"}})
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.SetGroups(map[string][]string{"web": {"nginx"}})
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{"api": {"nginx"}}, nil).AnyTimes()
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{"api": {"nginx"}}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
+		synctest.Wait()
 
-	assert.Assert(t, pollFor(t, func() bool {
 		groups := s.Groups()
-		return !containsInstance(groups, "web", "nginx") && containsInstance(groups, "api", "nginx")
-	}, 3*time.Second), "nginx should have moved from group web to group api via reconciliation")
+		assert.Assert(t, !containsInstance(groups, "web", "nginx") && containsInstance(groups, "api", "nginx"),
+			"nginx should have moved from group web to group api via reconciliation")
+	})
 }
 
 func TestGroupWatch_ReconciliationRemovesFromGroup(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.SetGroups(map[string][]string{"web": {"nginx"}})
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.SetGroups(map[string][]string{"web": {"nginx"}})
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
-	// Provider no longer reports nginx in any group.
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
+		// Provider no longer reports nginx in any group.
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
+		synctest.Wait()
 
-	assert.Assert(t, pollFor(t, func() bool {
-		return !containsInstance(s.Groups(), "web", "nginx")
-	}, 3*time.Second), "nginx should have been removed from group web via reconciliation")
+		assert.Assert(t, !containsInstance(s.Groups(), "web", "nginx"), "nginx should have been removed from group web via reconciliation")
+	})
 }
 
 // TestGroupWatch_CreatedEvent_MultipleGroups verifies that an instance whose
 // Groups field lists two groups is added to both groups simultaneously.
 func TestGroupWatch_CreatedEvent_MultipleGroups(t *testing.T) {
-	s, _, p := setupSablier(t)
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
 
-	// shared-api belongs to both team-a and team-b.
-	eventsC <- sablier.InstanceEvent{
-		Type: provider.InstanceEventCreated,
-		Info: sablier.InstanceInfo{Name: "shared-api", Groups: []string{"team-a", "team-b"}},
-	}
+		// shared-api belongs to both team-a and team-b.
+		eventsC <- sablier.InstanceEvent{
+			Type: provider.InstanceEventCreated,
+			Info: sablier.InstanceInfo{Name: "shared-api", Groups: []string{"team-a", "team-b"}},
+		}
+		synctest.Wait()
 
-	assert.Assert(t, pollFor(t, func() bool {
 		groups := s.Groups()
-		return containsInstance(groups, "team-a", "shared-api") &&
-			containsInstance(groups, "team-b", "shared-api")
-	}, 2*time.Second), "shared-api should appear in both team-a and team-b after created event")
+		assert.Assert(t, containsInstance(groups, "team-a", "shared-api") &&
+			containsInstance(groups, "team-b", "shared-api"),
+			"shared-api should appear in both team-a and team-b after created event")
+	})
 }
 
 // TestGroupWatch_UpdatedEvent_AddsSecondGroup verifies that updating an instance
 // to add a second group leaves the first group intact and adds to the new one.
 func TestGroupWatch_UpdatedEvent_AddsSecondGroup(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.SetGroups(map[string][]string{"team-a": {"shared-api"}})
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.SetGroups(map[string][]string{"team-a": {"shared-api"}})
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
 
-	// Label updated from "team-a" to "team-a,team-b".
-	eventsC <- sablier.InstanceEvent{
-		Type: provider.InstanceEventUpdated,
-		Info: sablier.InstanceInfo{Name: "shared-api", Groups: []string{"team-a", "team-b"}},
-	}
+		// Label updated from "team-a" to "team-a,team-b".
+		eventsC <- sablier.InstanceEvent{
+			Type: provider.InstanceEventUpdated,
+			Info: sablier.InstanceInfo{Name: "shared-api", Groups: []string{"team-a", "team-b"}},
+		}
+		synctest.Wait()
 
-	assert.Assert(t, pollFor(t, func() bool {
 		groups := s.Groups()
-		return containsInstance(groups, "team-a", "shared-api") &&
-			containsInstance(groups, "team-b", "shared-api")
-	}, 2*time.Second), "shared-api should be in both team-a and team-b after update")
+		assert.Assert(t, containsInstance(groups, "team-a", "shared-api") &&
+			containsInstance(groups, "team-b", "shared-api"),
+			"shared-api should be in both team-a and team-b after update")
+	})
 }
 
 // TestGroupWatch_RemovedEvent_RemovesFromAllGroups verifies that removing an
 // instance that belonged to multiple groups drops it from every group.
 func TestGroupWatch_RemovedEvent_RemovesFromAllGroups(t *testing.T) {
-	s, _, p := setupSablier(t)
-	s.SetGroups(map[string][]string{
-		"team-a": {"shared-api", "frontend"},
-		"team-b": {"shared-api", "backend"},
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
+		s.SetGroups(map[string][]string{
+			"team-a": {"shared-api", "frontend"},
+			"team-b": {"shared-api", "backend"},
+		})
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		eventsC := make(chan sablier.InstanceEvent, 1)
+		errC := make(chan error, 1)
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
+		// Provider reflects the post-removal state: shared-api is gone; frontend and backend remain.
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{
+			"team-a": {"frontend"},
+			"team-b": {"backend"},
+		}, nil).AnyTimes()
+
+		startGroupWatch(t, s, ctx, cancel)
+
+		eventsC <- sablier.InstanceEvent{
+			Type: provider.InstanceEventRemoved,
+			Info: sablier.InstanceInfo{Name: "shared-api"},
+		}
+		synctest.Wait()
+
+		groups := s.Groups()
+		assert.Assert(t, !containsInstance(groups, "team-a", "shared-api") &&
+			!containsInstance(groups, "team-b", "shared-api"),
+			"shared-api should be removed from both team-a and team-b after removed event")
+
+		// Other instances should be unaffected.
+		assert.Assert(t, containsInstance(groups, "team-a", "frontend") &&
+			containsInstance(groups, "team-b", "backend"),
+			"frontend and backend should still be in their respective groups")
 	})
-
-	ctx, cancel := context.WithCancel(t.Context())
-
-	eventsC := make(chan sablier.InstanceEvent, 1)
-	errC := make(chan error, 1)
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: eventsC, Err: errC})
-	// Provider reflects the post-removal state: shared-api is gone; frontend and backend remain.
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{
-		"team-a": {"frontend"},
-		"team-b": {"backend"},
-	}, nil).AnyTimes()
-
-	startGroupWatch(t, s, ctx, cancel)
-
-	eventsC <- sablier.InstanceEvent{
-		Type: provider.InstanceEventRemoved,
-		Info: sablier.InstanceInfo{Name: "shared-api"},
-	}
-
-	assert.Assert(t, pollFor(t, func() bool {
-		groups := s.Groups()
-		return !containsInstance(groups, "team-a", "shared-api") &&
-			!containsInstance(groups, "team-b", "shared-api")
-	}, 2*time.Second), "shared-api should be removed from both team-a and team-b after removed event")
-
-	// Other instances should be unaffected.
-	assert.Assert(t, pollFor(t, func() bool {
-		groups := s.Groups()
-		return containsInstance(groups, "team-a", "frontend") &&
-			containsInstance(groups, "team-b", "backend")
-	}, 2*time.Second), "frontend and backend should still be in their respective groups")
 }
 
 // TestGroupWatch_ReconciliationMultipleGroups verifies that reconciliation via
 // InstanceGroups correctly places an instance into multiple groups.
 func TestGroupWatch_ReconciliationMultipleGroups(t *testing.T) {
-	s, _, p := setupSablier(t)
+	synctest.Test(t, func(t *testing.T) {
+		s, _, p := setupSablier(t)
 
-	ctx, cancel := context.WithCancel(t.Context())
+		ctx, cancel := context.WithCancel(t.Context())
 
-	p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
-		Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
-	}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
-	p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{
-		"team-a": {"frontend", "shared-api"},
-		"team-b": {"backend", "shared-api"},
-	}, nil).AnyTimes()
+		p.EXPECT().InstanceEvents(gomock.Any(), provider.InstanceEventsOptions{
+			Types: []provider.InstanceEventType{provider.InstanceEventCreated, provider.InstanceEventUpdated, provider.InstanceEventRemoved},
+		}).Return(sablier.InstanceEventStream{Events: make(chan sablier.InstanceEvent), Err: make(chan error, 1)})
+		p.EXPECT().InstanceGroups(gomock.Any()).Return(map[string][]string{
+			"team-a": {"frontend", "shared-api"},
+			"team-b": {"backend", "shared-api"},
+		}, nil).AnyTimes()
 
-	startGroupWatch(t, s, ctx, cancel)
+		startGroupWatch(t, s, ctx, cancel)
+		synctest.Wait()
 
-	assert.Assert(t, pollFor(t, func() bool {
 		groups := s.Groups()
-		return containsInstance(groups, "team-a", "shared-api") &&
+		assert.Assert(t, containsInstance(groups, "team-a", "shared-api") &&
 			containsInstance(groups, "team-b", "shared-api") &&
 			containsInstance(groups, "team-a", "frontend") &&
-			containsInstance(groups, "team-b", "backend")
-	}, 3*time.Second), "reconciliation should populate all instances across multiple groups")
+			containsInstance(groups, "team-b", "backend"),
+			"reconciliation should populate all instances across multiple groups")
+	})
 }
 
 // startGroupWatch launches s.GroupWatch in a goroutine and registers a
@@ -471,19 +494,6 @@ func startGroupWatch(t *testing.T, s *sablier.Sablier, ctx context.Context, canc
 		case <-time.After(5 * time.Second):
 		}
 	})
-}
-
-// pollFor repeatedly calls check until it returns true or the deadline passes.
-func pollFor(t *testing.T, check func() bool, timeout time.Duration) bool {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if check() {
-			return true
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return false
 }
 
 // containsInstance reports whether group contains instance.

--- a/pkg/sablier/instance_dependency_orchestration_test.go
+++ b/pkg/sablier/instance_dependency_orchestration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/neilotoole/slogt"
@@ -261,24 +262,26 @@ func TestStartWithDependencies_PropagatesStartError(t *testing.T) {
 }
 
 func TestEnsureDependencyStarted_SingleFlight(t *testing.T) {
-	fp := newFakeDepProvider()
-	fp.startDelay = 50 * time.Millisecond
-	s := newDepSablier(t, fp)
+	synctest.Test(t, func(t *testing.T) {
+		fp := newFakeDepProvider()
+		fp.startDelay = 50 * time.Millisecond
+		s := newDepSablier(t, fp)
 
-	const n = 8
-	var wg sync.WaitGroup
-	wg.Add(n)
-	for range n {
-		go func() {
-			defer wg.Done()
-			_ = s.ensureDependencyStarted(context.Background(), "db")
-		}()
-	}
-	wg.Wait()
+		const n = 8
+		var wg sync.WaitGroup
+		wg.Add(n)
+		for range n {
+			go func() {
+				defer wg.Done()
+				_ = s.ensureDependencyStarted(context.Background(), "db")
+			}()
+		}
+		wg.Wait()
 
-	if c := fp.count("db"); c != 1 {
-		t.Fatalf("expected a single InstanceStart across concurrent callers, got %d", c)
-	}
+		if c := fp.count("db"); c != 1 {
+			t.Fatalf("expected a single InstanceStart across concurrent callers, got %d", c)
+		}
+	})
 }
 
 func TestEnsureDependencyStarted_DefersToManagedStart(t *testing.T) {

--- a/pkg/sablier/instance_expired_test.go
+++ b/pkg/sablier/instance_expired_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/neilotoole/slogt"
@@ -14,100 +15,107 @@ import (
 )
 
 func TestOnInstanceExpired_StopsAndRecordsMetrics(t *testing.T) {
-	_, _, p, rec := setupSablierWithMetrics(t)
-	ctx := t.Context()
+	synctest.Test(t, func(t *testing.T) {
+		_, _, p, rec := setupSablierWithMetrics(t)
+		ctx := t.Context()
 
-	stopped := make(chan struct{}, 1)
-	p.EXPECT().InstanceStop(gomock.Any(), "i1").DoAndReturn(func(_ any, _ string) error {
-		stopped <- struct{}{}
-		return nil
+		stopped := make(chan struct{}, 1)
+		p.EXPECT().InstanceStop(gomock.Any(), "i1").DoAndReturn(func(_ any, _ string) error {
+			stopped <- struct{}{}
+			return nil
+		})
+
+		cb := sablier.OnInstanceExpired(ctx, p, rec, slogt.New(t))
+		cb("i1")
+
+		select {
+		case <-stopped:
+		case <-time.After(2 * time.Second):
+			t.Fatal("instance stop was not invoked")
+		}
+
+		// Wait until the callback goroutine records the metrics.
+		synctest.Wait()
+		calls := rec.snapshot()
+		assert.Assert(t, containsCall(calls, "stop:i1/expired"))
+		assert.Assert(t, containsCall(calls, "active-:i1"))
+		assert.Assert(t, containsCall(calls, "ready_discard:i1"))
 	})
-
-	cb := sablier.OnInstanceExpired(ctx, p, rec, slogt.New(t))
-	cb("i1")
-
-	select {
-	case <-stopped:
-	case <-time.After(2 * time.Second):
-		t.Fatal("instance stop was not invoked")
-	}
-
-	// Let recorder calls complete in the callback goroutine.
-	time.Sleep(20 * time.Millisecond)
-	calls := rec.snapshot()
-	assert.Assert(t, containsCall(calls, "stop:i1/expired"))
-	assert.Assert(t, containsCall(calls, "active-:i1"))
-	assert.Assert(t, containsCall(calls, "ready_discard:i1"))
 }
 
 func TestOnInstanceExpired_ProviderStopErrorStillRecordsMetrics(t *testing.T) {
-	_, _, p, rec := setupSablierWithMetrics(t)
-	ctx := t.Context()
+	synctest.Test(t, func(t *testing.T) {
+		_, _, p, rec := setupSablierWithMetrics(t)
+		ctx := t.Context()
 
-	stopped := make(chan struct{}, 1)
-	p.EXPECT().InstanceStop(gomock.Any(), "i2").DoAndReturn(func(_ any, _ string) error {
-		stopped <- struct{}{}
-		return errors.New("cannot stop")
+		stopped := make(chan struct{}, 1)
+		p.EXPECT().InstanceStop(gomock.Any(), "i2").DoAndReturn(func(_ any, _ string) error {
+			stopped <- struct{}{}
+			return errors.New("cannot stop")
+		})
+
+		cb := sablier.OnInstanceExpired(ctx, p, rec, slogt.New(t))
+		cb("i2")
+
+		select {
+		case <-stopped:
+		case <-time.After(2 * time.Second):
+			t.Fatal("instance stop was not invoked")
+		}
+
+		synctest.Wait()
+		calls := rec.snapshot()
+		assert.Assert(t, containsCall(calls, "stop:i2/expired"))
+		assert.Assert(t, containsCall(calls, "active-:i2"))
+		assert.Assert(t, containsCall(calls, "ready_discard:i2"))
 	})
-
-	cb := sablier.OnInstanceExpired(ctx, p, rec, slogt.New(t))
-	cb("i2")
-
-	select {
-	case <-stopped:
-	case <-time.After(2 * time.Second):
-		t.Fatal("instance stop was not invoked")
-	}
-
-	time.Sleep(20 * time.Millisecond)
-	calls := rec.snapshot()
-	assert.Assert(t, containsCall(calls, "stop:i2/expired"))
-	assert.Assert(t, containsCall(calls, "active-:i2"))
-	assert.Assert(t, containsCall(calls, "ready_discard:i2"))
 }
 
 func TestSablierOnInstanceExpired_VerifyEnabledOnExpirationStopsLabeledInstance(t *testing.T) {
-	manager, _, provider, rec := setupSablierWithMetrics(t)
-	manager.WithVerifyEnabledOnExpiration(true)
-	ctx := t.Context()
+	synctest.Test(t, func(t *testing.T) {
+		manager, _, provider, rec := setupSablierWithMetrics(t)
+		manager.WithVerifyEnabledOnExpiration(true)
+		ctx := t.Context()
 
-	provider.EXPECT().InstanceInspect(ctx, "nginx").Return(sablier.InstanceInfo{
-		Name:    "nginx",
-		Enabled: "true",
-	}, nil)
-	provider.EXPECT().InstanceStop(ctx, "nginx").Return(nil)
+		provider.EXPECT().InstanceInspect(ctx, "nginx").Return(sablier.InstanceInfo{
+			Name:    "nginx",
+			Enabled: "true",
+		}, nil)
+		provider.EXPECT().InstanceStop(ctx, "nginx").Return(nil)
 
-	manager.OnInstanceExpired(ctx)("nginx")
+		manager.OnInstanceExpired(ctx)("nginx")
 
-	assert.Assert(t, checkWithTimeout(50*time.Millisecond, 5*time.Second, func() bool {
+		synctest.Wait()
 		calls := rec.snapshot()
-		return containsCall(calls, "stop:nginx/expired") &&
+		assert.Assert(t, containsCall(calls, "stop:nginx/expired") &&
 			containsCall(calls, "active-:nginx") &&
-			containsCall(calls, "ready_discard:nginx")
-	}), "expected expiration metrics")
+			containsCall(calls, "ready_discard:nginx"), "expected expiration metrics")
+	})
 }
 
 func TestSablierOnInstanceExpired_VerifyEnabledOnExpirationSkipsUnlabeledInstance(t *testing.T) {
-	manager, _, provider, rec := setupSablierWithMetrics(t)
-	manager.WithVerifyEnabledOnExpiration(true)
-	ctx := t.Context()
-	inspected := make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		manager, _, provider, rec := setupSablierWithMetrics(t)
+		manager.WithVerifyEnabledOnExpiration(true)
+		ctx := t.Context()
+		inspected := make(chan struct{})
 
-	provider.EXPECT().InstanceInspect(ctx, "nginx").DoAndReturn(func(_ any, _ string) (sablier.InstanceInfo, error) {
-		close(inspected)
-		return sablier.InstanceInfo{Name: "nginx"}, nil
+		provider.EXPECT().InstanceInspect(ctx, "nginx").DoAndReturn(func(_ any, _ string) (sablier.InstanceInfo, error) {
+			close(inspected)
+			return sablier.InstanceInfo{Name: "nginx"}, nil
+		})
+
+		manager.OnInstanceExpired(ctx)("nginx")
+
+		select {
+		case <-inspected:
+		case <-time.After(5 * time.Second):
+			t.Fatal("InstanceInspect was never called")
+		}
+		synctest.Wait()
+
+		assertNoExpirationMetrics(t, rec)
 	})
-
-	manager.OnInstanceExpired(ctx)("nginx")
-
-	select {
-	case <-inspected:
-	case <-time.After(5 * time.Second):
-		t.Fatal("InstanceInspect was never called")
-	}
-	time.Sleep(50 * time.Millisecond)
-
-	assertNoExpirationMetrics(t, rec)
 }
 
 func assertNoExpirationMetrics(t *testing.T, rec metrics.Recorder) {

--- a/pkg/sablier/instance_request_test.go
+++ b/pkg/sablier/instance_request_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/sablierapp/sablier/pkg/sablier"
@@ -15,23 +16,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 )
-
-// checkWithTimeout polls fn at the given interval until it returns true or the timeout expires.
-func checkWithTimeout(interval, timeout time.Duration, fn func() bool) bool {
-	deadline := time.After(timeout)
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		if fn() {
-			return true
-		}
-		select {
-		case <-deadline:
-			return false
-		case <-ticker.C:
-		}
-	}
-}
 
 func TestInstanceRequest_EmptyName(t *testing.T) {
 	manager, _, _ := setupSablier(t)
@@ -334,175 +318,177 @@ func TestInstanceRequest_SecondCallJoinsInFlightPendingStart(t *testing.T) {
 }
 
 func TestInstanceRequest_AsyncErrorSurfacedOnNotReadyPath(t *testing.T) {
-	manager, sessions, provider := setupSablier(t)
-	ctx := t.Context()
+	synctest.Test(t, func(t *testing.T) {
+		manager, sessions, provider := setupSablier(t)
+		ctx := t.Context()
 
-	stoppedInfo := sablier.InstanceInfo{
-		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
-		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
-	}
-	notReady := stoppedInfo
-	notReady.Status = sablier.InstanceStatusStarting
+		stoppedInfo := sablier.InstanceInfo{
+			Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+			Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+		}
+		notReady := stoppedInfo
+		notReady.Status = sablier.InstanceStatusStarting
 
-	// First call: store miss -> requestStart
-	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
-	provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil)
-	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
+		// First call: store miss -> requestStart
+		sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+		provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil)
+		sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
 
-	// Goroutine fails immediately
-	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("connection refused"))
+		// Goroutine fails immediately
+		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("connection refused"))
 
-	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
-	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
+		info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+		assert.NilError(t, err)
+		assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 
-	// Subsequent calls: store returns the stored not-ready state (realistic behavior).
-	// While goroutine is still running, polling returns not-ready with Put.
-	// Once goroutine finishes, consumePendingError surfaces the error (no Put in that case).
-	sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil).AnyTimes()
-	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil).AnyTimes()
+		// Wait until the async start fails.
+		synctest.Wait()
 
-	assert.Assert(t, checkWithTimeout(100*time.Millisecond, 5*time.Second, func() bool {
+		// Second call: the store returns the stored not-ready state and
+		// consumePendingError surfaces the error, so Put is not called.
+		sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil)
+
 		_, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
-		return err != nil
-	}), "expected async error to be surfaced on the not-ready path")
-	assert.ErrorContains(t, err, "instance start failed: connection refused")
+		assert.ErrorContains(t, err, "instance start failed: connection refused")
+	})
 }
 
 func TestInstanceRequest_RetryAfterErrorConsumed(t *testing.T) {
-	manager, sessions, provider := setupSablier(t)
-	ctx := t.Context()
+	synctest.Test(t, func(t *testing.T) {
+		manager, sessions, provider := setupSablier(t)
+		ctx := t.Context()
 
-	stoppedInfo := sablier.InstanceInfo{
-		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
-		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
-	}
-	notReady := stoppedInfo
-	notReady.Status = sablier.InstanceStatusStarting
-	secondDone := make(chan struct{})
+		stoppedInfo := sablier.InstanceInfo{
+			Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+			Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+		}
+		notReady := stoppedInfo
+		notReady.Status = sablier.InstanceStatusStarting
+		secondDone := make(chan struct{})
 
-	// All Get/Put/Inspect calls use AnyTimes since polling may hit them multiple times
-	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).AnyTimes()
-	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil).AnyTimes()
-	provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil).AnyTimes()
+		// The 1st and 3rd calls start the instance. The 2nd call only reads the store.
+		sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound).Times(3)
+		sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil).Times(2)
+		provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil).Times(2)
 
-	gomock.InOrder(
-		// First attempt — fails immediately
-		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("connection refused")),
-		// Retry — succeeds
-		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ any, _ string) error {
-			close(secondDone)
-			return nil
-		}),
-	)
+		gomock.InOrder(
+			// First attempt — fails immediately
+			provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("connection refused")),
+			// Retry — succeeds
+			provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ any, _ string) error {
+				close(secondDone)
+				return nil
+			}),
+		)
 
-	// 1st call: dispatches goroutine (fails)
-	_, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
-	assert.NilError(t, err)
+		// 1st call: dispatches goroutine (fails)
+		_, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+		assert.NilError(t, err)
 
-	// 2nd call: poll until the error is consumable
-	assert.Assert(t, checkWithTimeout(100*time.Millisecond, 5*time.Second, func() bool {
+		// 2nd call: the error is consumable once the goroutine is done
+		synctest.Wait()
 		_, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
-		return err != nil
-	}), "expected error to be surfaced")
-	assert.ErrorContains(t, err, "instance start failed: connection refused")
+		assert.ErrorContains(t, err, "instance start failed: connection refused")
 
-	// 3rd call: entry cleared, store miss again -> requestStart retries
-	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
-	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
+		// 3rd call: entry cleared, store miss again -> requestStart retries
+		info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+		assert.NilError(t, err)
+		assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 
-	select {
-	case <-secondDone:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Retry goroutine was never started")
-	}
+		select {
+		case <-secondDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Retry goroutine was never started")
+		}
+	})
 }
 
 func TestInstanceRequest_SuccessfulStartCleansUpPendingEntry(t *testing.T) {
-	manager, sessions, provider := setupSablier(t)
-	ctx := t.Context()
+	synctest.Test(t, func(t *testing.T) {
+		manager, sessions, provider := setupSablier(t)
+		ctx := t.Context()
 
-	stoppedInfo := sablier.InstanceInfo{
-		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
-		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
-	}
-	notReady := stoppedInfo
-	notReady.Status = sablier.InstanceStatusStarting
-	ready := sablier.InstanceInfo{Name: "nginx", CurrentReplicas: 1, DesiredReplicas: 1, Status: sablier.InstanceStatusReady}
+		stoppedInfo := sablier.InstanceInfo{
+			Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+			Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+		}
+		notReady := stoppedInfo
+		notReady.Status = sablier.InstanceStatusStarting
+		ready := sablier.InstanceInfo{Name: "nginx", CurrentReplicas: 1, DesiredReplicas: 1, Status: sablier.InstanceStatusReady}
 
-	// 1st call: store miss -> requestStart (goroutine succeeds)
-	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
-	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
+		// 1st call: store miss -> requestStart (goroutine succeeds)
+		sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+		sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
 
-	startDone := make(chan struct{})
-	gomock.InOrder(
-		provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil), // pre-start inspect
-		provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(ready, nil),       // post-start inspect in not-ready path
-	)
-	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ any, _ string) error {
-		close(startDone)
-		return nil
+		startDone := make(chan struct{})
+		gomock.InOrder(
+			provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil), // pre-start inspect
+			provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(ready, nil),       // post-start inspect in not-ready path
+		)
+		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ any, _ string) error {
+			close(startDone)
+			return nil
+		})
+
+		info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+		assert.NilError(t, err)
+		assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
+
+		// Wait for goroutine to finish and self-clean
+		select {
+		case <-startDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("InstanceStart goroutine never completed")
+		}
+		// Wait until the goroutine removes the pending entry.
+		synctest.Wait()
+
+		// 2nd call: store returns not-ready, no pending entry exists, goes straight to inspect
+		sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil)
+		sessions.EXPECT().Put(ctx, readyAtMatcher{}, time.Minute).Return(nil)
+
+		info, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
+		assert.NilError(t, err)
+		assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusReady))
 	})
-
-	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
-	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
-
-	// Wait for goroutine to finish and self-clean
-	select {
-	case <-startDone:
-	case <-time.After(5 * time.Second):
-		t.Fatal("InstanceStart goroutine never completed")
-	}
-	// Small settle time for the goroutine to acquire the lock and clean up
-	time.Sleep(50 * time.Millisecond)
-
-	// 2nd call: store returns not-ready, no pending entry exists, goes straight to inspect
-	sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil)
-	sessions.EXPECT().Put(ctx, readyAtMatcher{}, time.Minute).Return(nil)
-
-	info, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
-	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusReady))
 }
 
 func TestInstanceRequest_StartTimeoutSurfacesError(t *testing.T) {
-	manager, sessions, provider := setupSablier(t)
-	manager.InstanceStartTimeout = 100 * time.Millisecond
-	ctx := t.Context()
+	synctest.Test(t, func(t *testing.T) {
+		manager, sessions, provider := setupSablier(t)
+		manager.InstanceStartTimeout = 100 * time.Millisecond
+		ctx := t.Context()
 
-	stoppedInfo := sablier.InstanceInfo{
-		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
-		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
-	}
-	notReady := stoppedInfo
-	notReady.Status = sablier.InstanceStatusStarting
+		stoppedInfo := sablier.InstanceInfo{
+			Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+			Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+		}
+		notReady := stoppedInfo
+		notReady.Status = sablier.InstanceStatusStarting
 
-	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
-	provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil)
-	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
+		sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+		provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil)
+		sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
 
-	// InstanceStart blocks until context is cancelled
-	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(startCtx any, _ string) error {
-		<-startCtx.(interface{ Done() <-chan struct{} }).Done()
-		return startCtx.(interface{ Err() error }).Err()
-	})
+		// InstanceStart blocks until context is cancelled
+		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(startCtx any, _ string) error {
+			<-startCtx.(interface{ Done() <-chan struct{} }).Done()
+			return startCtx.(interface{ Err() error }).Err()
+		})
 
-	info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
-	assert.NilError(t, err)
-	assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
+		info, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+		assert.NilError(t, err)
+		assert.Equal(t, info.Status, sablier.InstanceStatus(sablier.InstanceStatusStarting))
 
-	// Subsequent calls: store returns not-ready; polling may get not-ready while
-	// the goroutine is still in progress, or the timeout error once it completes.
-	sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil).AnyTimes()
-	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil).AnyTimes()
+		// Wait until the start timeout cancels InstanceStart.
+		synctest.Sleep(manager.InstanceStartTimeout)
 
-	assert.Assert(t, checkWithTimeout(50*time.Millisecond, 5*time.Second, func() bool {
+		// The store returns not-ready and the next call surfaces the timeout error.
+		sessions.EXPECT().Get(ctx, "nginx").Return(notReady, nil)
+
 		_, err = manager.InstanceRequest(ctx, "nginx", time.Minute)
-		return err != nil
-	}), "expected timeout error to be surfaced")
-	assert.ErrorContains(t, err, "instance start failed")
+		assert.ErrorContains(t, err, "instance start failed")
+	})
 }
 
 func TestInstanceRequest_ExistingNotReady_InspectsProvider(t *testing.T) {
@@ -562,74 +548,76 @@ func TestInstanceRequest_StoreGetError(t *testing.T) {
 }
 
 func TestInstanceRequest_NewInstance_RecordsStartMetrics_Success(t *testing.T) {
-	manager, sessions, provider, rec := setupSablierWithMetrics(t)
-	ctx := t.Context()
+	synctest.Test(t, func(t *testing.T) {
+		manager, sessions, provider, rec := setupSablierWithMetrics(t)
+		ctx := t.Context()
 
-	startDone := make(chan struct{})
+		startDone := make(chan struct{})
 
-	stoppedInfo := sablier.InstanceInfo{
-		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
-		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
-	}
-	notReady := stoppedInfo
-	notReady.Status = sablier.InstanceStatusStarting
+		stoppedInfo := sablier.InstanceInfo{
+			Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+			Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
+		}
+		notReady := stoppedInfo
+		notReady.Status = sablier.InstanceStatusStarting
 
-	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
-	provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil)
-	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
+		sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+		provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil)
+		sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
 
-	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ any, _ string) error {
-		close(startDone)
-		return nil
+		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").DoAndReturn(func(_ any, _ string) error {
+			close(startDone)
+			return nil
+		})
+
+		_, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+		assert.NilError(t, err)
+
+		select {
+		case <-startDone:
+		case <-time.After(5 * time.Second):
+			t.Fatal("InstanceStart goroutine never completed")
+		}
+		// Wait until the goroutine records the end metric.
+		synctest.Wait()
+		assert.Assert(t, slices.Contains(rec.snapshot(), "start_end:nginx"), "expected start_end metric")
+
+		calls := rec.snapshot()
+		assertContains(t, calls, "ready_begin:nginx")
+		assertContains(t, calls, "active+:nginx")
 	})
-
-	_, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
-	assert.NilError(t, err)
-
-	select {
-	case <-startDone:
-	case <-time.After(5 * time.Second):
-		t.Fatal("InstanceStart goroutine never completed")
-	}
-	// Settle for the goroutine to record the end metric.
-	assert.Assert(t, checkWithTimeout(50*time.Millisecond, 5*time.Second, func() bool {
-		return slices.Contains(rec.snapshot(), "start_end:nginx")
-	}), "expected start_end metric")
-
-	calls := rec.snapshot()
-	assertContains(t, calls, "ready_begin:nginx")
-	assertContains(t, calls, "active+:nginx")
 }
 
 func TestInstanceRequest_NewInstance_RecordsStartFailure(t *testing.T) {
-	manager, sessions, provider, rec := setupSablierWithMetrics(t)
-	ctx := t.Context()
+	synctest.Test(t, func(t *testing.T) {
+		manager, sessions, provider, rec := setupSablierWithMetrics(t)
+		ctx := t.Context()
 
-	stoppedInfo := sablier.InstanceInfo{
-		Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
-		Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
-	}
-	notReady := stoppedInfo
-	notReady.Status = sablier.InstanceStatusStarting
-
-	sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
-	provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil)
-	sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
-	provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("boom"))
-
-	_, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
-	assert.NilError(t, err) // first call returns not-ready, error surfaces on next
-
-	assert.Assert(t, checkWithTimeout(50*time.Millisecond, 5*time.Second, func() bool {
-		return slices.Contains(rec.snapshot(), "start_fail:nginx")
-	}), "expected start_fail metric")
-
-	calls := rec.snapshot()
-	for _, c := range calls {
-		if c == "start_end:nginx" {
-			t.Errorf("did not expect start_end on failure, got: %v", calls)
+		stoppedInfo := sablier.InstanceInfo{
+			Name: "nginx", CurrentReplicas: 0, DesiredReplicas: 1, Status: sablier.InstanceStatusStopped,
+			Provider: "docker", Docker: &sablier.DockerContainerInfo{ID: "nginx", Image: "nginx:latest"},
 		}
-	}
+		notReady := stoppedInfo
+		notReady.Status = sablier.InstanceStatusStarting
+
+		sessions.EXPECT().Get(ctx, "nginx").Return(sablier.InstanceInfo{}, store.ErrKeyNotFound)
+		provider.EXPECT().InstanceInspect(gomock.Any(), "nginx").Return(stoppedInfo, nil)
+		sessions.EXPECT().Put(ctx, notReady, time.Minute).Return(nil)
+		provider.EXPECT().InstanceStart(gomock.Any(), "nginx").Return(errors.New("boom"))
+
+		_, err := manager.InstanceRequest(ctx, "nginx", time.Minute)
+		assert.NilError(t, err) // first call returns not-ready, error surfaces on next
+
+		synctest.Wait()
+		assert.Assert(t, slices.Contains(rec.snapshot(), "start_fail:nginx"), "expected start_fail metric")
+
+		calls := rec.snapshot()
+		for _, c := range calls {
+			if c == "start_end:nginx" {
+				t.Errorf("did not expect start_end on failure, got: %v", calls)
+			}
+		}
+	})
 }
 
 func TestInstanceRequest_ReadyTransition_RecordsReadyEnd(t *testing.T) {

--- a/pkg/sablier/session_request_test.go
+++ b/pkg/sablier/session_request_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/sablierapp/sablier/pkg/sablier"
@@ -328,22 +329,24 @@ func TestSessionsManager_RequestReadySessionCancelledByUser(t *testing.T) {
 func TestSessionsManager_RequestReadySessionCancelledByTimeout(t *testing.T) {
 
 	t.Run("request ready session is cancelled by timeout", func(t *testing.T) {
-		manager, store, provider := setupSablier(t)
-		store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil).AnyTimes()
-		store.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		synctest.Test(t, func(t *testing.T) {
+			manager, store, provider := setupSablier(t)
+			store.EXPECT().Get(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil).AnyTimes()
+			store.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-		provider.EXPECT().InstanceInspect(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil)
+			provider.EXPECT().InstanceInspect(gomock.Any(), gomock.Any()).Return(sablier.InstanceInfo{Name: "apache", Status: sablier.InstanceStatusStarting}, nil)
 
-		errchan := make(chan error)
-		go func() {
-			_, err := manager.RequestReadySession(t.Context(), []string{"apache"}, time.Minute, time.Second)
-			errchan <- err
-		}()
+			errchan := make(chan error)
+			go func() {
+				_, err := manager.RequestReadySession(t.Context(), []string{"apache"}, time.Minute, time.Second)
+				errchan <- err
+			}()
 
-		err := <-errchan
-		timeoutErr, ok := errors.AsType[sablier.ErrTimeout](err)
-		assert.Assert(t, ok)
-		assert.Equal(t, time.Second, timeoutErr.Duration)
+			err := <-errchan
+			timeoutErr, ok := errors.AsType[sablier.ErrTimeout](err)
+			assert.Assert(t, ok)
+			assert.Equal(t, time.Second, timeoutErr.Duration)
+		})
 	})
 }
 

--- a/pkg/store/inmemory/inmemory_test.go
+++ b/pkg/store/inmemory/inmemory_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sablierapp/sablier/pkg/store"
 	"gotest.tools/v3/assert"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -21,19 +22,21 @@ func TestInMemory(t *testing.T) {
 	})
 	t.Run("InMemoryPut", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-		vk := NewInMemory()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := context.Background()
+			vk := newInMemory(t)
 
-		err := vk.Put(ctx, sablier.InstanceInfo{Name: "test"}, 1*time.Second)
-		assert.NilError(t, err)
+			err := vk.Put(ctx, sablier.InstanceInfo{Name: "test"}, 1*time.Second)
+			assert.NilError(t, err)
 
-		i, err := vk.Get(ctx, "test")
-		assert.NilError(t, err)
-		assert.Equal(t, i.Name, "test")
+			i, err := vk.Get(ctx, "test")
+			assert.NilError(t, err)
+			assert.Equal(t, i.Name, "test")
 
-		<-time.After(2 * time.Second)
-		_, err = vk.Get(ctx, "test")
-		assert.ErrorIs(t, err, store.ErrKeyNotFound)
+			synctest.Sleep(2 * time.Second)
+			_, err = vk.Get(ctx, "test")
+			assert.ErrorIs(t, err, store.ErrKeyNotFound)
+		})
 	})
 	t.Run("InMemoryDelete", func(t *testing.T) {
 		t.Parallel()
@@ -55,44 +58,56 @@ func TestInMemory(t *testing.T) {
 	})
 	t.Run("InMemoryRange", func(t *testing.T) {
 		t.Parallel()
-		ctx := context.Background()
-		vk := NewInMemory()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := context.Background()
+			vk := newInMemory(t)
 
-		err := vk.Put(ctx, sablier.InstanceInfo{Name: "live", Groups: []string{"demo"}}, 30*time.Second)
-		assert.NilError(t, err)
-		err = vk.Put(ctx, sablier.InstanceInfo{Name: "expired"}, 10*time.Millisecond)
-		assert.NilError(t, err)
+			err := vk.Put(ctx, sablier.InstanceInfo{Name: "live", Groups: []string{"demo"}}, 30*time.Second)
+			assert.NilError(t, err)
+			err = vk.Put(ctx, sablier.InstanceInfo{Name: "expired"}, 10*time.Millisecond)
+			assert.NilError(t, err)
 
-		<-time.After(30 * time.Millisecond)
+			synctest.Sleep(30 * time.Millisecond)
 
-		got := make(map[string]time.Time)
-		err = vk.Range(ctx, func(info sablier.InstanceInfo, expiresAt time.Time) {
-			got[info.Name] = expiresAt
+			got := make(map[string]time.Time)
+			err = vk.Range(ctx, func(info sablier.InstanceInfo, expiresAt time.Time) {
+				got[info.Name] = expiresAt
+			})
+			assert.NilError(t, err)
+
+			// Only the live session is enumerated; the expired one is skipped.
+			assert.Equal(t, len(got), 1)
+			exp, ok := got["live"]
+			assert.Assert(t, ok)
+			assert.Assert(t, exp.After(time.Now()))
 		})
-		assert.NilError(t, err)
-
-		// Only the live session is enumerated; the expired one is skipped.
-		assert.Equal(t, len(got), 1)
-		exp, ok := got["live"]
-		assert.Assert(t, ok)
-		assert.Assert(t, exp.After(time.Now()))
 	})
 	t.Run("InMemoryOnExpire", func(t *testing.T) {
 		t.Parallel()
-		vk := NewInMemory()
+		synctest.Test(t, func(t *testing.T) {
+			vk := newInMemory(t)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
 
-		expirations := make(chan string)
-		err := vk.OnExpire(ctx, func(key string) {
-			expirations <- key
+			expirations := make(chan string)
+			err := vk.OnExpire(ctx, func(key string) {
+				expirations <- key
+			})
+			assert.NilError(t, err)
+
+			err = vk.Put(ctx, sablier.InstanceInfo{Name: "test"}, 1*time.Second)
+			assert.NilError(t, err)
+			expired := <-expirations
+			assert.Equal(t, expired, "test")
 		})
-		assert.NilError(t, err)
-
-		err = vk.Put(ctx, sablier.InstanceInfo{Name: "test"}, 1*time.Second)
-		assert.NilError(t, err)
-		expired := <-expirations
-		assert.Equal(t, expired, "test")
 	})
+}
+
+// newInMemory stops the expiry goroutine at cleanup, because synctest.Test fails
+// when a goroutine stays blocked. See https://pkg.go.dev/testing/synctest#Test
+func newInMemory(t *testing.T) sablier.Store {
+	s := NewInMemory()
+	t.Cleanup(s.(*InMemory).kv.Stop)
+	return s
 }

--- a/pkg/tinykv/tinykv_test.go
+++ b/pkg/tinykv/tinykv_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -42,24 +43,26 @@ func TestTimeoutHeap(t *testing.T) {
 var _ KV[int] = &store[int]{}
 
 func TestGetPut(t *testing.T) {
-	assert := assert.New(t)
-	rg := New[int](0, nil)
-	defer rg.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		rg := New[int](0, nil)
+		defer rg.Stop()
 
-	require.NoError(t, rg.Put("1", 1, time.Minute*50))
-	v, ok := rg.Get("1")
-	assert.True(ok)
-	assert.Equal(1, v)
+		require.NoError(t, rg.Put("1", 1, time.Minute*50))
+		v, ok := rg.Get("1")
+		assert.True(ok)
+		assert.Equal(1, v)
 
-	require.NoError(t, rg.Put("2", 2, time.Millisecond*50))
-	v, ok = rg.Get("2")
-	assert.True(ok)
-	assert.Equal(2, v)
-	<-time.After(time.Millisecond * 100)
+		require.NoError(t, rg.Put("2", 2, time.Millisecond*50))
+		v, ok = rg.Get("2")
+		assert.True(ok)
+		assert.Equal(2, v)
+		synctest.Sleep(time.Millisecond * 100)
 
-	v, ok = rg.Get("2")
-	assert.False(ok)
-	assert.NotEqual(2, v)
+		v, ok = rg.Get("2")
+		assert.False(ok)
+		assert.NotEqual(2, v)
+	})
 }
 
 func TestKeys(t *testing.T) {
@@ -107,43 +110,45 @@ func TestEntries(t *testing.T) {
 }
 
 func TestRange(t *testing.T) {
-	assert := assert.New(t)
-	rg := New[int](0, nil)
-	defer rg.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		rg := New[int](0, nil)
+		defer rg.Stop()
 
-	require.NoError(t, rg.Put("live1", 1, time.Minute*50))
-	require.NoError(t, rg.Put("live2", 2, time.Minute*50))
-	require.NoError(t, rg.Put("expired", 3, time.Millisecond))
+		require.NoError(t, rg.Put("live1", 1, time.Minute*50))
+		require.NoError(t, rg.Put("live2", 2, time.Minute*50))
+		require.NoError(t, rg.Put("expired", 3, time.Millisecond))
 
-	<-time.After(time.Millisecond * 20)
+		synctest.Sleep(time.Millisecond * 20)
 
-	got := make(map[string]int)
-	expiries := make(map[string]time.Time)
-	rg.Range(func(key string, value int, expiresAt time.Time) {
-		got[key] = value
-		expiries[key] = expiresAt
+		got := make(map[string]int)
+		expiries := make(map[string]time.Time)
+		rg.Range(func(key string, value int, expiresAt time.Time) {
+			got[key] = value
+			expiries[key] = expiresAt
+		})
+
+		// Expired entries must never be yielded.
+		assert.Len(got, 2)
+		assert.Equal(1, got["live1"])
+		assert.Equal(2, got["live2"])
+		_, ok := got["expired"]
+		assert.False(ok, "expired entries must not be yielded by Range")
+
+		// The reported expiry is in the future for live entries.
+		assert.True(expiries["live1"].After(time.Now()))
+
+		// Range must not renew timeouts: the reported expiry is stable across calls.
+		first := expiries["live1"]
+		synctest.Sleep(time.Millisecond * 20)
+		var second time.Time
+		rg.Range(func(key string, _ int, expiresAt time.Time) {
+			if key == "live1" {
+				second = expiresAt
+			}
+		})
+		assert.Equal(first, second, "Range must not renew an entry's timeout")
 	})
-
-	// Expired entries must never be yielded.
-	assert.Len(got, 2)
-	assert.Equal(1, got["live1"])
-	assert.Equal(2, got["live2"])
-	_, ok := got["expired"]
-	assert.False(ok, "expired entries must not be yielded by Range")
-
-	// The reported expiry is in the future for live entries.
-	assert.True(expiries["live1"].After(time.Now()))
-
-	// Range must not renew timeouts: the reported expiry is stable across calls.
-	first := expiries["live1"]
-	<-time.After(time.Millisecond * 20)
-	var second time.Time
-	rg.Range(func(key string, _ int, expiresAt time.Time) {
-		if key == "live1" {
-			second = expiresAt
-		}
-	})
-	assert.Equal(first, second, "Range must not renew an entry's timeout")
 }
 
 func TestMarshalJSON(t *testing.T) {
@@ -193,223 +198,247 @@ func TestUnmarshalJSONExpired(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	assert := assert.New(t)
-	rcvd := make(chan string, 100)
-	notify := func(k string, v any) {
-		rcvd <- k
-	}
-	rg := New(time.Millisecond*10, notify)
-	n := 1000
-	for i := n; i < 2*n; i++ {
-		assert.NoError(rg.Put(strconv.Itoa(i), i, time.Millisecond*10))
-	}
-	got := make([]string, n)
-OUT01:
-	for {
-		select {
-		case v := <-rcvd:
-			i, err := strconv.Atoi(v)
-			assert.NoError(err)
-			i = i - n
-			if i < 0 || i >= n {
-				t.Fail()
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		rcvd := make(chan string, 100)
+		notify := func(k string, v any) {
+			rcvd <- k
+		}
+		rg := New(time.Millisecond*10, notify)
+		defer rg.Stop()
+		n := 1000
+		for i := n; i < 2*n; i++ {
+			assert.NoError(rg.Put(strconv.Itoa(i), i, time.Millisecond*10))
+		}
+		got := make([]string, n)
+	OUT01:
+		for {
+			select {
+			case v := <-rcvd:
+				i, err := strconv.Atoi(v)
+				assert.NoError(err)
+				i = i - n
+				if i < 0 || i >= n {
+					t.Fail()
+				}
+				got[i] = v
+			case <-time.After(time.Millisecond * 100):
+				break OUT01
 			}
-			got[i] = v
-		case <-time.After(time.Millisecond * 100):
-			break OUT01
 		}
-	}
-	assert.Equal(len(got), n)
-	for i := range n {
-		if got[i] != "" {
-			continue
+		assert.Equal(len(got), n)
+		for i := range n {
+			if got[i] != "" {
+				continue
+			}
+			assert.Fail("should have value", i, got[i])
 		}
-		assert.Fail("should have value", i, got[i])
-	}
+	})
 }
 
 func Test03(t *testing.T) {
-	assert := assert.New(t)
-	var putAt time.Time
-	elapsed := make(chan time.Duration, 1)
-	kv := New(
-		time.Millisecond*50,
-		func(k string, v any) {
-			elapsed <- time.Since(putAt)
-		})
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		var putAt time.Time
+		elapsed := make(chan time.Duration, 1)
+		kv := New(
+			time.Millisecond*50,
+			func(k string, v any) {
+				elapsed <- time.Since(putAt)
+			})
+		defer kv.Stop()
 
-	putAt = time.Now()
-	require.NoError(t, kv.Put("1", 1, time.Millisecond*10))
+		putAt = time.Now()
+		require.NoError(t, kv.Put("1", 1, time.Millisecond*10))
 
-	<-time.After(time.Millisecond * 100)
-	assert.WithinDuration(putAt, putAt.Add(<-elapsed), time.Millisecond*60)
+		synctest.Sleep(time.Millisecond * 100)
+		assert.WithinDuration(putAt, putAt.Add(<-elapsed), time.Millisecond*60)
+	})
 }
 
 func Test04(t *testing.T) {
-	assert := assert.New(t)
-	kv := New(
-		time.Millisecond*10,
-		func(k string, v any) {
-			t.Fatal(k, v)
-		})
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		kv := New(
+			time.Millisecond*10,
+			func(k string, v any) {
+				t.Fatal(k, v)
+			})
+		defer kv.Stop()
 
-	err := kv.Put("1", 1, time.Millisecond*10000)
-	assert.NoError(err)
-	<-time.After(time.Millisecond * 50)
-	kv.Delete("1")
-	kv.Delete("1")
+		err := kv.Put("1", 1, time.Millisecond*10000)
+		assert.NoError(err)
+		synctest.Sleep(time.Millisecond * 50)
+		kv.Delete("1")
+		kv.Delete("1")
 
-	<-time.After(time.Millisecond * 100)
-	_, ok := kv.Get("1")
-	assert.False(ok)
+		synctest.Sleep(time.Millisecond * 100)
+		_, ok := kv.Get("1")
+		assert.False(ok)
+	})
 }
 
 func Test05(t *testing.T) {
-	assert := assert.New(t)
-	N := 10000
-	var cnt atomic.Int64
-	kv := New(
-		time.Millisecond*10,
-		func(k string, v any) {
-			cnt.Add(1)
-		})
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		N := 10000
+		var cnt atomic.Int64
+		kv := New(
+			time.Millisecond*10,
+			func(k string, v any) {
+				cnt.Add(1)
+			})
+		defer kv.Stop()
 
-	src := rand.NewSource(time.Now().Unix())
-	rnd := rand.New(src)
-	for i := range N {
-		k := fmt.Sprintf("%d", i)
-		require.NoError(t, kv.Put(k, fmt.Sprintf("VAL::%v", k),
-			time.Millisecond*time.Duration(rnd.Intn(10)+1)))
-	}
+		src := rand.NewSource(time.Now().Unix())
+		rnd := rand.New(src)
+		for i := range N {
+			k := fmt.Sprintf("%d", i)
+			require.NoError(t, kv.Put(k, fmt.Sprintf("VAL::%v", k),
+				time.Millisecond*time.Duration(rnd.Intn(10)+1)))
+		}
 
-	<-time.After(time.Millisecond * 100)
-	for i := range N {
-		k := fmt.Sprintf("%d", i)
-		_, ok := kv.Get(k)
-		assert.False(ok)
-	}
+		synctest.Sleep(time.Millisecond * 100)
+		for i := range N {
+			k := fmt.Sprintf("%d", i)
+			_, ok := kv.Get(k)
+			assert.False(ok)
+		}
+	})
 }
 
 func Test11(t *testing.T) {
-	assert := assert.New(t)
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
 
-	key := "QQG"
+		key := "QQG"
 
-	var expiredKey = make(chan string, 100)
-	onExpired := func(k string, v any) { expiredKey <- k }
+		var expiredKey = make(chan string, 100)
+		onExpired := func(k string, v any) { expiredKey <- k }
 
-	kv := New(time.Millisecond*100, onExpired)
-	err := kv.Put(
-		key, "G",
-		time.Millisecond*15)
-	assert.NoError(err)
+		kv := New(time.Millisecond*100, onExpired)
+		defer kv.Stop()
+		err := kv.Put(
+			key, "G",
+			time.Millisecond*15)
+		assert.NoError(err)
 
-	<-time.After(time.Millisecond * 10)
+		synctest.Sleep(time.Millisecond * 10)
 
-	v, ok := kv.Get(key)
-	assert.True(ok)
-	assert.Equal("G", v)
+		v, ok := kv.Get(key)
+		assert.True(ok)
+		assert.Equal("G", v)
 
-	<-time.After(time.Millisecond * 10)
+		synctest.Sleep(time.Millisecond * 10)
 
-	_, ok = kv.Get(key)
-	assert.False(ok)
-	<-time.After(time.Millisecond)
-	assert.Equal(key, <-expiredKey)
+		_, ok = kv.Get(key)
+		assert.False(ok)
+		synctest.Wait()
+		assert.Equal(key, <-expiredKey)
 
-	<-time.After(time.Millisecond * 110)
+		synctest.Sleep(time.Millisecond * 110)
 
-	_, ok = kv.Get(key)
-	assert.False(ok)
+		_, ok = kv.Get(key)
+		assert.False(ok)
+	})
 }
 
 func Test12(t *testing.T) {
-	assert := assert.New(t)
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
 
-	key := "QQG"
+		key := "QQG"
 
-	onExpired := func(k string, v any) {}
+		onExpired := func(k string, v any) {}
 
-	kv := New(time.Millisecond*100, onExpired)
-	err := kv.Put(
-		key, "G",
-		time.Millisecond)
-	assert.NoError(err)
+		kv := New(time.Millisecond*100, onExpired)
+		defer kv.Stop()
+		err := kv.Put(
+			key, "G",
+			time.Millisecond)
+		assert.NoError(err)
 
-	<-time.After(time.Millisecond * 10)
+		synctest.Sleep(time.Millisecond * 10)
 
-	v, ok := kv.Get(key)
-	assert.False(ok)
-	assert.Equal(nil, v)
+		v, ok := kv.Get(key)
+		assert.False(ok)
+		assert.Equal(nil, v)
+	})
 }
 
 func Test13(t *testing.T) {
-	assert := assert.New(t)
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
 
-	got := make(chan any, 10)
-	onExpired := func(k string, v any) {
-		got <- v
-	}
+		got := make(chan any, 10)
+		onExpired := func(k string, v any) {
+			got <- v
+		}
 
-	kv := New(time.Millisecond*10, onExpired)
-	err := kv.Put(
-		"1", 123,
-		time.Millisecond)
-	assert.NoError(err)
+		kv := New(time.Millisecond*10, onExpired)
+		defer kv.Stop()
+		err := kv.Put(
+			"1", 123,
+			time.Millisecond)
+		assert.NoError(err)
 
-	<-time.After(time.Millisecond * 50)
+		synctest.Sleep(time.Millisecond * 50)
 
-	v, ok := kv.Get("1")
-	assert.False(ok)
-	assert.Equal(nil, v)
+		v, ok := kv.Get("1")
+		assert.False(ok)
+		assert.Equal(nil, v)
 
-	v = <-got
-	assert.Equal(123, v)
+		v = <-got
+		assert.Equal(123, v)
+	})
 }
 
 func TestOrdering(t *testing.T) {
-	assert := assert.New(t)
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
 
-	type data struct {
-		key   string
-		value any
-	}
-	got := make(chan data, 100)
-	onExpired := func(k string, v any) {
-		got <- data{k, v}
-	}
-
-	kv := New(time.Millisecond*5, onExpired)
-
-	for i := 1; i <= 10; i++ {
-		k := strconv.Itoa(i)
-		v := i
-		assert.NoError(kv.Put(k, v, time.Millisecond*time.Duration(i)*50))
-	}
-
-	var order = make([]int, 10)
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for {
-			select {
-			case v := <-got:
-				i, _ := strconv.Atoi(v.key)
-				i--
-				val := v.value.(int)
-				val--
-				order[i] = val
-			case <-time.After(time.Millisecond * 100):
-				return
-			}
+		type data struct {
+			key   string
+			value any
 		}
-	}()
-	<-done
-	for k, v := range order {
-		assert.Equal(k, v)
-	}
+		got := make(chan data, 100)
+		onExpired := func(k string, v any) {
+			got <- data{k, v}
+		}
 
-	assert.Equal(1, 1)
+		kv := New(time.Millisecond*5, onExpired)
+		defer kv.Stop()
+
+		for i := 1; i <= 10; i++ {
+			k := strconv.Itoa(i)
+			v := i
+			assert.NoError(kv.Put(k, v, time.Millisecond*time.Duration(i)*50))
+		}
+
+		var order = make([]int, 10)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for {
+				select {
+				case v := <-got:
+					i, _ := strconv.Atoi(v.key)
+					i--
+					val := v.value.(int)
+					val--
+					order[i] = val
+				case <-time.After(time.Millisecond * 100):
+					return
+				}
+			}
+		}()
+		<-done
+		for k, v := range order {
+			assert.Equal(k, v)
+		}
+
+		assert.Equal(1, 1)
+	})
 }
 
 // putAt adds an entry with a given expiry time. It keeps the timers from
@@ -462,31 +491,33 @@ func TestExpireFuncNotifiesExpiredKeyWithRenewedNeighbour(t *testing.T) {
 // The same defect through the public API.
 // See https://github.com/sablierapp/sablier/issues/1110
 func TestRenewedKeyKeepsNeighbourNotification(t *testing.T) {
-	for i := range 5 {
-		var mu sync.Mutex
-		fired := map[string]int{}
-		kv := New[int](20*time.Millisecond, func(k string, _ int) {
+	synctest.Test(t, func(t *testing.T) {
+		for i := range 5 {
+			var mu sync.Mutex
+			fired := map[string]int{}
+			kv := New[int](20*time.Millisecond, func(k string, _ int) {
+				mu.Lock()
+				fired[k]++
+				mu.Unlock()
+			})
+
+			require.NoError(t, kv.Put("a", 1, 100*time.Millisecond))
+			require.NoError(t, kv.Put("b", 1, 100*time.Millisecond))
+			synctest.Sleep(60 * time.Millisecond)
+			require.NoError(t, kv.Put("b", 2, time.Hour))
+			synctest.Sleep(300 * time.Millisecond)
+
+			_, ok := kv.Get("a")
+			assert.Falsef(t, ok, "iteration %d, the store must not contain the idle key", i)
+
 			mu.Lock()
-			fired[k]++
+			assert.Positivef(t, fired["a"], "iteration %d, onExpire must fire for the idle key", i)
+			assert.Zerof(t, fired["b"], "iteration %d, the renewed key must not expire", i)
 			mu.Unlock()
-		})
 
-		require.NoError(t, kv.Put("a", 1, 100*time.Millisecond))
-		require.NoError(t, kv.Put("b", 1, 100*time.Millisecond))
-		<-time.After(60 * time.Millisecond)
-		require.NoError(t, kv.Put("b", 2, time.Hour))
-		<-time.After(300 * time.Millisecond)
-
-		_, ok := kv.Get("a")
-		assert.Falsef(t, ok, "iteration %d, the store must not contain the idle key", i)
-
-		mu.Lock()
-		assert.Positivef(t, fired["a"], "iteration %d, onExpire must fire for the idle key", i)
-		assert.Zerof(t, fired["b"], "iteration %d, the renewed key must not expire", i)
-		mu.Unlock()
-
-		kv.Stop()
-	}
+			kv.Stop()
+		}
+	})
 }
 
 func BenchmarkGetNoValue(b *testing.B) {


### PR DESCRIPTION
## Summary

This PR runs the tests that wait on the real clock in a `testing/synctest` bubble. The tests are in `pkg/sablier`, `pkg/tinykv` and `pkg/store/inmemory`. In a bubble, the tests use a fake clock, so they do not wait on real time and they give the same result on each run. Go 1.27 adds `synctest.Sleep`, which is `time.Sleep` followed by `synctest.Wait`. This PR does not change production code.

## Changes

- Replace `time.Sleep`, `<-time.After` and polling loops with `synctest.Wait` or `synctest.Sleep`. The durations in the tests do not change.
- Remove the `eventually`, `pollFor` and `checkWithTimeout` helpers, because no test uses them now.
- Stop the tinykv expiry goroutine in each converted test, because `synctest.Test` fails when a goroutine stays blocked. The in-memory store tests use a small `newInMemory` helper for this.
- In `TestInstanceRequest_AsyncErrorSurfacedOnNotReadyPath`, `TestInstanceRequest_RetryAfterErrorConsumed` and `TestInstanceRequest_StartTimeoutSurfacesError`, set exact gomock call counts. The old `AnyTimes` expectations only allowed the extra calls of the polling loops. The exact counts also check that `Put` is not called when the pending error is surfaced.

## Test time

Measured with `go test -short -count=1` on Windows.

| Package | Before | After |
| --- | --- | --- |
| `pkg/sablier` | 2.99s | 0.27s |
| `pkg/tinykv` | 3.96s | 0.42s |
| `pkg/store/inmemory` | 2.43s | 0.09s |

## Tests that this PR does not convert

- Tests that wait on a signal channel that is ready at once. In these tests, `time.After` is only a safety timeout.
- Tests that wait for a ticker or a timeout of 30 ms or less and do not sleep.
- `pkg/sablier/running_hours_watch_test.go`. The fake clock starts at midnight UTC, so the window helpers make a window across midnight. That changes which code path the tests cover.

## Notes

- `Test05` seeds its random source with `time.Now()`. The time is fixed in a bubble, so the test uses the same random durations on each run.
- The exact gomock counts make the three tests depend on the number of store and provider calls. A refactor that changes these numbers must update the tests.

## Verification

- `go test -short -count=10` on the converted tests in each package passes.
- `go test -short -count=30 -cpu=1,4,16` on the converted tests passes.
- With #1118, #1119 and #1120 applied, `go test -short ./...` passes, except `TestSetupTheme`, which also fails on `main` on Windows. `go test -short -count=5` passes on the packages with the goroutine leak check.
- `go vet ./...` and gofmt pass. golangci-lint 2.13.2 reports 0 issues.
- The converted tests read shared state only through a mutex, an atomic value or a channel. The race detector does not run on the local machine. CI runs the tests with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
